### PR TITLE
CI: Remove lnav mac dev dependency

### DIFF
--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -94,7 +94,6 @@ elif [ "${OS}" = "darwin" ]; then
     install_or_upgrade automake
     install_or_upgrade python3
     install_or_upgrade diffutils
-    lnav -i "$SCRIPTPATH/algorand_node_log.json"
 elif [ "${OS}" = "windows" ]; then
     if ! $msys2 pacman -S --disable-download-timeout --noconfirm git automake autoconf m4 libtool make mingw-w64-x86_64-gcc mingw-w64-x86_64-python mingw-w64-x86_64-jq unzip procps; then
         echo "Error installing pacman dependencies"

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -93,7 +93,6 @@ elif [ "${OS}" = "darwin" ]; then
     install_or_upgrade autoconf
     install_or_upgrade automake
     install_or_upgrade python3
-    install_or_upgrade lnav
     install_or_upgrade diffutils
     lnav -i "$SCRIPTPATH/algorand_node_log.json"
 elif [ "${OS}" = "windows" ]; then


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

There seems to be an issue on some Mac platforms installing llvm, a dependency of lnav, with homebrew. Removing lnav (a useful but not essential log file viewer tool) from the list of Mac dependencies resolves the issue.

## Test Plan

No code change besides this configure_dev.sh script change.
