### PR TITLE
catchpoints: log ledger download failures

### DIFF
--- a/catchup/catchpointService.go
+++ b/catchup/catchpointService.go
@@ -315,13 +315,9 @@ func (cs *CatchpointCatchupService) processStageLedgerDownload() error {
 		}
 		peer := psp.Peer
 		start := time.Now()
-		var peerAddr string // HTTPPeer, UnicastPeer, wsPeerCore all implement this
-		if p, ok := peer.(interface{ GetAddress() string }); ok {
-			peerAddr = p.GetAddress()
-		}
 		err0 = lf.downloadLedger(cs.ctx, peer, round)
 		if err0 == nil {
-			cs.log.Infof("ledger downloaded from %s in %d seconds", peerAddr, time.Since(start)/time.Second)
+			cs.log.Infof("ledger downloaded from %s in %d seconds", peerAddress(peer), time.Since(start)/time.Second)
 			start = time.Now()
 			err0 = cs.ledgerAccessor.BuildMerkleTrie(cs.ctx, cs.updateVerifiedCounts)
 			if err0 == nil {
@@ -329,10 +325,10 @@ func (cs *CatchpointCatchupService) processStageLedgerDownload() error {
 				break
 			}
 			// failed to build the merkle trie for the above catchpoint file.
-			cs.log.Infof("failed to build merkle trie for catchpoint file from %s: %v", peerAddr, err0)
+			cs.log.Infof("failed to build merkle trie for catchpoint file from %s: %v", peerAddress(peer), err0)
 			cs.blocksDownloadPeerSelector.rankPeer(psp, peerRankInvalidDownload)
 		} else {
-			cs.log.Infof("failed to download catchpoint ledger from peer %s: %v", peerAddr, err0)
+			cs.log.Infof("failed to download catchpoint ledger from peer %s: %v", peerAddress(peer), err0)
 			cs.blocksDownloadPeerSelector.rankPeer(psp, peerRankDownloadFailed)
 		}
 


### PR DESCRIPTION
## Summary

I noticed we have logging around catchpoint ledger file download success, and catchpoint block download errors, but no logging for catchpoint ledger file download failures. This provides more logging about failures related to ledger file timeout & retry issues like those seen with #5503.

## Test Plan

Logging only changes, existing tests should pass.