### PR TITLE
Dev Tools: remove lnav dependency from beta branch

### DIFF
--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -93,9 +93,7 @@ elif [ "${OS}" = "darwin" ]; then
     install_or_upgrade autoconf
     install_or_upgrade automake
     install_or_upgrade python3
-    install_or_upgrade lnav
     install_or_upgrade diffutils
-    lnav -i "$SCRIPTPATH/algorand_node_log.json"
 elif [ "${OS}" = "windows" ]; then
     if ! $msys2 pacman -S --disable-download-timeout --noconfirm git automake autoconf m4 libtool make mingw-w64-x86_64-gcc mingw-w64-x86_64-python mingw-w64-x86_64-jq unzip procps; then
         echo "Error installing pacman dependencies"


### PR DESCRIPTION
## Summary

This cherry-pick of the lnav dev tool removal to the beta branch to unblock CI testing.

## Test Plan

N/A Not a code change
