### PR TITLE
Waste less space in the main Transaction type

### DIFF
--- a/crypto/onetimesig.go
+++ b/crypto/onetimesig.go
@@ -96,6 +96,17 @@ func (ots OneTimeSignature) ToHeartbeatProof() HeartbeatProof {
 	}
 }
 
+// BatchPrep enqueues the necessary checks into the batch.  The caller must call
+// batchVerifier.verify() to verify it.
+func (hbp HeartbeatProof) BatchPrep(voteID OneTimeSignatureVerifier, id OneTimeSignatureIdentifier, msg Hashable, batchVerifier BatchVerifier) {
+	offsetID := OneTimeSignatureSubkeyOffsetID{SubKeyPK: hbp.PK, Batch: id.Batch, Offset: id.Offset}
+	batchID := OneTimeSignatureSubkeyBatchID{SubKeyPK: hbp.PK2, Batch: id.Batch}
+	batchVerifier.EnqueueSignature(PublicKey(voteID), batchID, Signature(hbp.PK2Sig))
+	batchVerifier.EnqueueSignature(PublicKey(batchID.SubKeyPK), offsetID, Signature(hbp.PK1Sig))
+	batchVerifier.EnqueueSignature(PublicKey(offsetID.SubKeyPK), msg, Signature(hbp.Sig))
+
+}
+
 // A OneTimeSignatureSubkeyBatchID identifies an ephemeralSubkey of a batch
 // for the purposes of signing it with the top-level master key.
 type OneTimeSignatureSubkeyBatchID struct {

--- a/data/transactions/heartbeat.go
+++ b/data/transactions/heartbeat.go
@@ -29,21 +29,21 @@ type HeartbeatTxnFields struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
 	// HbAddress is the account this txn is proving onlineness for.
-	HbAddress basics.Address `codec:"hbad"`
+	HbAddress basics.Address `codec:"a"`
 
 	// HbProof is a signature using HeartbeatAddress's partkey, thereby showing it is online.
-	HbProof crypto.HeartbeatProof `codec:"hbprf"`
+	HbProof crypto.HeartbeatProof `codec:"prf"`
 
 	// The final three fields are included to allow early, concurrent check of
 	// the HbProof.
 
 	// HbSeed must be the block seed for the this transaction's firstValid
 	// block. It is the message that must be signed with HbAddress's part key.
-	HbSeed committee.Seed `codec:"hbsd"`
+	HbSeed committee.Seed `codec:"sd"`
 
 	// HbVoteID must match the HbAddress account's current VoteID.
-	HbVoteID crypto.OneTimeSignatureVerifier `codec:"hbvid"`
+	HbVoteID crypto.OneTimeSignatureVerifier `codec:"vid"`
 
 	// HbKeyDilution must match HbAddress account's current KeyDilution.
-	HbKeyDilution uint64 `codec:"hbkd"`
+	HbKeyDilution uint64 `codec:"kd"`
 }

--- a/data/transactions/msgp_gen.go
+++ b/data/transactions/msgp_gen.go
@@ -2948,28 +2948,28 @@ func (z *HeartbeatTxnFields) MarshalMsg(b []byte) (o []byte) {
 	o = append(o, 0x80|uint8(zb0001Len))
 	if zb0001Len != 0 {
 		if (zb0001Mask & 0x2) == 0 { // if not empty
-			// string "hbad"
-			o = append(o, 0xa4, 0x68, 0x62, 0x61, 0x64)
+			// string "a"
+			o = append(o, 0xa1, 0x61)
 			o = (*z).HbAddress.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
-			// string "hbkd"
-			o = append(o, 0xa4, 0x68, 0x62, 0x6b, 0x64)
+			// string "kd"
+			o = append(o, 0xa2, 0x6b, 0x64)
 			o = msgp.AppendUint64(o, (*z).HbKeyDilution)
 		}
 		if (zb0001Mask & 0x8) == 0 { // if not empty
-			// string "hbprf"
-			o = append(o, 0xa5, 0x68, 0x62, 0x70, 0x72, 0x66)
+			// string "prf"
+			o = append(o, 0xa3, 0x70, 0x72, 0x66)
 			o = (*z).HbProof.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not empty
-			// string "hbsd"
-			o = append(o, 0xa4, 0x68, 0x62, 0x73, 0x64)
+			// string "sd"
+			o = append(o, 0xa2, 0x73, 0x64)
 			o = (*z).HbSeed.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x20) == 0 { // if not empty
-			// string "hbvid"
-			o = append(o, 0xa5, 0x68, 0x62, 0x76, 0x69, 0x64)
+			// string "vid"
+			o = append(o, 0xa3, 0x76, 0x69, 0x64)
 			o = (*z).HbVoteID.MarshalMsg(o)
 		}
 	}
@@ -3062,31 +3062,31 @@ func (z *HeartbeatTxnFields) UnmarshalMsgWithState(bts []byte, st msgp.Unmarshal
 				return
 			}
 			switch string(field) {
-			case "hbad":
+			case "a":
 				bts, err = (*z).HbAddress.UnmarshalMsgWithState(bts, st)
 				if err != nil {
 					err = msgp.WrapError(err, "HbAddress")
 					return
 				}
-			case "hbprf":
+			case "prf":
 				bts, err = (*z).HbProof.UnmarshalMsgWithState(bts, st)
 				if err != nil {
 					err = msgp.WrapError(err, "HbProof")
 					return
 				}
-			case "hbsd":
+			case "sd":
 				bts, err = (*z).HbSeed.UnmarshalMsgWithState(bts, st)
 				if err != nil {
 					err = msgp.WrapError(err, "HbSeed")
 					return
 				}
-			case "hbvid":
+			case "vid":
 				bts, err = (*z).HbVoteID.UnmarshalMsgWithState(bts, st)
 				if err != nil {
 					err = msgp.WrapError(err, "HbVoteID")
 					return
 				}
-			case "hbkd":
+			case "kd":
 				(*z).HbKeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "HbKeyDilution")
@@ -3115,7 +3115,7 @@ func (_ *HeartbeatTxnFields) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *HeartbeatTxnFields) Msgsize() (s int) {
-	s = 1 + 5 + (*z).HbAddress.Msgsize() + 6 + (*z).HbProof.Msgsize() + 5 + (*z).HbSeed.Msgsize() + 6 + (*z).HbVoteID.Msgsize() + 5 + msgp.Uint64Size
+	s = 1 + 2 + (*z).HbAddress.Msgsize() + 4 + (*z).HbProof.Msgsize() + 3 + (*z).HbSeed.Msgsize() + 4 + (*z).HbVoteID.Msgsize() + 3 + msgp.Uint64Size
 	return
 }
 
@@ -3126,7 +3126,7 @@ func (z *HeartbeatTxnFields) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func HeartbeatTxnFieldsMaxSize() (s int) {
-	s = 1 + 5 + basics.AddressMaxSize() + 6 + crypto.HeartbeatProofMaxSize() + 5 + committee.SeedMaxSize() + 6 + crypto.OneTimeSignatureVerifierMaxSize() + 5 + msgp.Uint64Size
+	s = 1 + 2 + basics.AddressMaxSize() + 4 + crypto.HeartbeatProofMaxSize() + 3 + committee.SeedMaxSize() + 4 + crypto.OneTimeSignatureVerifierMaxSize() + 3 + msgp.Uint64Size
 	return
 }
 
@@ -5205,236 +5205,220 @@ func StateProofTxnFieldsMaxSize() (s int) {
 func (z *Transaction) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0007Len := uint32(51)
-	var zb0007Mask uint64 /* 61 bits */
+	zb0007Len := uint32(47)
+	var zb0007Mask uint64 /* 56 bits */
 	if (*z).AssetTransferTxnFields.AssetAmount == 0 {
 		zb0007Len--
-		zb0007Mask |= 0x400
+		zb0007Mask |= 0x200
 	}
 	if (*z).AssetTransferTxnFields.AssetCloseTo.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x800
+		zb0007Mask |= 0x400
 	}
 	if (*z).AssetFreezeTxnFields.AssetFrozen == false {
 		zb0007Len--
-		zb0007Mask |= 0x1000
+		zb0007Mask |= 0x800
 	}
 	if (*z).PaymentTxnFields.Amount.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x2000
+		zb0007Mask |= 0x1000
 	}
 	if len((*z).ApplicationCallTxnFields.ApplicationArgs) == 0 {
 		zb0007Len--
-		zb0007Mask |= 0x4000
+		zb0007Mask |= 0x2000
 	}
 	if (*z).ApplicationCallTxnFields.OnCompletion == 0 {
 		zb0007Len--
-		zb0007Mask |= 0x8000
+		zb0007Mask |= 0x4000
 	}
 	if len((*z).ApplicationCallTxnFields.ApprovalProgram) == 0 {
 		zb0007Len--
-		zb0007Mask |= 0x10000
+		zb0007Mask |= 0x8000
 	}
 	if (*z).AssetConfigTxnFields.AssetParams.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x20000
+		zb0007Mask |= 0x10000
 	}
 	if len((*z).ApplicationCallTxnFields.ForeignAssets) == 0 {
 		zb0007Len--
-		zb0007Mask |= 0x40000
+		zb0007Mask |= 0x20000
 	}
 	if len((*z).ApplicationCallTxnFields.Accounts) == 0 {
 		zb0007Len--
-		zb0007Mask |= 0x80000
+		zb0007Mask |= 0x40000
 	}
 	if len((*z).ApplicationCallTxnFields.Boxes) == 0 {
 		zb0007Len--
-		zb0007Mask |= 0x100000
+		zb0007Mask |= 0x80000
 	}
 	if (*z).ApplicationCallTxnFields.ExtraProgramPages == 0 {
 		zb0007Len--
-		zb0007Mask |= 0x200000
+		zb0007Mask |= 0x100000
 	}
 	if len((*z).ApplicationCallTxnFields.ForeignApps) == 0 {
 		zb0007Len--
-		zb0007Mask |= 0x400000
+		zb0007Mask |= 0x200000
 	}
 	if (*z).ApplicationCallTxnFields.GlobalStateSchema.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x800000
+		zb0007Mask |= 0x400000
 	}
 	if (*z).ApplicationCallTxnFields.ApplicationID.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x1000000
+		zb0007Mask |= 0x800000
 	}
 	if (*z).ApplicationCallTxnFields.LocalStateSchema.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x2000000
+		zb0007Mask |= 0x1000000
 	}
 	if len((*z).ApplicationCallTxnFields.ClearStateProgram) == 0 {
 		zb0007Len--
-		zb0007Mask |= 0x4000000
+		zb0007Mask |= 0x2000000
 	}
 	if (*z).AssetTransferTxnFields.AssetReceiver.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x8000000
+		zb0007Mask |= 0x4000000
 	}
 	if (*z).AssetTransferTxnFields.AssetSender.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x10000000
+		zb0007Mask |= 0x8000000
 	}
 	if (*z).AssetConfigTxnFields.ConfigAsset.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x20000000
+		zb0007Mask |= 0x10000000
 	}
 	if (*z).PaymentTxnFields.CloseRemainderTo.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x40000000
+		zb0007Mask |= 0x20000000
 	}
 	if (*z).AssetFreezeTxnFields.FreezeAccount.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x80000000
+		zb0007Mask |= 0x40000000
 	}
 	if (*z).AssetFreezeTxnFields.FreezeAsset.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x100000000
+		zb0007Mask |= 0x80000000
 	}
 	if (*z).Header.Fee.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x200000000
+		zb0007Mask |= 0x100000000
 	}
 	if (*z).Header.FirstValid.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x400000000
+		zb0007Mask |= 0x200000000
 	}
 	if (*z).Header.GenesisID == "" {
 		zb0007Len--
-		zb0007Mask |= 0x800000000
+		zb0007Mask |= 0x400000000
 	}
 	if (*z).Header.GenesisHash.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x1000000000
+		zb0007Mask |= 0x800000000
 	}
 	if (*z).Header.Group.MsgIsZero() {
 		zb0007Len--
+		zb0007Mask |= 0x1000000000
+	}
+	if (*z).HeartbeatTxnFields == nil {
+		zb0007Len--
 		zb0007Mask |= 0x2000000000
-	}
-	if (*z).HeartbeatTxnFields.HbAddress.MsgIsZero() {
-		zb0007Len--
-		zb0007Mask |= 0x4000000000
-	}
-	if (*z).HeartbeatTxnFields.HbKeyDilution == 0 {
-		zb0007Len--
-		zb0007Mask |= 0x8000000000
-	}
-	if (*z).HeartbeatTxnFields.HbProof.MsgIsZero() {
-		zb0007Len--
-		zb0007Mask |= 0x10000000000
-	}
-	if (*z).HeartbeatTxnFields.HbSeed.MsgIsZero() {
-		zb0007Len--
-		zb0007Mask |= 0x20000000000
-	}
-	if (*z).HeartbeatTxnFields.HbVoteID.MsgIsZero() {
-		zb0007Len--
-		zb0007Mask |= 0x40000000000
 	}
 	if (*z).Header.LastValid.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x80000000000
+		zb0007Mask |= 0x4000000000
 	}
 	if (*z).Header.Lease == ([32]byte{}) {
 		zb0007Len--
-		zb0007Mask |= 0x100000000000
+		zb0007Mask |= 0x8000000000
 	}
 	if (*z).KeyregTxnFields.Nonparticipation == false {
 		zb0007Len--
-		zb0007Mask |= 0x200000000000
+		zb0007Mask |= 0x10000000000
 	}
 	if len((*z).Header.Note) == 0 {
 		zb0007Len--
-		zb0007Mask |= 0x400000000000
+		zb0007Mask |= 0x20000000000
 	}
 	if (*z).PaymentTxnFields.Receiver.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x800000000000
+		zb0007Mask |= 0x40000000000
 	}
 	if (*z).Header.RekeyTo.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x1000000000000
+		zb0007Mask |= 0x80000000000
 	}
 	if (*z).KeyregTxnFields.SelectionPK.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x2000000000000
+		zb0007Mask |= 0x100000000000
 	}
 	if (*z).Header.Sender.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x4000000000000
+		zb0007Mask |= 0x200000000000
 	}
 	if (*z).StateProofTxnFields.StateProof.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x8000000000000
+		zb0007Mask |= 0x400000000000
 	}
 	if (*z).StateProofTxnFields.Message.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x10000000000000
+		zb0007Mask |= 0x800000000000
 	}
 	if (*z).KeyregTxnFields.StateProofPK.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x20000000000000
+		zb0007Mask |= 0x1000000000000
 	}
 	if (*z).StateProofTxnFields.StateProofType.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x40000000000000
+		zb0007Mask |= 0x2000000000000
 	}
 	if (*z).Type.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x80000000000000
+		zb0007Mask |= 0x4000000000000
 	}
 	if (*z).KeyregTxnFields.VoteFirst.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x100000000000000
+		zb0007Mask |= 0x8000000000000
 	}
 	if (*z).KeyregTxnFields.VoteKeyDilution == 0 {
 		zb0007Len--
-		zb0007Mask |= 0x200000000000000
+		zb0007Mask |= 0x10000000000000
 	}
 	if (*z).KeyregTxnFields.VotePK.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x400000000000000
+		zb0007Mask |= 0x20000000000000
 	}
 	if (*z).KeyregTxnFields.VoteLast.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x800000000000000
+		zb0007Mask |= 0x40000000000000
 	}
 	if (*z).AssetTransferTxnFields.XferAsset.MsgIsZero() {
 		zb0007Len--
-		zb0007Mask |= 0x1000000000000000
+		zb0007Mask |= 0x80000000000000
 	}
 	// variable map header, size zb0007Len
 	o = msgp.AppendMapHeader(o, zb0007Len)
 	if zb0007Len != 0 {
-		if (zb0007Mask & 0x400) == 0 { // if not empty
+		if (zb0007Mask & 0x200) == 0 { // if not empty
 			// string "aamt"
 			o = append(o, 0xa4, 0x61, 0x61, 0x6d, 0x74)
 			o = msgp.AppendUint64(o, (*z).AssetTransferTxnFields.AssetAmount)
 		}
-		if (zb0007Mask & 0x800) == 0 { // if not empty
+		if (zb0007Mask & 0x400) == 0 { // if not empty
 			// string "aclose"
 			o = append(o, 0xa6, 0x61, 0x63, 0x6c, 0x6f, 0x73, 0x65)
 			o = (*z).AssetTransferTxnFields.AssetCloseTo.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x1000) == 0 { // if not empty
+		if (zb0007Mask & 0x800) == 0 { // if not empty
 			// string "afrz"
 			o = append(o, 0xa4, 0x61, 0x66, 0x72, 0x7a)
 			o = msgp.AppendBool(o, (*z).AssetFreezeTxnFields.AssetFrozen)
 		}
-		if (zb0007Mask & 0x2000) == 0 { // if not empty
+		if (zb0007Mask & 0x1000) == 0 { // if not empty
 			// string "amt"
 			o = append(o, 0xa3, 0x61, 0x6d, 0x74)
 			o = (*z).PaymentTxnFields.Amount.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x4000) == 0 { // if not empty
+		if (zb0007Mask & 0x2000) == 0 { // if not empty
 			// string "apaa"
 			o = append(o, 0xa4, 0x61, 0x70, 0x61, 0x61)
 			if (*z).ApplicationCallTxnFields.ApplicationArgs == nil {
@@ -5446,22 +5430,22 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte) {
 				o = msgp.AppendBytes(o, (*z).ApplicationCallTxnFields.ApplicationArgs[zb0002])
 			}
 		}
-		if (zb0007Mask & 0x8000) == 0 { // if not empty
+		if (zb0007Mask & 0x4000) == 0 { // if not empty
 			// string "apan"
 			o = append(o, 0xa4, 0x61, 0x70, 0x61, 0x6e)
 			o = msgp.AppendUint64(o, uint64((*z).ApplicationCallTxnFields.OnCompletion))
 		}
-		if (zb0007Mask & 0x10000) == 0 { // if not empty
+		if (zb0007Mask & 0x8000) == 0 { // if not empty
 			// string "apap"
 			o = append(o, 0xa4, 0x61, 0x70, 0x61, 0x70)
 			o = msgp.AppendBytes(o, (*z).ApplicationCallTxnFields.ApprovalProgram)
 		}
-		if (zb0007Mask & 0x20000) == 0 { // if not empty
+		if (zb0007Mask & 0x10000) == 0 { // if not empty
 			// string "apar"
 			o = append(o, 0xa4, 0x61, 0x70, 0x61, 0x72)
 			o = (*z).AssetConfigTxnFields.AssetParams.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x40000) == 0 { // if not empty
+		if (zb0007Mask & 0x20000) == 0 { // if not empty
 			// string "apas"
 			o = append(o, 0xa4, 0x61, 0x70, 0x61, 0x73)
 			if (*z).ApplicationCallTxnFields.ForeignAssets == nil {
@@ -5473,7 +5457,7 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte) {
 				o = (*z).ApplicationCallTxnFields.ForeignAssets[zb0006].MarshalMsg(o)
 			}
 		}
-		if (zb0007Mask & 0x80000) == 0 { // if not empty
+		if (zb0007Mask & 0x40000) == 0 { // if not empty
 			// string "apat"
 			o = append(o, 0xa4, 0x61, 0x70, 0x61, 0x74)
 			if (*z).ApplicationCallTxnFields.Accounts == nil {
@@ -5485,7 +5469,7 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte) {
 				o = (*z).ApplicationCallTxnFields.Accounts[zb0003].MarshalMsg(o)
 			}
 		}
-		if (zb0007Mask & 0x100000) == 0 { // if not empty
+		if (zb0007Mask & 0x80000) == 0 { // if not empty
 			// string "apbx"
 			o = append(o, 0xa4, 0x61, 0x70, 0x62, 0x78)
 			if (*z).ApplicationCallTxnFields.Boxes == nil {
@@ -5519,12 +5503,12 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte) {
 				}
 			}
 		}
-		if (zb0007Mask & 0x200000) == 0 { // if not empty
+		if (zb0007Mask & 0x100000) == 0 { // if not empty
 			// string "apep"
 			o = append(o, 0xa4, 0x61, 0x70, 0x65, 0x70)
 			o = msgp.AppendUint32(o, (*z).ApplicationCallTxnFields.ExtraProgramPages)
 		}
-		if (zb0007Mask & 0x400000) == 0 { // if not empty
+		if (zb0007Mask & 0x200000) == 0 { // if not empty
 			// string "apfa"
 			o = append(o, 0xa4, 0x61, 0x70, 0x66, 0x61)
 			if (*z).ApplicationCallTxnFields.ForeignApps == nil {
@@ -5536,192 +5520,176 @@ func (z *Transaction) MarshalMsg(b []byte) (o []byte) {
 				o = (*z).ApplicationCallTxnFields.ForeignApps[zb0004].MarshalMsg(o)
 			}
 		}
-		if (zb0007Mask & 0x800000) == 0 { // if not empty
+		if (zb0007Mask & 0x400000) == 0 { // if not empty
 			// string "apgs"
 			o = append(o, 0xa4, 0x61, 0x70, 0x67, 0x73)
 			o = (*z).ApplicationCallTxnFields.GlobalStateSchema.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x1000000) == 0 { // if not empty
+		if (zb0007Mask & 0x800000) == 0 { // if not empty
 			// string "apid"
 			o = append(o, 0xa4, 0x61, 0x70, 0x69, 0x64)
 			o = (*z).ApplicationCallTxnFields.ApplicationID.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x2000000) == 0 { // if not empty
+		if (zb0007Mask & 0x1000000) == 0 { // if not empty
 			// string "apls"
 			o = append(o, 0xa4, 0x61, 0x70, 0x6c, 0x73)
 			o = (*z).ApplicationCallTxnFields.LocalStateSchema.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x4000000) == 0 { // if not empty
+		if (zb0007Mask & 0x2000000) == 0 { // if not empty
 			// string "apsu"
 			o = append(o, 0xa4, 0x61, 0x70, 0x73, 0x75)
 			o = msgp.AppendBytes(o, (*z).ApplicationCallTxnFields.ClearStateProgram)
 		}
-		if (zb0007Mask & 0x8000000) == 0 { // if not empty
+		if (zb0007Mask & 0x4000000) == 0 { // if not empty
 			// string "arcv"
 			o = append(o, 0xa4, 0x61, 0x72, 0x63, 0x76)
 			o = (*z).AssetTransferTxnFields.AssetReceiver.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x10000000) == 0 { // if not empty
+		if (zb0007Mask & 0x8000000) == 0 { // if not empty
 			// string "asnd"
 			o = append(o, 0xa4, 0x61, 0x73, 0x6e, 0x64)
 			o = (*z).AssetTransferTxnFields.AssetSender.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x20000000) == 0 { // if not empty
+		if (zb0007Mask & 0x10000000) == 0 { // if not empty
 			// string "caid"
 			o = append(o, 0xa4, 0x63, 0x61, 0x69, 0x64)
 			o = (*z).AssetConfigTxnFields.ConfigAsset.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x40000000) == 0 { // if not empty
+		if (zb0007Mask & 0x20000000) == 0 { // if not empty
 			// string "close"
 			o = append(o, 0xa5, 0x63, 0x6c, 0x6f, 0x73, 0x65)
 			o = (*z).PaymentTxnFields.CloseRemainderTo.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x80000000) == 0 { // if not empty
+		if (zb0007Mask & 0x40000000) == 0 { // if not empty
 			// string "fadd"
 			o = append(o, 0xa4, 0x66, 0x61, 0x64, 0x64)
 			o = (*z).AssetFreezeTxnFields.FreezeAccount.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x100000000) == 0 { // if not empty
+		if (zb0007Mask & 0x80000000) == 0 { // if not empty
 			// string "faid"
 			o = append(o, 0xa4, 0x66, 0x61, 0x69, 0x64)
 			o = (*z).AssetFreezeTxnFields.FreezeAsset.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x200000000) == 0 { // if not empty
+		if (zb0007Mask & 0x100000000) == 0 { // if not empty
 			// string "fee"
 			o = append(o, 0xa3, 0x66, 0x65, 0x65)
 			o = (*z).Header.Fee.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x400000000) == 0 { // if not empty
+		if (zb0007Mask & 0x200000000) == 0 { // if not empty
 			// string "fv"
 			o = append(o, 0xa2, 0x66, 0x76)
 			o = (*z).Header.FirstValid.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x800000000) == 0 { // if not empty
+		if (zb0007Mask & 0x400000000) == 0 { // if not empty
 			// string "gen"
 			o = append(o, 0xa3, 0x67, 0x65, 0x6e)
 			o = msgp.AppendString(o, (*z).Header.GenesisID)
 		}
-		if (zb0007Mask & 0x1000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x800000000) == 0 { // if not empty
 			// string "gh"
 			o = append(o, 0xa2, 0x67, 0x68)
 			o = (*z).Header.GenesisHash.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x2000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x1000000000) == 0 { // if not empty
 			// string "grp"
 			o = append(o, 0xa3, 0x67, 0x72, 0x70)
 			o = (*z).Header.Group.MarshalMsg(o)
 		}
+		if (zb0007Mask & 0x2000000000) == 0 { // if not empty
+			// string "hb"
+			o = append(o, 0xa2, 0x68, 0x62)
+			if (*z).HeartbeatTxnFields == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o = (*z).HeartbeatTxnFields.MarshalMsg(o)
+			}
+		}
 		if (zb0007Mask & 0x4000000000) == 0 { // if not empty
-			// string "hbad"
-			o = append(o, 0xa4, 0x68, 0x62, 0x61, 0x64)
-			o = (*z).HeartbeatTxnFields.HbAddress.MarshalMsg(o)
-		}
-		if (zb0007Mask & 0x8000000000) == 0 { // if not empty
-			// string "hbkd"
-			o = append(o, 0xa4, 0x68, 0x62, 0x6b, 0x64)
-			o = msgp.AppendUint64(o, (*z).HeartbeatTxnFields.HbKeyDilution)
-		}
-		if (zb0007Mask & 0x10000000000) == 0 { // if not empty
-			// string "hbprf"
-			o = append(o, 0xa5, 0x68, 0x62, 0x70, 0x72, 0x66)
-			o = (*z).HeartbeatTxnFields.HbProof.MarshalMsg(o)
-		}
-		if (zb0007Mask & 0x20000000000) == 0 { // if not empty
-			// string "hbsd"
-			o = append(o, 0xa4, 0x68, 0x62, 0x73, 0x64)
-			o = (*z).HeartbeatTxnFields.HbSeed.MarshalMsg(o)
-		}
-		if (zb0007Mask & 0x40000000000) == 0 { // if not empty
-			// string "hbvid"
-			o = append(o, 0xa5, 0x68, 0x62, 0x76, 0x69, 0x64)
-			o = (*z).HeartbeatTxnFields.HbVoteID.MarshalMsg(o)
-		}
-		if (zb0007Mask & 0x80000000000) == 0 { // if not empty
 			// string "lv"
 			o = append(o, 0xa2, 0x6c, 0x76)
 			o = (*z).Header.LastValid.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x100000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x8000000000) == 0 { // if not empty
 			// string "lx"
 			o = append(o, 0xa2, 0x6c, 0x78)
 			o = msgp.AppendBytes(o, ((*z).Header.Lease)[:])
 		}
-		if (zb0007Mask & 0x200000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x10000000000) == 0 { // if not empty
 			// string "nonpart"
 			o = append(o, 0xa7, 0x6e, 0x6f, 0x6e, 0x70, 0x61, 0x72, 0x74)
 			o = msgp.AppendBool(o, (*z).KeyregTxnFields.Nonparticipation)
 		}
-		if (zb0007Mask & 0x400000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x20000000000) == 0 { // if not empty
 			// string "note"
 			o = append(o, 0xa4, 0x6e, 0x6f, 0x74, 0x65)
 			o = msgp.AppendBytes(o, (*z).Header.Note)
 		}
-		if (zb0007Mask & 0x800000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x40000000000) == 0 { // if not empty
 			// string "rcv"
 			o = append(o, 0xa3, 0x72, 0x63, 0x76)
 			o = (*z).PaymentTxnFields.Receiver.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x1000000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x80000000000) == 0 { // if not empty
 			// string "rekey"
 			o = append(o, 0xa5, 0x72, 0x65, 0x6b, 0x65, 0x79)
 			o = (*z).Header.RekeyTo.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x2000000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x100000000000) == 0 { // if not empty
 			// string "selkey"
 			o = append(o, 0xa6, 0x73, 0x65, 0x6c, 0x6b, 0x65, 0x79)
 			o = (*z).KeyregTxnFields.SelectionPK.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x4000000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x200000000000) == 0 { // if not empty
 			// string "snd"
 			o = append(o, 0xa3, 0x73, 0x6e, 0x64)
 			o = (*z).Header.Sender.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x8000000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x400000000000) == 0 { // if not empty
 			// string "sp"
 			o = append(o, 0xa2, 0x73, 0x70)
 			o = (*z).StateProofTxnFields.StateProof.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x10000000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x800000000000) == 0 { // if not empty
 			// string "spmsg"
 			o = append(o, 0xa5, 0x73, 0x70, 0x6d, 0x73, 0x67)
 			o = (*z).StateProofTxnFields.Message.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x20000000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x1000000000000) == 0 { // if not empty
 			// string "sprfkey"
 			o = append(o, 0xa7, 0x73, 0x70, 0x72, 0x66, 0x6b, 0x65, 0x79)
 			o = (*z).KeyregTxnFields.StateProofPK.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x40000000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x2000000000000) == 0 { // if not empty
 			// string "sptype"
 			o = append(o, 0xa6, 0x73, 0x70, 0x74, 0x79, 0x70, 0x65)
 			o = (*z).StateProofTxnFields.StateProofType.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x80000000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x4000000000000) == 0 { // if not empty
 			// string "type"
 			o = append(o, 0xa4, 0x74, 0x79, 0x70, 0x65)
 			o = (*z).Type.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x100000000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x8000000000000) == 0 { // if not empty
 			// string "votefst"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x66, 0x73, 0x74)
 			o = (*z).KeyregTxnFields.VoteFirst.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x200000000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x10000000000000) == 0 { // if not empty
 			// string "votekd"
 			o = append(o, 0xa6, 0x76, 0x6f, 0x74, 0x65, 0x6b, 0x64)
 			o = msgp.AppendUint64(o, (*z).KeyregTxnFields.VoteKeyDilution)
 		}
-		if (zb0007Mask & 0x400000000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x20000000000000) == 0 { // if not empty
 			// string "votekey"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x6b, 0x65, 0x79)
 			o = (*z).KeyregTxnFields.VotePK.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x800000000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x40000000000000) == 0 { // if not empty
 			// string "votelst"
 			o = append(o, 0xa7, 0x76, 0x6f, 0x74, 0x65, 0x6c, 0x73, 0x74)
 			o = (*z).KeyregTxnFields.VoteLast.MarshalMsg(o)
 		}
-		if (zb0007Mask & 0x1000000000000000) == 0 { // if not empty
+		if (zb0007Mask & 0x80000000000000) == 0 { // if not empty
 			// string "xaid"
 			o = append(o, 0xa4, 0x78, 0x61, 0x69, 0x64)
 			o = (*z).AssetTransferTxnFields.XferAsset.MarshalMsg(o)
@@ -6356,42 +6324,21 @@ func (z *Transaction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 		}
 		if zb0007 > 0 {
 			zb0007--
-			bts, err = (*z).HeartbeatTxnFields.HbAddress.UnmarshalMsgWithState(bts, st)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "HbAddress")
-				return
-			}
-		}
-		if zb0007 > 0 {
-			zb0007--
-			bts, err = (*z).HeartbeatTxnFields.HbProof.UnmarshalMsgWithState(bts, st)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "HbProof")
-				return
-			}
-		}
-		if zb0007 > 0 {
-			zb0007--
-			bts, err = (*z).HeartbeatTxnFields.HbSeed.UnmarshalMsgWithState(bts, st)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "HbSeed")
-				return
-			}
-		}
-		if zb0007 > 0 {
-			zb0007--
-			bts, err = (*z).HeartbeatTxnFields.HbVoteID.UnmarshalMsgWithState(bts, st)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "HbVoteID")
-				return
-			}
-		}
-		if zb0007 > 0 {
-			zb0007--
-			(*z).HeartbeatTxnFields.HbKeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "HbKeyDilution")
-				return
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				(*z).HeartbeatTxnFields = nil
+			} else {
+				if (*z).HeartbeatTxnFields == nil {
+					(*z).HeartbeatTxnFields = new(HeartbeatTxnFields)
+				}
+				bts, err = (*z).HeartbeatTxnFields.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "struct-from-array", "HeartbeatTxnFields")
+					return
+				}
 			}
 		}
 		if zb0007 > 0 {
@@ -6926,35 +6873,22 @@ func (z *Transaction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "Message")
 					return
 				}
-			case "hbad":
-				bts, err = (*z).HeartbeatTxnFields.HbAddress.UnmarshalMsgWithState(bts, st)
-				if err != nil {
-					err = msgp.WrapError(err, "HbAddress")
-					return
-				}
-			case "hbprf":
-				bts, err = (*z).HeartbeatTxnFields.HbProof.UnmarshalMsgWithState(bts, st)
-				if err != nil {
-					err = msgp.WrapError(err, "HbProof")
-					return
-				}
-			case "hbsd":
-				bts, err = (*z).HeartbeatTxnFields.HbSeed.UnmarshalMsgWithState(bts, st)
-				if err != nil {
-					err = msgp.WrapError(err, "HbSeed")
-					return
-				}
-			case "hbvid":
-				bts, err = (*z).HeartbeatTxnFields.HbVoteID.UnmarshalMsgWithState(bts, st)
-				if err != nil {
-					err = msgp.WrapError(err, "HbVoteID")
-					return
-				}
-			case "hbkd":
-				(*z).HeartbeatTxnFields.HbKeyDilution, bts, err = msgp.ReadUint64Bytes(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "HbKeyDilution")
-					return
+			case "hb":
+				if msgp.IsNil(bts) {
+					bts, err = msgp.ReadNilBytes(bts)
+					if err != nil {
+						return
+					}
+					(*z).HeartbeatTxnFields = nil
+				} else {
+					if (*z).HeartbeatTxnFields == nil {
+						(*z).HeartbeatTxnFields = new(HeartbeatTxnFields)
+					}
+					bts, err = (*z).HeartbeatTxnFields.UnmarshalMsgWithState(bts, st)
+					if err != nil {
+						err = msgp.WrapError(err, "HeartbeatTxnFields")
+						return
+					}
 				}
 			default:
 				err = msgp.ErrNoField(string(field))
@@ -6999,13 +6933,18 @@ func (z *Transaction) Msgsize() (s int) {
 	for zb0006 := range (*z).ApplicationCallTxnFields.ForeignAssets {
 		s += (*z).ApplicationCallTxnFields.ForeignAssets[zb0006].Msgsize()
 	}
-	s += 5 + (*z).ApplicationCallTxnFields.LocalStateSchema.Msgsize() + 5 + (*z).ApplicationCallTxnFields.GlobalStateSchema.Msgsize() + 5 + msgp.BytesPrefixSize + len((*z).ApplicationCallTxnFields.ApprovalProgram) + 5 + msgp.BytesPrefixSize + len((*z).ApplicationCallTxnFields.ClearStateProgram) + 5 + msgp.Uint32Size + 7 + (*z).StateProofTxnFields.StateProofType.Msgsize() + 3 + (*z).StateProofTxnFields.StateProof.Msgsize() + 6 + (*z).StateProofTxnFields.Message.Msgsize() + 5 + (*z).HeartbeatTxnFields.HbAddress.Msgsize() + 6 + (*z).HeartbeatTxnFields.HbProof.Msgsize() + 5 + (*z).HeartbeatTxnFields.HbSeed.Msgsize() + 6 + (*z).HeartbeatTxnFields.HbVoteID.Msgsize() + 5 + msgp.Uint64Size
+	s += 5 + (*z).ApplicationCallTxnFields.LocalStateSchema.Msgsize() + 5 + (*z).ApplicationCallTxnFields.GlobalStateSchema.Msgsize() + 5 + msgp.BytesPrefixSize + len((*z).ApplicationCallTxnFields.ApprovalProgram) + 5 + msgp.BytesPrefixSize + len((*z).ApplicationCallTxnFields.ClearStateProgram) + 5 + msgp.Uint32Size + 7 + (*z).StateProofTxnFields.StateProofType.Msgsize() + 3 + (*z).StateProofTxnFields.StateProof.Msgsize() + 6 + (*z).StateProofTxnFields.Message.Msgsize() + 3
+	if (*z).HeartbeatTxnFields == nil {
+		s += msgp.NilSize
+	} else {
+		s += (*z).HeartbeatTxnFields.Msgsize()
+	}
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *Transaction) MsgIsZero() bool {
-	return ((*z).Type.MsgIsZero()) && ((*z).Header.Sender.MsgIsZero()) && ((*z).Header.Fee.MsgIsZero()) && ((*z).Header.FirstValid.MsgIsZero()) && ((*z).Header.LastValid.MsgIsZero()) && (len((*z).Header.Note) == 0) && ((*z).Header.GenesisID == "") && ((*z).Header.GenesisHash.MsgIsZero()) && ((*z).Header.Group.MsgIsZero()) && ((*z).Header.Lease == ([32]byte{})) && ((*z).Header.RekeyTo.MsgIsZero()) && ((*z).KeyregTxnFields.VotePK.MsgIsZero()) && ((*z).KeyregTxnFields.SelectionPK.MsgIsZero()) && ((*z).KeyregTxnFields.StateProofPK.MsgIsZero()) && ((*z).KeyregTxnFields.VoteFirst.MsgIsZero()) && ((*z).KeyregTxnFields.VoteLast.MsgIsZero()) && ((*z).KeyregTxnFields.VoteKeyDilution == 0) && ((*z).KeyregTxnFields.Nonparticipation == false) && ((*z).PaymentTxnFields.Receiver.MsgIsZero()) && ((*z).PaymentTxnFields.Amount.MsgIsZero()) && ((*z).PaymentTxnFields.CloseRemainderTo.MsgIsZero()) && ((*z).AssetConfigTxnFields.ConfigAsset.MsgIsZero()) && ((*z).AssetConfigTxnFields.AssetParams.MsgIsZero()) && ((*z).AssetTransferTxnFields.XferAsset.MsgIsZero()) && ((*z).AssetTransferTxnFields.AssetAmount == 0) && ((*z).AssetTransferTxnFields.AssetSender.MsgIsZero()) && ((*z).AssetTransferTxnFields.AssetReceiver.MsgIsZero()) && ((*z).AssetTransferTxnFields.AssetCloseTo.MsgIsZero()) && ((*z).AssetFreezeTxnFields.FreezeAccount.MsgIsZero()) && ((*z).AssetFreezeTxnFields.FreezeAsset.MsgIsZero()) && ((*z).AssetFreezeTxnFields.AssetFrozen == false) && ((*z).ApplicationCallTxnFields.ApplicationID.MsgIsZero()) && ((*z).ApplicationCallTxnFields.OnCompletion == 0) && (len((*z).ApplicationCallTxnFields.ApplicationArgs) == 0) && (len((*z).ApplicationCallTxnFields.Accounts) == 0) && (len((*z).ApplicationCallTxnFields.ForeignApps) == 0) && (len((*z).ApplicationCallTxnFields.Boxes) == 0) && (len((*z).ApplicationCallTxnFields.ForeignAssets) == 0) && ((*z).ApplicationCallTxnFields.LocalStateSchema.MsgIsZero()) && ((*z).ApplicationCallTxnFields.GlobalStateSchema.MsgIsZero()) && (len((*z).ApplicationCallTxnFields.ApprovalProgram) == 0) && (len((*z).ApplicationCallTxnFields.ClearStateProgram) == 0) && ((*z).ApplicationCallTxnFields.ExtraProgramPages == 0) && ((*z).StateProofTxnFields.StateProofType.MsgIsZero()) && ((*z).StateProofTxnFields.StateProof.MsgIsZero()) && ((*z).StateProofTxnFields.Message.MsgIsZero()) && ((*z).HeartbeatTxnFields.HbAddress.MsgIsZero()) && ((*z).HeartbeatTxnFields.HbProof.MsgIsZero()) && ((*z).HeartbeatTxnFields.HbSeed.MsgIsZero()) && ((*z).HeartbeatTxnFields.HbVoteID.MsgIsZero()) && ((*z).HeartbeatTxnFields.HbKeyDilution == 0)
+	return ((*z).Type.MsgIsZero()) && ((*z).Header.Sender.MsgIsZero()) && ((*z).Header.Fee.MsgIsZero()) && ((*z).Header.FirstValid.MsgIsZero()) && ((*z).Header.LastValid.MsgIsZero()) && (len((*z).Header.Note) == 0) && ((*z).Header.GenesisID == "") && ((*z).Header.GenesisHash.MsgIsZero()) && ((*z).Header.Group.MsgIsZero()) && ((*z).Header.Lease == ([32]byte{})) && ((*z).Header.RekeyTo.MsgIsZero()) && ((*z).KeyregTxnFields.VotePK.MsgIsZero()) && ((*z).KeyregTxnFields.SelectionPK.MsgIsZero()) && ((*z).KeyregTxnFields.StateProofPK.MsgIsZero()) && ((*z).KeyregTxnFields.VoteFirst.MsgIsZero()) && ((*z).KeyregTxnFields.VoteLast.MsgIsZero()) && ((*z).KeyregTxnFields.VoteKeyDilution == 0) && ((*z).KeyregTxnFields.Nonparticipation == false) && ((*z).PaymentTxnFields.Receiver.MsgIsZero()) && ((*z).PaymentTxnFields.Amount.MsgIsZero()) && ((*z).PaymentTxnFields.CloseRemainderTo.MsgIsZero()) && ((*z).AssetConfigTxnFields.ConfigAsset.MsgIsZero()) && ((*z).AssetConfigTxnFields.AssetParams.MsgIsZero()) && ((*z).AssetTransferTxnFields.XferAsset.MsgIsZero()) && ((*z).AssetTransferTxnFields.AssetAmount == 0) && ((*z).AssetTransferTxnFields.AssetSender.MsgIsZero()) && ((*z).AssetTransferTxnFields.AssetReceiver.MsgIsZero()) && ((*z).AssetTransferTxnFields.AssetCloseTo.MsgIsZero()) && ((*z).AssetFreezeTxnFields.FreezeAccount.MsgIsZero()) && ((*z).AssetFreezeTxnFields.FreezeAsset.MsgIsZero()) && ((*z).AssetFreezeTxnFields.AssetFrozen == false) && ((*z).ApplicationCallTxnFields.ApplicationID.MsgIsZero()) && ((*z).ApplicationCallTxnFields.OnCompletion == 0) && (len((*z).ApplicationCallTxnFields.ApplicationArgs) == 0) && (len((*z).ApplicationCallTxnFields.Accounts) == 0) && (len((*z).ApplicationCallTxnFields.ForeignApps) == 0) && (len((*z).ApplicationCallTxnFields.Boxes) == 0) && (len((*z).ApplicationCallTxnFields.ForeignAssets) == 0) && ((*z).ApplicationCallTxnFields.LocalStateSchema.MsgIsZero()) && ((*z).ApplicationCallTxnFields.GlobalStateSchema.MsgIsZero()) && (len((*z).ApplicationCallTxnFields.ApprovalProgram) == 0) && (len((*z).ApplicationCallTxnFields.ClearStateProgram) == 0) && ((*z).ApplicationCallTxnFields.ExtraProgramPages == 0) && ((*z).StateProofTxnFields.StateProofType.MsgIsZero()) && ((*z).StateProofTxnFields.StateProof.MsgIsZero()) && ((*z).StateProofTxnFields.Message.MsgIsZero()) && ((*z).HeartbeatTxnFields == nil)
 }
 
 // MaxSize returns a maximum valid message size for this message type
@@ -7027,7 +6966,8 @@ func TransactionMaxSize() (s int) {
 	s += 5
 	// Calculating size of slice: z.ApplicationCallTxnFields.ForeignAssets
 	s += msgp.ArrayHeaderSize + ((encodedMaxForeignAssets) * (basics.AssetIndexMaxSize()))
-	s += 5 + basics.StateSchemaMaxSize() + 5 + basics.StateSchemaMaxSize() + 5 + msgp.BytesPrefixSize + config.MaxAvailableAppProgramLen + 5 + msgp.BytesPrefixSize + config.MaxAvailableAppProgramLen + 5 + msgp.Uint32Size + 7 + protocol.StateProofTypeMaxSize() + 3 + stateproof.StateProofMaxSize() + 6 + stateproofmsg.MessageMaxSize() + 5 + basics.AddressMaxSize() + 6 + crypto.HeartbeatProofMaxSize() + 5 + committee.SeedMaxSize() + 6 + crypto.OneTimeSignatureVerifierMaxSize() + 5 + msgp.Uint64Size
+	s += 5 + basics.StateSchemaMaxSize() + 5 + basics.StateSchemaMaxSize() + 5 + msgp.BytesPrefixSize + config.MaxAvailableAppProgramLen + 5 + msgp.BytesPrefixSize + config.MaxAvailableAppProgramLen + 5 + msgp.Uint32Size + 7 + protocol.StateProofTypeMaxSize() + 3 + stateproof.StateProofMaxSize() + 6 + stateproofmsg.MessageMaxSize() + 3
+	s += HeartbeatTxnFieldsMaxSize()
 	return
 }
 

--- a/data/transactions/stateproof.go
+++ b/data/transactions/stateproof.go
@@ -33,14 +33,6 @@ type StateProofTxnFields struct {
 	Message        stateproofmsg.Message   `codec:"spmsg"`
 }
 
-// Empty returns whether the StateProofTxnFields are all zero,
-// in the sense of being omitted in a msgpack encoding.
-func (sp StateProofTxnFields) Empty() bool {
-	return sp.StateProofType == protocol.StateProofBasic &&
-		sp.StateProof.MsgIsZero() &&
-		sp.Message.MsgIsZero()
-}
-
 // specialAddr is used to form a unique address that will send out state proofs.
 //
 //msgp:ignore specialAddr

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -101,7 +101,11 @@ type Transaction struct {
 	AssetFreezeTxnFields
 	ApplicationCallTxnFields
 	StateProofTxnFields
-	HeartbeatTxnFields
+
+	// By making HeartbeatTxnFields a pointer we save a ton of space of the
+	// Transaction object. Unlike other txn types, the fields will be
+	// embedded under a named field in the transaction encoding.
+	*HeartbeatTxnFields `codec:"hb"`
 }
 
 // ApplyData contains information about the transaction's execution.
@@ -632,11 +636,11 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 		nonZeroFields[protocol.ApplicationCallTx] = true
 	}
 
-	if !tx.StateProofTxnFields.Empty() {
+	if !tx.StateProofTxnFields.MsgIsZero() {
 		nonZeroFields[protocol.StateProofTx] = true
 	}
 
-	if tx.HeartbeatTxnFields != (HeartbeatTxnFields{}) {
+	if tx.HeartbeatTxnFields != nil {
 		nonZeroFields[protocol.HeartbeatTx] = true
 	}
 

--- a/data/transactions/transaction_test.go
+++ b/data/transactions/transaction_test.go
@@ -605,7 +605,7 @@ func TestWellFormedErrors(t *testing.T) {
 			tx: Transaction{
 				Type:   protocol.HeartbeatTx,
 				Header: okHeader,
-				HeartbeatTxnFields: HeartbeatTxnFields{
+				HeartbeatTxnFields: &HeartbeatTxnFields{
 					HbSeed:        committee.Seed{0x02},
 					HbVoteID:      crypto.OneTimeSignatureVerifier{0x03},
 					HbKeyDilution: 10,
@@ -618,7 +618,7 @@ func TestWellFormedErrors(t *testing.T) {
 			tx: Transaction{
 				Type:   protocol.HeartbeatTx,
 				Header: okHeader,
-				HeartbeatTxnFields: HeartbeatTxnFields{
+				HeartbeatTxnFields: &HeartbeatTxnFields{
 					HbProof: crypto.HeartbeatProof{
 						Sig: [64]byte{0x01},
 					},
@@ -633,7 +633,7 @@ func TestWellFormedErrors(t *testing.T) {
 			tx: Transaction{
 				Type:   protocol.HeartbeatTx,
 				Header: okHeader,
-				HeartbeatTxnFields: HeartbeatTxnFields{
+				HeartbeatTxnFields: &HeartbeatTxnFields{
 					HbProof: crypto.HeartbeatProof{
 						Sig: [64]byte{0x01},
 					},
@@ -648,7 +648,7 @@ func TestWellFormedErrors(t *testing.T) {
 			tx: Transaction{
 				Type:   protocol.HeartbeatTx,
 				Header: okHeader,
-				HeartbeatTxnFields: HeartbeatTxnFields{
+				HeartbeatTxnFields: &HeartbeatTxnFields{
 					HbProof: crypto.HeartbeatProof{
 						Sig: [64]byte{0x01},
 					},
@@ -663,7 +663,7 @@ func TestWellFormedErrors(t *testing.T) {
 			tx: Transaction{
 				Type:   protocol.HeartbeatTx,
 				Header: okHeader,
-				HeartbeatTxnFields: HeartbeatTxnFields{
+				HeartbeatTxnFields: &HeartbeatTxnFields{
 					HbProof: crypto.HeartbeatProof{
 						Sig: [64]byte{0x01},
 					},
@@ -684,7 +684,7 @@ func TestWellFormedErrors(t *testing.T) {
 					FirstValid: 100,
 					Note:       []byte{0x01},
 				},
-				HeartbeatTxnFields: HeartbeatTxnFields{
+				HeartbeatTxnFields: &HeartbeatTxnFields{
 					HbProof: crypto.HeartbeatProof{
 						Sig: [64]byte{0x01},
 					},
@@ -706,7 +706,7 @@ func TestWellFormedErrors(t *testing.T) {
 					FirstValid: 100,
 					Lease:      [32]byte{0x01},
 				},
-				HeartbeatTxnFields: HeartbeatTxnFields{
+				HeartbeatTxnFields: &HeartbeatTxnFields{
 					HbProof: crypto.HeartbeatProof{
 						Sig: [64]byte{0x01},
 					},
@@ -727,7 +727,7 @@ func TestWellFormedErrors(t *testing.T) {
 					FirstValid: 100,
 					RekeyTo:    [32]byte{0x01},
 				},
-				HeartbeatTxnFields: HeartbeatTxnFields{
+				HeartbeatTxnFields: &HeartbeatTxnFields{
 					HbProof: crypto.HeartbeatProof{
 						Sig: [64]byte{0x01},
 					},

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -312,11 +312,7 @@ func stxnCoreChecks(gi int, groupCtx *GroupContext, batchVerifier crypto.BatchVe
 
 	if s.Txn.Type == protocol.HeartbeatTx {
 		id := basics.OneTimeIDForRound(s.Txn.LastValid, s.Txn.HbKeyDilution)
-		offsetID := crypto.OneTimeSignatureSubkeyOffsetID{SubKeyPK: s.Txn.HbProof.PK, Batch: id.Batch, Offset: id.Offset}
-		batchID := crypto.OneTimeSignatureSubkeyBatchID{SubKeyPK: s.Txn.HbProof.PK2, Batch: id.Batch}
-		batchVerifier.EnqueueSignature(crypto.PublicKey(s.Txn.HbVoteID), batchID, crypto.Signature(s.Txn.HbProof.PK2Sig))
-		batchVerifier.EnqueueSignature(crypto.PublicKey(batchID.SubKeyPK), offsetID, crypto.Signature(s.Txn.HbProof.PK1Sig))
-		batchVerifier.EnqueueSignature(crypto.PublicKey(offsetID.SubKeyPK), s.Txn.HbSeed, crypto.Signature(s.Txn.HbProof.Sig))
+		s.Txn.HbProof.BatchPrep(s.Txn.HbVoteID, id, s.Txn.HbSeed, batchVerifier)
 	}
 
 	switch sigType {

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -112,7 +112,7 @@ func createHeartbeatTxn(fv basics.Round, t *testing.T) transactions.SignedTxn {
 			FirstValid: fv,
 			LastValid:  lv,
 		},
-		HeartbeatTxnFields: transactions.HeartbeatTxnFields{
+		HeartbeatTxnFields: &transactions.HeartbeatTxnFields{
 			HbProof:       otss.Sign(id, seed).ToHeartbeatProof(),
 			HbSeed:        seed,
 			HbVoteID:      otss.OneTimeSignatureVerifier,

--- a/data/txntest/txn.go
+++ b/data/txntest/txn.go
@@ -225,6 +225,17 @@ func (tx Txn) Txn() transactions.Transaction {
 	case nil:
 		tx.Fee = basics.MicroAlgos{}
 	}
+
+	hb := &transactions.HeartbeatTxnFields{
+		HbAddress:     tx.HbAddress,
+		HbProof:       tx.HbProof,
+		HbSeed:        tx.HbSeed,
+		HbVoteID:      tx.HbVoteID,
+		HbKeyDilution: tx.HbKeyDilution,
+	}
+	if hb.MsgIsZero() {
+		hb = nil
+	}
 	return transactions.Transaction{
 		Type: tx.Type,
 		Header: transactions.Header{
@@ -288,13 +299,7 @@ func (tx Txn) Txn() transactions.Transaction {
 			StateProof:     tx.StateProof,
 			Message:        tx.StateProofMsg,
 		},
-		HeartbeatTxnFields: transactions.HeartbeatTxnFields{
-			HbAddress:     tx.HbAddress,
-			HbProof:       tx.HbProof,
-			HbSeed:        tx.HbSeed,
-			HbVoteID:      tx.HbVoteID,
-			HbKeyDilution: tx.HbKeyDilution,
-		},
+		HeartbeatTxnFields: hb,
 	}
 }
 

--- a/heartbeat/service.go
+++ b/heartbeat/service.go
@@ -180,7 +180,7 @@ func (s *Service) prepareHeartbeat(pr account.ParticipationRecordForRound, lates
 	}
 
 	id := basics.OneTimeIDForRound(stxn.Txn.LastValid, pr.KeyDilution)
-	stxn.Txn.HeartbeatTxnFields = transactions.HeartbeatTxnFields{
+	stxn.Txn.HeartbeatTxnFields = &transactions.HeartbeatTxnFields{
 		HbAddress:     pr.Account,
 		HbProof:       pr.Voting.Sign(id, latest.Seed).ToHeartbeatProof(),
 		HbSeed:        latest.Seed,

--- a/ledger/acctonline_expired_test.go
+++ b/ledger/acctonline_expired_test.go
@@ -458,7 +458,7 @@ func TestOnlineAcctModelSimple(t *testing.T) {
 	})
 	// test same scenario on double ledger
 	t.Run("DoubleLedger", func(t *testing.T) {
-		m := newDoubleLedgerAcctModel(t, protocol.ConsensusV39, true) // TODO simulate heartbeats
+		m := newDoubleLedgerAcctModel(t, protocol.ConsensusFuture, true)
 		defer m.teardown()
 		testOnlineAcctModelSimple(t, m)
 	})
@@ -626,7 +626,7 @@ func TestOnlineAcctModelScenario(t *testing.T) {
 			})
 			// test same scenario on double ledger
 			t.Run("DoubleLedger", func(t *testing.T) {
-				m := newDoubleLedgerAcctModel(t, protocol.ConsensusV39, true) // TODO simulate heartbeats
+				m := newDoubleLedgerAcctModel(t, protocol.ConsensusFuture, true)
 				defer m.teardown()
 				runScenario(t, m, tc.scenario)
 			})

--- a/ledger/apply/heartbeat_test.go
+++ b/ledger/apply/heartbeat_test.go
@@ -79,37 +79,37 @@ func TestHeartbeat(t *testing.T) {
 
 	rnd := basics.Round(150)
 	// no fee
-	err := Heartbeat(tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
+	err := Heartbeat(*tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
 	require.ErrorContains(t, err, "free heartbeat")
 
 	// just as bad: cheap
 	tx.Fee = basics.MicroAlgos{Raw: 10}
-	err = Heartbeat(tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
+	err = Heartbeat(*tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
 	require.ErrorContains(t, err, "cheap heartbeat")
 
 	// address fee
 	tx.Fee = basics.MicroAlgos{Raw: 1000}
 
 	// Seed is missing
-	err = Heartbeat(tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
+	err = Heartbeat(*tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
 	require.ErrorContains(t, err, "provided seed")
 
 	tx.HbSeed = seed
 	// VoterID is missing
-	err = Heartbeat(tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
+	err = Heartbeat(*tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
 	require.ErrorContains(t, err, "provided voter ID")
 
 	tx.HbVoteID = otss.OneTimeSignatureVerifier
 	// still no key dilution
-	err = Heartbeat(tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
+	err = Heartbeat(*tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
 	require.ErrorContains(t, err, "provided key dilution 0")
 
 	tx.HbKeyDilution = keyDilution + 1
-	err = Heartbeat(tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
+	err = Heartbeat(*tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
 	require.ErrorContains(t, err, "provided key dilution 778")
 
 	tx.HbKeyDilution = keyDilution
-	err = Heartbeat(tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
+	err = Heartbeat(*tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
 	require.NoError(t, err)
 	after, err := mockBal.Get(voter, false)
 	require.NoError(t, err)
@@ -198,7 +198,7 @@ func TestCheapRules(t *testing.T) {
 
 		tx := txn.Txn()
 		fmt.Printf("tc %+v\n", tc)
-		err := Heartbeat(tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, tc.rnd)
+		err := Heartbeat(*tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, tc.rnd)
 		if tc.err == "" {
 			assert.NoError(t, err)
 		} else {

--- a/ledger/eval/eval.go
+++ b/ledger/eval/eval.go
@@ -1310,7 +1310,7 @@ func (eval *BlockEvaluator) applyTransaction(tx transactions.Transaction, cow *r
 		err = apply.StateProof(tx.StateProofTxnFields, tx.Header.FirstValid, cow, eval.validate)
 
 	case protocol.HeartbeatTx:
-		err = apply.Heartbeat(tx.HeartbeatTxnFields, tx.Header, cow, cow, cow.Round())
+		err = apply.Heartbeat(*tx.HeartbeatTxnFields, tx.Header, cow, cow, cow.Round())
 
 	default:
 		err = fmt.Errorf("unknown transaction type %v", tx.Type)

--- a/ledger/eval/prefetcher/prefetcher_alignment_test.go
+++ b/ledger/eval/prefetcher/prefetcher_alignment_test.go
@@ -1463,7 +1463,7 @@ func TestEvaluatorPrefetcherAlignmentHeartbeat(t *testing.T) {
 			GenesisHash: genesisHash(),
 			Fee:         basics.Algos(1), // Heartbeat txn is unusual in that it checks fees a bit.
 		},
-		HeartbeatTxnFields: transactions.HeartbeatTxnFields{
+		HeartbeatTxnFields: &transactions.HeartbeatTxnFields{
 			HbAddress:     makeAddress(2),
 			HbProof:       otss.Sign(firstID, committee.Seed(genesisHash())).ToHeartbeatProof(),
 			HbSeed:        committee.Seed(genesisHash()),

--- a/node/node.go
+++ b/node/node.go
@@ -465,6 +465,7 @@ func (node *AlgorandFullNode) Stop() {
 	if node.catchpointCatchupService != nil {
 		node.catchpointCatchupService.Stop()
 	} else {
+		node.heartbeatService.Stop()
 		node.stateProofWorker.Stop()
 		node.txHandler.Stop()
 		node.agreementService.Shutdown()
@@ -1226,6 +1227,7 @@ func (node *AlgorandFullNode) SetCatchpointCatchupMode(catchpointCatchupMode boo
 			}()
 			node.net.ClearHandlers()
 			node.net.ClearValidatorHandlers()
+			node.heartbeatService.Stop()
 			node.stateProofWorker.Stop()
 			node.heartbeatService.Stop()
 			node.txHandler.Stop()

--- a/tools/x-repo-types/typeAnalyzer/typeAnalyzer.go
+++ b/tools/x-repo-types/typeAnalyzer/typeAnalyzer.go
@@ -237,12 +237,17 @@ func (t *TypeNode) buildStructChildren(path TypePath) TypePath {
 
 		if typeField.Anonymous {
 			// embedded struct case
-			actualKind := typeField.Type.Kind()
+			fieldType := typeField.Type
+			if fieldType.Kind() == reflect.Ptr {
+				// get underlying type for embedded pointer to struct
+				fieldType = fieldType.Elem()
+			}
+			actualKind := fieldType.Kind()
 			if actualKind != reflect.Struct {
 				panic(fmt.Sprintf("expected [%s] but got unexpected embedded type: %s", reflect.Struct, typeField.Type))
 			}
 
-			embedded := TypeNode{t.Depth, typeField.Type, reflect.Struct, nil, nil}
+			embedded := TypeNode{t.Depth, fieldType, reflect.Struct, nil, nil}
 			embeddedCyclePath := embedded.build(path)
 			if len(embeddedCyclePath) > 0 {
 				cyclePath = embeddedCyclePath

--- a/util/set.go
+++ b/util/set.go
@@ -54,7 +54,9 @@ func Union[T comparable](sets ...Set[T]) Set[T] {
 }
 
 // Intersection constructs a new set, containing all elements that appear in all
-// given sets. nil is never returned.
+// given sets. nil is never returned. Intersection of no sets is an empty set
+// because that seems more useful, regardless of your very reasonable arguments
+// otherwise.
 func Intersection[T comparable](sets ...Set[T]) Set[T] {
 	var intersection = make(Set[T])
 	if len(sets) == 0 {


### PR DESCRIPTION
Use a pointer to HeartbeatTxnFields instead of embedded the entire, large structure.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
