### PR TITLE
catchpoints: more support for EnableOnlineAccountCatchpoints

### DIFF
--- a/cmd/catchpointdump/database.go
+++ b/cmd/catchpointdump/database.go
@@ -88,6 +88,14 @@ var databaseCmd = &cobra.Command{
 		if err != nil {
 			reportErrorf("Unable to print state proof verification database : %v", err)
 		}
+		err = printOnlineAccounts(ledgerTrackerFilename, ledgerTrackerStaging, outFile)
+		if err != nil {
+			reportErrorf("Unable to print online accounts : %v", err)
+		}
+		err = printOnlineRoundParams(ledgerTrackerFilename, ledgerTrackerStaging, outFile)
+		if err != nil {
+			reportErrorf("Unable to print online round params : %v", err)
+		}
 	},
 }
 

--- a/cmd/catchpointdump/file.go
+++ b/cmd/catchpointdump/file.go
@@ -594,7 +594,7 @@ func printOnlineAccounts(databaseName string, stagingTables bool, outFile *os.Fi
 	}
 
 	return dbAccessor.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		rows, err := sqlitedriver.MakeOnlineAccountsIter(ctx, tx, stagingTables)
+		rows, err := sqlitedriver.MakeOnlineAccountsIter(ctx, tx, stagingTables, 0)
 		if err != nil {
 			return err
 		}
@@ -627,7 +627,7 @@ func printOnlineRoundParams(databaseName string, stagingTables bool, outFile *os
 	}
 
 	return dbAccessor.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		rows, err := sqlitedriver.MakeOnlineRoundParamsIter(ctx, tx, stagingTables)
+		rows, err := sqlitedriver.MakeOnlineRoundParamsIter(ctx, tx, stagingTables, 0)
 		if err != nil {
 			return err
 		}

--- a/cmd/catchpointdump/file.go
+++ b/cmd/catchpointdump/file.go
@@ -142,6 +142,14 @@ var fileCmd = &cobra.Command{
 			if err != nil {
 				reportErrorf("Unable to print state proof verification database : %v", err)
 			}
+			err = printOnlineAccounts("./ledger.tracker.sqlite", true, outFile)
+			if err != nil {
+				reportErrorf("Unable to print online accounts : %v", err)
+			}
+			err = printOnlineRoundParams("./ledger.tracker.sqlite", true, outFile)
+			if err != nil {
+				reportErrorf("Unable to print online round params : %v", err)
+			}
 		}
 	},
 }
@@ -219,8 +227,17 @@ func loadCatchpointIntoDatabase(ctx context.Context, catchupAccessor ledger.Catc
 					if err != nil {
 						return fileHeader, err
 					}
-					fmt.Printf("accounts digest=%s, spver digest=%s, onlineaccounts digest=%s onlineroundparams digest=%s\n\n",
+					fmt.Printf("accounts digest=%s, spver digest=%s, onlineaccounts digest=%s onlineroundparams digest=%s\n",
 						balanceHash, spverHash, onlineAccountsHash, onlineRoundParamsHash)
+
+					fmt.Printf("Catchpoint label: %s\n", fileHeader.Catchpoint)
+					// make v7 label
+					v7Label := ledgercore.MakeCatchpointLabelMakerV7(fileHeader.BlocksRound, &fileHeader.BlockHeaderDigest, &balanceHash, fileHeader.Totals, &spverHash)
+					fmt.Printf("catchpoint v7 label: %s\n", ledgercore.MakeLabel(v7Label))
+
+					// make v8 label (current)
+					v8Label := ledgercore.MakeCatchpointLabelMakerCurrent(fileHeader.BlocksRound, &fileHeader.BlockHeaderDigest, &balanceHash, fileHeader.Totals, &spverHash, &onlineAccountsHash, &onlineRoundParamsHash)
+					fmt.Printf("catchpoint v8 label: %s\n\n", ledgercore.MakeLabel(v8Label))
 				}
 				return fileHeader, nil
 			}
@@ -296,6 +313,8 @@ func printAccountsDatabase(databaseName string, stagingTables bool, fileHeader l
 			"Catchpoint: %s",
 			"Total Accounts: %d",
 			"Total KVs: %d",
+			"Total Online Accounts: %d",
+			"Total Online Round Params: %d",
 			"Total Chunks: %d",
 		}
 		var headerValues = []interface{}{
@@ -306,6 +325,8 @@ func printAccountsDatabase(databaseName string, stagingTables bool, fileHeader l
 			fileHeader.Catchpoint,
 			fileHeader.TotalAccounts,
 			fileHeader.TotalKVs,
+			fileHeader.TotalOnlineAccounts,
+			fileHeader.TotalOnlineRoundParams,
 			fileHeader.TotalChunks,
 		}
 		// safety check
@@ -556,6 +577,72 @@ func printKeyValueStore(databaseName string, stagingTables bool, outFile *os.Fil
 				lastProgressUpdate = time.Now()
 				printDumpingCatchpointProgressLine(int(float64(progress)*50.0/float64(rowsCount)), 50, int64(progress))
 			}
+		}
+		return nil
+	})
+}
+
+func printOnlineAccounts(databaseName string, stagingTables bool, outFile *os.File) error {
+	fmt.Printf("\n")
+
+	fileWriter := bufio.NewWriterSize(outFile, 1024*1024)
+	defer fileWriter.Flush()
+
+	dbAccessor, err := db.MakeAccessor(databaseName, true, false)
+	if err != nil || dbAccessor.Handle == nil {
+		return err
+	}
+
+	return dbAccessor.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		rows, err := sqlitedriver.MakeOnlineAccountsIter(ctx, tx, stagingTables)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			row, err := rows.GetItem()
+			if err != nil {
+				return err
+			}
+			jsonData, err := json.Marshal(row)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(fileWriter, "onlineaccount: %s\n", string(jsonData))
+		}
+		return nil
+	})
+}
+
+func printOnlineRoundParams(databaseName string, stagingTables bool, outFile *os.File) error {
+	fmt.Printf("\n")
+
+	fileWriter := bufio.NewWriterSize(outFile, 1024*1024)
+	defer fileWriter.Flush()
+
+	dbAccessor, err := db.MakeAccessor(databaseName, true, false)
+	if err != nil || dbAccessor.Handle == nil {
+		return err
+	}
+
+	return dbAccessor.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		rows, err := sqlitedriver.MakeOnlineRoundParamsIter(ctx, tx, stagingTables)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			row, err := rows.GetItem()
+			if err != nil {
+				return err
+			}
+			jsonData, err := json.Marshal(row)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(fileWriter, "onlineroundparams: %s\n", string(jsonData))
 		}
 		return nil
 	})

--- a/cmd/catchpointdump/file.go
+++ b/cmd/catchpointdump/file.go
@@ -532,7 +532,6 @@ func printKeyValue(writer *bufio.Writer, key, value []byte) {
 }
 
 func printKeyValueStore(databaseName string, stagingTables bool, outFile *os.File) error {
-	fmt.Printf("\n")
 	printDumpingCatchpointProgressLine(0, 50, 0)
 	lastProgressUpdate := time.Now()
 	progress := uint64(0)
@@ -583,8 +582,6 @@ func printKeyValueStore(databaseName string, stagingTables bool, outFile *os.Fil
 }
 
 func printOnlineAccounts(databaseName string, stagingTables bool, outFile *os.File) error {
-	fmt.Printf("\n")
-
 	fileWriter := bufio.NewWriterSize(outFile, 1024*1024)
 	defer fileWriter.Flush()
 
@@ -616,8 +613,6 @@ func printOnlineAccounts(databaseName string, stagingTables bool, outFile *os.Fi
 }
 
 func printOnlineRoundParams(databaseName string, stagingTables bool, outFile *os.File) error {
-	fmt.Printf("\n")
-
 	fileWriter := bufio.NewWriterSize(outFile, 1024*1024)
 	defer fileWriter.Flush()
 

--- a/cmd/catchpointdump/net.go
+++ b/cmd/catchpointdump/net.go
@@ -365,7 +365,14 @@ func loadAndDump(addr string, tarFile string, genesisInitState ledgercore.InitSt
 		if err != nil {
 			return err
 		}
-
+		err = printOnlineAccounts("./ledger.tracker.sqlite", true, outFile)
+		if err != nil {
+			return err
+		}
+		err = printOnlineRoundParams("./ledger.tracker.sqlite", true, outFile)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/ledger/acctdeltas_test.go
+++ b/ledger/acctdeltas_test.go
@@ -2750,6 +2750,27 @@ func TestAccountOnlineRoundParams(t *testing.T) {
 	require.Equal(t, onlineRoundParams, dbOnlineRoundParams[1:])
 	require.Equal(t, maxRounds, int(endRound))
 
+	// Use MakeOnlineRoundParamsIter to dump all data, starting from 10
+	iter, err := sqlitedriver.MakeOnlineRoundParamsIter(context.Background(), tx, false, 10)
+	require.NoError(t, err)
+	defer iter.Close()
+	var roundParamsIterData []ledgercore.OnlineRoundParamsData
+	var roundParamsIterLastRound basics.Round
+	for iter.Next() {
+		item, err := iter.GetItem()
+		require.NoError(t, err)
+
+		var orpData ledgercore.OnlineRoundParamsData
+		err = protocol.Decode(item.Data, &orpData)
+		require.NoError(t, err)
+		roundParamsIterLastRound = item.Round
+
+		roundParamsIterData = append(roundParamsIterData, orpData)
+	}
+	require.Equal(t, onlineRoundParams[9:], roundParamsIterData)
+	require.Equal(t, maxRounds, int(roundParamsIterLastRound))
+
+	// Prune online round params to rnd 10
 	err = arw.AccountsPruneOnlineRoundParams(10)
 	require.NoError(t, err)
 
@@ -2772,6 +2793,15 @@ func TestAccountOnlineRoundParams(t *testing.T) {
 func TestOnlineAccountsDeletion(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
+	t.Run("delete", func(t *testing.T) {
+		runTestOnlineAccountsDeletion(t, testOnlineAccountsDeletion)
+	})
+	t.Run("excludeBefore", func(t *testing.T) {
+		runTestOnlineAccountsDeletion(t, testOnlineAccountsExcludeBefore)
+	})
+}
+
+func runTestOnlineAccountsDeletion(t *testing.T, assertFunc func(*testing.T, basics.Address, basics.Address, *sql.Tx)) {
 	dbs, _ := storetesting.DbOpenTest(t, true)
 	storetesting.SetDbLogging(t, dbs)
 	defer dbs.Close()
@@ -2782,8 +2812,6 @@ func TestOnlineAccountsDeletion(t *testing.T) {
 
 	var accts map[basics.Address]basics.AccountData
 	sqlitedriver.AccountsInitTest(t, tx, accts, protocol.ConsensusCurrentVersion)
-
-	arw := sqlitedriver.NewAccountsSQLReaderWriter(tx)
 
 	updates := compactOnlineAccountDeltas{}
 	addrA := ledgertesting.RandomAddress()
@@ -2836,6 +2864,12 @@ func TestOnlineAccountsDeletion(t *testing.T) {
 	updated, err := onlineAccountsNewRoundImpl(writer, updates, proto, lastUpdateRound)
 	require.NoError(t, err)
 	require.Len(t, updated, 5)
+
+	assertFunc(t, addrA, addrB, tx)
+}
+
+func testOnlineAccountsDeletion(t *testing.T, addrA, addrB basics.Address, tx *sql.Tx) {
+	arw := sqlitedriver.NewAccountsSQLReaderWriter(tx)
 
 	queries, err := sqlitedriver.OnlineAccountsInitDbQueries(tx)
 	require.NoError(t, err)
@@ -2894,6 +2928,62 @@ func TestOnlineAccountsDeletion(t *testing.T) {
 		history, validThrough, err = queries.LookupOnlineHistory(addrB)
 		require.NoError(t, err)
 		require.Equal(t, basics.Round(0), validThrough)
+		require.Len(t, history, 1)
+	}
+}
+
+// same assertions as testOnlineAccountsDeletion but with excludeBefore
+func testOnlineAccountsExcludeBefore(t *testing.T, addrA, addrB basics.Address, tx *sql.Tx) {
+	// Use MakeOnlineAccountsIter to dump all data, starting from rnd
+	getAcctDataForRound := func(rnd basics.Round, expectedCount int64) map[basics.Address][]*encoded.OnlineAccountRecordV6 {
+		it, err := sqlitedriver.MakeOnlineAccountsIter(context.Background(), tx, false, rnd)
+		require.NoError(t, err)
+
+		var count int64
+		ret := make(map[basics.Address][]*encoded.OnlineAccountRecordV6)
+		for it.Next() {
+			acct, err := it.GetItem()
+			require.NoError(t, err)
+			ret[acct.Address] = append(ret[acct.Address], acct)
+			count++
+		}
+		require.Equal(t, expectedCount, count)
+		return ret
+	}
+
+	for _, rnd := range []basics.Round{1, 2, 3} {
+		vals := getAcctDataForRound(rnd, 5)
+
+		history, ok := vals[addrA]
+		require.True(t, ok)
+		require.Len(t, history, 3)
+
+		history, ok = vals[addrB]
+		require.True(t, ok)
+		require.Len(t, history, 2)
+	}
+
+	for _, rnd := range []basics.Round{4, 5, 6, 7} {
+		vals := getAcctDataForRound(rnd, 3)
+
+		history, ok := vals[addrA]
+		require.True(t, ok)
+		require.Len(t, history, 1)
+
+		history, ok = vals[addrB]
+		require.True(t, ok)
+		require.Len(t, history, 2)
+	}
+
+	for _, rnd := range []basics.Round{8, 9} {
+		vals := getAcctDataForRound(rnd, 2)
+
+		history, ok := vals[addrA]
+		require.True(t, ok)
+		require.Len(t, history, 1)
+
+		history, ok = vals[addrB]
+		require.True(t, ok)
 		require.Len(t, history, 1)
 	}
 }

--- a/ledger/catchpointfilewriter.go
+++ b/ledger/catchpointfilewriter.go
@@ -379,7 +379,7 @@ func (cw *catchpointFileWriter) readDatabaseStep(ctx context.Context) error {
 		cw.kvDone = true
 	}
 
-	if cw.params.EnableOnlineAccountCatchpoints && !cw.onlineAccountsDone {
+	if cw.params.EnableCatchpointsWithOnlineAccounts && !cw.onlineAccountsDone {
 		// Create the OnlineAccounts iterator JIT
 		if cw.onlineAccountRows == nil {
 			rows, err := cw.tx.MakeOnlineAccountsIter(ctx, false, cw.onlineExcludeBefore)
@@ -408,7 +408,7 @@ func (cw *catchpointFileWriter) readDatabaseStep(ctx context.Context) error {
 		cw.onlineAccountsDone = true
 	}
 
-	if cw.params.EnableOnlineAccountCatchpoints && !cw.onlineRoundParamsDone {
+	if cw.params.EnableCatchpointsWithOnlineAccounts && !cw.onlineRoundParamsDone {
 		// Create the OnlineRoundParams iterator JIT
 		if cw.onlineRoundParamsRows == nil {
 			rows, err := cw.tx.MakeOnlineRoundParamsIter(ctx, false, cw.onlineExcludeBefore)

--- a/ledger/catchpointfilewriter_test.go
+++ b/ledger/catchpointfilewriter_test.go
@@ -149,7 +149,7 @@ func verifyStateProofVerificationContextWrite(t *testing.T, data []ledgercore.St
 	require.NoError(t, err)
 
 	err = ml.trackerDB().Transaction(func(ctx context.Context, tx trackerdb.TransactionScope) (err error) {
-		writer, err := makeCatchpointFileWriter(context.Background(), protoParams, fileName, tx, ResourcesPerCatchpointFileChunk)
+		writer, err := makeCatchpointFileWriter(context.Background(), protoParams, fileName, tx, ResourcesPerCatchpointFileChunk, 0)
 		if err != nil {
 			return err
 		}
@@ -264,7 +264,7 @@ func TestBasicCatchpointWriter(t *testing.T) {
 	fileName := filepath.Join(temporaryDirectory, "15.data")
 
 	err = ml.trackerDB().Transaction(func(ctx context.Context, tx trackerdb.TransactionScope) (err error) {
-		writer, err := makeCatchpointFileWriter(context.Background(), protoParams, fileName, tx, ResourcesPerCatchpointFileChunk)
+		writer, err := makeCatchpointFileWriter(context.Background(), protoParams, fileName, tx, ResourcesPerCatchpointFileChunk, 0)
 		if err != nil {
 			return err
 		}
@@ -307,7 +307,7 @@ func testWriteCatchpoint(t *testing.T, params config.ConsensusParams, rdb tracke
 	}
 
 	err := rdb.Transaction(func(ctx context.Context, tx trackerdb.TransactionScope) (err error) {
-		writer, err := makeCatchpointFileWriter(context.Background(), params, datapath, tx, maxResourcesPerChunk)
+		writer, err := makeCatchpointFileWriter(context.Background(), params, datapath, tx, maxResourcesPerChunk, 0)
 		if err != nil {
 			return err
 		}
@@ -440,7 +440,7 @@ func TestCatchpointReadDatabaseOverflowSingleAccount(t *testing.T) {
 		totalAccountsWritten := uint64(0)
 		totalResources := 0
 		totalChunks := 0
-		cw, err := makeCatchpointFileWriter(context.Background(), protoParams, catchpointDataFilePath, tx, maxResourcesPerChunk)
+		cw, err := makeCatchpointFileWriter(context.Background(), protoParams, catchpointDataFilePath, tx, maxResourcesPerChunk, 0)
 		require.NoError(t, err)
 
 		ar, err := tx.MakeAccountsReader()
@@ -546,7 +546,7 @@ func TestCatchpointReadDatabaseOverflowAccounts(t *testing.T) {
 
 		totalAccountsWritten := uint64(0)
 		totalResources := 0
-		cw, err := makeCatchpointFileWriter(context.Background(), protoParams, catchpointDataFilePath, tx, maxResourcesPerChunk)
+		cw, err := makeCatchpointFileWriter(context.Background(), protoParams, catchpointDataFilePath, tx, maxResourcesPerChunk, 0)
 		require.NoError(t, err)
 
 		// repeat this until read all accts
@@ -1113,18 +1113,18 @@ assert
 	t.Log("DB round generator", genDBRound, "validator", valDBRound)
 	t.Log("Latest round generator", genLatestRound, "validator", valLatestRound)
 
-	genOAHash, genOARows, err := calculateVerificationHash(context.Background(), dl.generator.trackerDB().MakeOnlineAccountsIter, false)
+	genOAHash, genOARows, err := calculateVerificationHash(context.Background(), dl.generator.trackerDB().MakeOnlineAccountsIter, 0, false)
 	require.NoError(t, err)
-	valOAHash, valOARows, err := calculateVerificationHash(context.Background(), dl.validator.trackerDB().MakeOnlineAccountsIter, false)
+	valOAHash, valOARows, err := calculateVerificationHash(context.Background(), dl.validator.trackerDB().MakeOnlineAccountsIter, 0, false)
 	require.NoError(t, err)
 	require.Equal(t, genOAHash, valOAHash)
 	require.NotZero(t, genOAHash)
 	require.Equal(t, genOARows, valOARows)
 	require.NotZero(t, genOARows)
 
-	genORPHash, genORPRows, err := calculateVerificationHash(context.Background(), dl.generator.trackerDB().MakeOnlineRoundParamsIter, false)
+	genORPHash, genORPRows, err := calculateVerificationHash(context.Background(), dl.generator.trackerDB().MakeOnlineRoundParamsIter, 0, false)
 	require.NoError(t, err)
-	valORPHash, valORPRows, err := calculateVerificationHash(context.Background(), dl.validator.trackerDB().MakeOnlineRoundParamsIter, false)
+	valORPHash, valORPRows, err := calculateVerificationHash(context.Background(), dl.validator.trackerDB().MakeOnlineRoundParamsIter, 0, false)
 	require.NoError(t, err)
 	require.Equal(t, genORPHash, valORPHash)
 	require.NotZero(t, genORPHash)
@@ -1141,13 +1141,13 @@ assert
 	l := testNewLedgerFromCatchpoint(t, dl.generator.trackerDB(), catchpointFilePath)
 	defer l.Close()
 
-	catchpointOAHash, catchpointOARows, err := calculateVerificationHash(context.Background(), l.trackerDBs.MakeOnlineAccountsIter, false)
+	catchpointOAHash, catchpointOARows, err := calculateVerificationHash(context.Background(), l.trackerDBs.MakeOnlineAccountsIter, 0, false)
 	require.NoError(t, err)
 	require.Equal(t, genOAHash, catchpointOAHash)
 	t.Log("catchpoint onlineaccounts hash", catchpointOAHash, "matches")
 	require.Equal(t, genOARows, catchpointOARows)
 
-	catchpointORPHash, catchpointORPRows, err := calculateVerificationHash(context.Background(), l.trackerDBs.MakeOnlineRoundParamsIter, false)
+	catchpointORPHash, catchpointORPRows, err := calculateVerificationHash(context.Background(), l.trackerDBs.MakeOnlineRoundParamsIter, 0, false)
 	require.NoError(t, err)
 	require.Equal(t, genORPHash, catchpointORPHash)
 	t.Log("catchpoint onlineroundparams hash", catchpointORPHash, "matches")

--- a/ledger/catchpointfilewriter_test.go
+++ b/ledger/catchpointfilewriter_test.go
@@ -831,14 +831,14 @@ func testCatchpointFlushRound(l *Ledger) {
 
 func TestExactAccountChunk(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	t.Parallel()
+	// t.Parallel() // probably not good to parallelize catchpoint file save/load
 
-	t.Run("v33", func(t *testing.T) {
-		proto := protocol.ConsensusV33
+	t.Run("v39", func(t *testing.T) {
+		proto := protocol.ConsensusV39
 		testExactAccountChunk(t, proto, 1)
 	})
-	t.Run("v34", func(t *testing.T) {
-		proto := protocol.ConsensusV34
+	t.Run("v40", func(t *testing.T) {
+		proto := protocol.ConsensusV40
 		testExactAccountChunk(t, proto, 2)
 	})
 	t.Run("future", func(t *testing.T) {

--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -326,11 +326,11 @@ func (ct *catchpointTracker) finishFirstStageAfterCrash(dbRound basics.Round, bl
 		return err
 	}
 
-	// pass dbRound+1-maxBalLookback as the onlineExcludeBefore parameter: since we can't be sure whether
+	// pass dbRound+1-maxBalLookback as the onlineAccountsForgetBefore parameter: since we can't be sure whether
 	// there are more than 320 rounds of history in the online accounts tables, this ensures the catchpoint
 	// will only contain the most recent 320 rounds.
-	onlineExcludeBefore := (dbRound + 1).SubSaturate(basics.Round(config.Consensus[blockProto].MaxBalLookback))
-	return ct.finishFirstStage(context.Background(), dbRound, onlineExcludeBefore, blockProto, 0)
+	onlineAccountsForgetBefore := (dbRound + 1).SubSaturate(basics.Round(config.Consensus[blockProto].MaxBalLookback))
+	return ct.finishFirstStage(context.Background(), dbRound, onlineAccountsForgetBefore, blockProto, 0)
 }
 
 func (ct *catchpointTracker) finishCatchpointsAfterCrash(blockProto protocol.ConsensusVersion, catchpointLookback uint64) error {

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -362,9 +362,10 @@ func createCatchpoint(t *testing.T, ct *catchpointTracker, accountsRound basics.
 	spVerificationEncodedData, stateProofVerificationHash, err := ct.getSPVerificationData()
 	require.NoError(t, err)
 
+	proto := protocol.ConsensusCurrentVersion
 	var catchpointGenerationStats telemetryspec.CatchpointGenerationEventDetails
 	_, _, _, _, _, biggestChunkLen, err := ct.generateCatchpointData(
-		context.Background(), accountsRound, &catchpointGenerationStats, spVerificationEncodedData)
+		context.Background(), config.Consensus[proto], accountsRound, &catchpointGenerationStats, spVerificationEncodedData)
 	require.NoError(t, err)
 
 	require.Equal(t, calculateStateProofVerificationHash(t, ml), stateProofVerificationHash)
@@ -372,7 +373,7 @@ func createCatchpoint(t *testing.T, ct *catchpointTracker, accountsRound basics.
 	err = ct.createCatchpoint(
 		context.Background(), accountsRound, round,
 		trackerdb.CatchpointFirstStageInfo{BiggestChunkLen: biggestChunkLen},
-		crypto.Digest{}, protocol.ConsensusCurrentVersion)
+		crypto.Digest{}, proto)
 	require.NoError(t, err)
 }
 
@@ -605,7 +606,7 @@ func BenchmarkLargeCatchpointDataWriting(b *testing.B) {
 	encodedSPData, _, err := ct.getSPVerificationData()
 	require.NoError(b, err)
 	b.ResetTimer()
-	ct.generateCatchpointData(context.Background(), basics.Round(0), &catchpointGenerationStats, encodedSPData)
+	ct.generateCatchpointData(context.Background(), proto, basics.Round(0), &catchpointGenerationStats, encodedSPData)
 	b.StopTimer()
 	b.ReportMetric(float64(accountsNumber), "accounts")
 }

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -365,7 +365,7 @@ func createCatchpoint(t *testing.T, ct *catchpointTracker, accountsRound basics.
 	proto := protocol.ConsensusCurrentVersion
 	var catchpointGenerationStats telemetryspec.CatchpointGenerationEventDetails
 	_, _, _, _, _, biggestChunkLen, err := ct.generateCatchpointData(
-		context.Background(), config.Consensus[proto], accountsRound, &catchpointGenerationStats, spVerificationEncodedData)
+		context.Background(), config.Consensus[proto], accountsRound, 0, &catchpointGenerationStats, spVerificationEncodedData)
 	require.NoError(t, err)
 
 	require.Equal(t, calculateStateProofVerificationHash(t, ml), stateProofVerificationHash)
@@ -606,7 +606,7 @@ func BenchmarkLargeCatchpointDataWriting(b *testing.B) {
 	encodedSPData, _, err := ct.getSPVerificationData()
 	require.NoError(b, err)
 	b.ResetTimer()
-	ct.generateCatchpointData(context.Background(), proto, basics.Round(0), &catchpointGenerationStats, encodedSPData)
+	ct.generateCatchpointData(context.Background(), proto, 0, 0, &catchpointGenerationStats, encodedSPData)
 	b.StopTimer()
 	b.ReportMetric(float64(accountsNumber), "accounts")
 }

--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -1031,12 +1031,12 @@ func (c *catchpointCatchupAccessorImpl) GetVerifyData(ctx context.Context) (bala
 			return fmt.Errorf("unable to get state proof verification data: %v", err)
 		}
 
-		onlineAccountsHash, _, err = calculateVerificationHash(ctx, tx.MakeOnlineAccountsIter, true)
+		onlineAccountsHash, _, err = calculateVerificationHash(ctx, tx.MakeOnlineAccountsIter, 0, true)
 		if err != nil {
 			return fmt.Errorf("unable to get online accounts verification data: %v", err)
 		}
 
-		onlineRoundParamsHash, _, err = calculateVerificationHash(ctx, tx.MakeOnlineRoundParamsIter, true)
+		onlineRoundParamsHash, _, err = calculateVerificationHash(ctx, tx.MakeOnlineRoundParamsIter, 0, true)
 		if err != nil {
 			return fmt.Errorf("unable to get online round params verification data: %v", err)
 		}
@@ -1058,11 +1058,12 @@ func (c *catchpointCatchupAccessorImpl) GetVerifyData(ctx context.Context) (bala
 // both at restore time (in catchpointCatchupAccessorImpl) and snapshot time (in catchpointTracker).
 func calculateVerificationHash[T crypto.Hashable](
 	ctx context.Context,
-	iterFactory func(context.Context, bool) (trackerdb.TableIterator[T], error),
+	iterFactory func(context.Context, bool, basics.Round) (trackerdb.TableIterator[T], error),
+	excludeBefore basics.Round,
 	useStaging bool,
 ) (crypto.Digest, uint64, error) {
 
-	rows, err := iterFactory(ctx, useStaging)
+	rows, err := iterFactory(ctx, useStaging, excludeBefore)
 	if err != nil {
 		return crypto.Digest{}, 0, err
 	}

--- a/ledger/store/trackerdb/dualdriver/dualdriver.go
+++ b/ledger/store/trackerdb/dualdriver/dualdriver.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/ledger/encoded"
 	"github.com/algorand/go-algorand/ledger/store/trackerdb"
 	"github.com/algorand/go-algorand/logging"
@@ -278,13 +279,13 @@ func (*reader) MakeKVsIter(ctx context.Context) (trackerdb.KVsIter, error) {
 }
 
 // MakeOnlineAccountsIter implements trackerdb.Reader
-func (*reader) MakeOnlineAccountsIter(context.Context, bool) (trackerdb.TableIterator[*encoded.OnlineAccountRecordV6], error) {
+func (*reader) MakeOnlineAccountsIter(context.Context, bool, basics.Round) (trackerdb.TableIterator[*encoded.OnlineAccountRecordV6], error) {
 	// TODO: catchpoint
 	return nil, nil
 }
 
 // MakeOnlineRoundParamsIter implements trackerdb.Reader
-func (*reader) MakeOnlineRoundParamsIter(context.Context, bool) (trackerdb.TableIterator[*encoded.OnlineRoundParamsRecordV6], error) {
+func (*reader) MakeOnlineRoundParamsIter(context.Context, bool, basics.Round) (trackerdb.TableIterator[*encoded.OnlineRoundParamsRecordV6], error) {
 	// TODO: catchpoint
 	return nil, nil
 }

--- a/ledger/store/trackerdb/generickv/reader.go
+++ b/ledger/store/trackerdb/generickv/reader.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/ledger/encoded"
 	"github.com/algorand/go-algorand/ledger/store/trackerdb"
 )
@@ -79,13 +80,13 @@ func (r *reader) MakeKVsIter(ctx context.Context) (trackerdb.KVsIter, error) {
 }
 
 // MakeOnlineAccountsIter implements trackerdb.Reader
-func (r *reader) MakeOnlineAccountsIter(context.Context, bool) (trackerdb.TableIterator[*encoded.OnlineAccountRecordV6], error) {
+func (r *reader) MakeOnlineAccountsIter(context.Context, bool, basics.Round) (trackerdb.TableIterator[*encoded.OnlineAccountRecordV6], error) {
 	// TODO: catchpoint
 	panic("unimplemented")
 }
 
 // MakeOnlineRoundParamsIter implements trackerdb.Reader
-func (r *reader) MakeOnlineRoundParamsIter(context.Context, bool) (trackerdb.TableIterator[*encoded.OnlineRoundParamsRecordV6], error) {
+func (r *reader) MakeOnlineRoundParamsIter(context.Context, bool, basics.Round) (trackerdb.TableIterator[*encoded.OnlineRoundParamsRecordV6], error) {
 	// TODO: catchpoint
 	panic("unimplemented")
 }

--- a/ledger/store/trackerdb/sqlitedriver/accountsV2.go
+++ b/ledger/store/trackerdb/sqlitedriver/accountsV2.go
@@ -723,7 +723,11 @@ func (w *accountsV2Writer) TxtailNewRound(ctx context.Context, baseRound basics.
 // After this cleanup runs, accounts in this table will have either one entry (if all entries besides the latest are expired),
 // or will have more than one entry (if multiple entries are not yet expired).
 func (w *accountsV2Writer) OnlineAccountsDelete(forgetBefore basics.Round) (err error) {
-	rows, err := w.e.Query("SELECT rowid, address, updRound, data FROM onlineaccounts WHERE updRound < ? ORDER BY address, updRound DESC", forgetBefore)
+	return w.onlineAccountsDelete(forgetBefore, "onlineaccounts")
+}
+
+func (w *accountsV2Writer) onlineAccountsDelete(forgetBefore basics.Round, table string) (err error) {
+	rows, err := w.e.Query("SELECT rowid, address, updRound, data FROM %s WHERE updRound < ? ORDER BY address, updRound DESC", table, forgetBefore)
 	if err != nil {
 		return err
 	}

--- a/ledger/store/trackerdb/sqlitedriver/accountsV2.go
+++ b/ledger/store/trackerdb/sqlitedriver/accountsV2.go
@@ -782,10 +782,10 @@ func (w *accountsV2Writer) onlineAccountsDelete(forgetBefore basics.Round, table
 		rowids = append(rowids, rowid.Int64)
 	}
 
-	return onlineAccountsDeleteByRowIDs(w.e, rowids)
+	return onlineAccountsDeleteByRowIDs(w.e, rowids, table)
 }
 
-func onlineAccountsDeleteByRowIDs(e db.Executable, rowids []int64) (err error) {
+func onlineAccountsDeleteByRowIDs(e db.Executable, rowids []int64, table string) (err error) {
 	if len(rowids) == 0 {
 		return
 	}
@@ -795,7 +795,7 @@ func onlineAccountsDeleteByRowIDs(e db.Executable, rowids []int64) (err error) {
 	// rowids might be larger => split to chunks are remove
 	chunks := rowidsToChunkedArgs(rowids)
 	for _, chunk := range chunks {
-		_, err = e.Exec("DELETE FROM onlineaccounts WHERE rowid IN (?"+strings.Repeat(",?", len(chunk)-1)+")", chunk...)
+		_, err = e.Exec("DELETE FROM "+table+" WHERE rowid IN (?"+strings.Repeat(",?", len(chunk)-1)+")", chunk...)
 		if err != nil {
 			return
 		}

--- a/ledger/store/trackerdb/sqlitedriver/accountsV2.go
+++ b/ledger/store/trackerdb/sqlitedriver/accountsV2.go
@@ -727,7 +727,7 @@ func (w *accountsV2Writer) OnlineAccountsDelete(forgetBefore basics.Round) (err 
 }
 
 func (w *accountsV2Writer) onlineAccountsDelete(forgetBefore basics.Round, table string) (err error) {
-	rows, err := w.e.Query("SELECT rowid, address, updRound, data FROM %s WHERE updRound < ? ORDER BY address, updRound DESC", table, forgetBefore)
+	rows, err := w.e.Query(fmt.Sprintf("SELECT rowid, address, updRound, data FROM %s WHERE updRound < ? ORDER BY address, updRound DESC", table), forgetBefore)
 	if err != nil {
 		return err
 	}

--- a/ledger/store/trackerdb/sqlitedriver/kvsIter.go
+++ b/ledger/store/trackerdb/sqlitedriver/kvsIter.go
@@ -91,7 +91,7 @@ func MakeOnlineAccountsIter(ctx context.Context, q db.Queryable, useStaging bool
 		// cheat: use Rdb to make a temporary table that we will delete later
 		e, ok := q.(*sql.Tx)
 		if !ok {
-			return nil, fmt.Errorf("MakeOnlineAccountsIter: cannot convert Queryable to sql.Tx")
+			return nil, fmt.Errorf("MakeOnlineAccountsIter: cannot convert Queryable to sql.Tx, q is %T", q)
 		}
 		// create a new table by selecting from the original table
 		destTable := table + "_iterator"

--- a/ledger/store/trackerdb/sqlitedriver/kvsIter.go
+++ b/ledger/store/trackerdb/sqlitedriver/kvsIter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/algorand/go-algorand/ledger/encoded"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/ledger/store/trackerdb"
+	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util/db"
 )
@@ -62,21 +63,61 @@ func (iter *kvsIter) Close() {
 
 // tableIterator is used to dump onlineaccounts and onlineroundparams tables for catchpoints.
 type tableIterator[T any] struct {
-	rows *sql.Rows
-	scan func(*sql.Rows) (T, error)
+	rows    *sql.Rows
+	scan    func(*sql.Rows) (T, error)
+	onClose func()
 }
 
 func (iter *tableIterator[T]) Next() bool { return iter.rows.Next() }
-func (iter *tableIterator[T]) Close()     { iter.rows.Close() }
+func (iter *tableIterator[T]) Close() {
+	iter.rows.Close()
+	if iter.onClose != nil {
+		iter.onClose()
+	}
+}
 func (iter *tableIterator[T]) GetItem() (T, error) {
 	return iter.scan(iter.rows)
 }
 
 // MakeOnlineAccountsIter creates an onlineAccounts iterator.
-func MakeOnlineAccountsIter(ctx context.Context, q db.Queryable, useStaging bool) (trackerdb.TableIterator[*encoded.OnlineAccountRecordV6], error) {
+func MakeOnlineAccountsIter(ctx context.Context, q db.Queryable, useStaging bool, excludeBefore basics.Round) (trackerdb.TableIterator[*encoded.OnlineAccountRecordV6], error) {
 	table := "onlineaccounts"
 	if useStaging {
 		table = "catchpointonlineaccounts"
+	}
+
+	var onClose func()
+	if excludeBefore != 0 {
+		// cheat: use Rdb to make a temporary table that we will delete later
+		e, ok := q.(*sql.Tx)
+		if !ok {
+			return nil, fmt.Errorf("MakeOnlineAccountsIter: cannot convert Queryable to sql.Tx")
+		}
+		// create a new table by selecting from the original table
+		destTable := table + "_iterator"
+		_, err := e.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", destTable))
+		if err != nil {
+			return nil, err
+		}
+		_, err = e.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s AS SELECT * FROM %s", destTable, table))
+		if err != nil {
+			return nil, err
+		}
+		// call prune on the new copied table, using the same logic as OnlineAccountsDelete
+		aw := accountsV2Writer{e: e}
+		err = aw.onlineAccountsDelete(excludeBefore, destTable)
+		if err != nil {
+			return nil, err
+		}
+		// remember to drop the table when the iterator is closed
+		onClose = func() {
+			_, err = e.ExecContext(ctx, fmt.Sprintf("DROP TABLE %s", destTable))
+			if err != nil {
+				logging.Base().Errorf("Failed to drop table %s: %v", destTable, err)
+			}
+		}
+		// use the new table to create the iterator
+		table = destTable
 	}
 
 	rows, err := q.QueryContext(ctx, fmt.Sprintf("SELECT address, updround, normalizedonlinebalance, votelastvalid, data FROM %s ORDER BY address, updround", table))
@@ -84,7 +125,11 @@ func MakeOnlineAccountsIter(ctx context.Context, q db.Queryable, useStaging bool
 		return nil, err
 	}
 
-	return &tableIterator[*encoded.OnlineAccountRecordV6]{rows: rows, scan: scanOnlineAccount}, nil
+	return &tableIterator[*encoded.OnlineAccountRecordV6]{
+		rows:    rows,
+		scan:    scanOnlineAccount,
+		onClose: onClose,
+	}, nil
 }
 
 func scanOnlineAccount(rows *sql.Rows) (*encoded.OnlineAccountRecordV6, error) {
@@ -136,12 +181,18 @@ func scanOnlineAccount(rows *sql.Rows) (*encoded.OnlineAccountRecordV6, error) {
 }
 
 // MakeOnlineRoundParamsIter creates an onlineRoundParams iterator.
-func MakeOnlineRoundParamsIter(ctx context.Context, q db.Queryable, useStaging bool) (trackerdb.TableIterator[*encoded.OnlineRoundParamsRecordV6], error) {
+func MakeOnlineRoundParamsIter(ctx context.Context, q db.Queryable, useStaging bool, excludeBefore basics.Round) (trackerdb.TableIterator[*encoded.OnlineRoundParamsRecordV6], error) {
 	table := "onlineroundparamstail"
 	if useStaging {
 		table = "catchpointonlineroundparamstail"
 	}
-	rows, err := q.QueryContext(ctx, fmt.Sprintf("SELECT rnd, data FROM %s ORDER BY rnd", table))
+
+	where := ""
+	if excludeBefore != 0 {
+		where = fmt.Sprintf("WHERE rnd >= %d", excludeBefore)
+	}
+
+	rows, err := q.QueryContext(ctx, fmt.Sprintf("SELECT rnd, data FROM %s %s ORDER BY rnd", table, where))
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/store/trackerdb/sqlitedriver/sqlitedriver.go
+++ b/ledger/store/trackerdb/sqlitedriver/sqlitedriver.go
@@ -212,13 +212,13 @@ func (r *sqlReader) MakeKVsIter(ctx context.Context) (trackerdb.KVsIter, error) 
 }
 
 // MakeOnlineAccountsIter implements trackerdb.Reader
-func (r *sqlReader) MakeOnlineAccountsIter(ctx context.Context, useStaging bool) (trackerdb.TableIterator[*encoded.OnlineAccountRecordV6], error) {
-	return MakeOnlineAccountsIter(ctx, r.q, useStaging)
+func (r *sqlReader) MakeOnlineAccountsIter(ctx context.Context, useStaging bool, excludeBefore basics.Round) (trackerdb.TableIterator[*encoded.OnlineAccountRecordV6], error) {
+	return MakeOnlineAccountsIter(ctx, r.q, useStaging, excludeBefore)
 }
 
 // MakeOnlineRoundParamsIter implements trackerdb.Reader
-func (r *sqlReader) MakeOnlineRoundParamsIter(ctx context.Context, useStaging bool) (trackerdb.TableIterator[*encoded.OnlineRoundParamsRecordV6], error) {
-	return MakeOnlineRoundParamsIter(ctx, r.q, useStaging)
+func (r *sqlReader) MakeOnlineRoundParamsIter(ctx context.Context, useStaging bool, excludeBefore basics.Round) (trackerdb.TableIterator[*encoded.OnlineRoundParamsRecordV6], error) {
+	return MakeOnlineRoundParamsIter(ctx, r.q, useStaging, excludeBefore)
 }
 
 type sqlWriter struct {

--- a/ledger/store/trackerdb/store.go
+++ b/ledger/store/trackerdb/store.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/ledger/encoded"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/util/db"
@@ -66,8 +67,8 @@ type Reader interface {
 	MakeCatchpointReader() (CatchpointReader, error)
 	MakeEncodedAccountsBatchIter() EncodedAccountsBatchIter
 	MakeKVsIter(ctx context.Context) (KVsIter, error)
-	MakeOnlineAccountsIter(ctx context.Context, useStaging bool) (TableIterator[*encoded.OnlineAccountRecordV6], error)
-	MakeOnlineRoundParamsIter(ctx context.Context, useStaging bool) (TableIterator[*encoded.OnlineRoundParamsRecordV6], error)
+	MakeOnlineAccountsIter(ctx context.Context, useStaging bool, excludeBefore basics.Round) (TableIterator[*encoded.OnlineAccountRecordV6], error)
+	MakeOnlineRoundParamsIter(ctx context.Context, useStaging bool, excludeBefore basics.Round) (TableIterator[*encoded.OnlineRoundParamsRecordV6], error)
 }
 
 // Writer is the interface for the trackerdb write operations.


### PR DESCRIPTION
## Summary

Follow-on to #6177.

When writing catchpoint files, the `catchpointFileWriter` currently does not have any access to the consensus parameters, and so does not know if `EnableOnlineAccountCatchpoints` is set. This means catchpoints files may contain chunks with `OnlineAccountRecordV6` and `OnlineRoundParamsRecordV6` even when `EnableOnlineAccountCatchpoints` is not set. However these objects are ignored when calculating the label — the catchpoint label hash calculation is conditioned on `EnableOnlineAccountCatchpoints`.

This adds an argument to `makeCatchpointFileWriter` so that `catchpointFileWriter` knows what the current consensus version is.

This also adds support to `catchpointdump` for analyzing and dumping the onlineaccount and onlineroundparams records in catchpoint files, and calculating the labels.

This also addresses a corner case when the state proof recoverability system (from #4803) tells the onlineaccounts tracker to retain more than 320 rounds of history (set by `votersTracker.lowestRound()`) and used here:
```
    maxOnlineLookback := basics.Round(ao.maxBalLookback())
    dcc.onlineAccountsForgetBefore = (dcc.newBase() + 1).SubSaturate(maxOnlineLookback)
    if dcc.lowestRound > 0 && dcc.lowestRound < dcc.onlineAccountsForgetBefore {
        // extend history as needed
        dcc.onlineAccountsForgetBefore = dcc.lowestRound
    }
```
In this case, catchpoint files will contain more than the expected 320 rows, and lead to catchpoint label hash mismatch if catchpoint-generating nodes have differing opinions of when the last state proof was verified. In practice, this can really only occur when a node is catching up quickly (after being stopped and restarted, or starting from 0) and flushing large batches of rounds — it might not have verified the most recent state proof when it hits the catchpoint first stage snapshot round. 

## Test Plan

Updated `TestExactAccountChunk` to exercise the new consensus params argument, can try updating other similar tests.

Needs a new test where dcc.lowestRound is set to something older than `(dcc.newBase()+1).SubSaturate(320)`, and verifies the excludeBefore argument works.