### PR TITLE
CI: install lnav outside of CI environments

### DIFF
--- a/scripts/algorand_node_log.json
+++ b/scripts/algorand_node_log.json
@@ -1,5 +1,6 @@
 {
     "algorand_node_log" : {
+        "$schema": "https://lnav.org/schemas/format-v1.schema.json",
         "title" : "Algorand Node Log Format",
         "description" : "Log format for logrus, used by go-algorand.",
         "url" : "https://github.com/sirupsen/logrus",

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -94,6 +94,10 @@ elif [ "${OS}" = "darwin" ]; then
     install_or_upgrade automake
     install_or_upgrade python3
     install_or_upgrade diffutils
+    if [ "$CI" != "true" ] && [ "$CIRCLECI" != "true" ]; then
+        install_or_upgrade lnav
+        lnav -i "$SCRIPTPATH/algorand_node_log.json"
+    fi
 elif [ "${OS}" = "windows" ]; then
     if ! $msys2 pacman -S --disable-download-timeout --noconfirm git automake autoconf m4 libtool make mingw-w64-x86_64-gcc mingw-w64-x86_64-python mingw-w64-x86_64-jq unzip procps; then
         echo "Error installing pacman dependencies"


### PR DESCRIPTION
## Summary

Follow-on to #6221, add back lnav installation and configuration when running outside of CI.

## Test Plan

No code changes.