### PR TITLE
DB: Remove AtomicContextWithRetryClearFn, rename to AtomicContext

### DIFF
--- a/ledger/store/trackerdb/sqlitedriver/sqlitedriver.go
+++ b/ledger/store/trackerdb/sqlitedriver/sqlitedriver.go
@@ -71,7 +71,7 @@ func (s *trackerSQLStore) Batch(fn trackerdb.BatchFn) (err error) {
 func (s *trackerSQLStore) BatchContext(ctx context.Context, fn trackerdb.BatchFn) (err error) {
 	return wrapIOError(s.pair.Wdb.AtomicContext(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		return fn(ctx, &sqlBatchScope{tx, false, &sqlWriter{tx}})
-	}))
+	}, nil))
 }
 
 func (s *trackerSQLStore) BeginBatch(ctx context.Context) (trackerdb.Batch, error) {
@@ -89,7 +89,7 @@ func (s *trackerSQLStore) Snapshot(fn trackerdb.SnapshotFn) (err error) {
 func (s *trackerSQLStore) SnapshotContext(ctx context.Context, fn trackerdb.SnapshotFn) (err error) {
 	return wrapIOError(s.pair.Rdb.AtomicContext(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		return fn(ctx, &sqlSnapshotScope{tx, &sqlReader{tx}})
-	}))
+	}, nil))
 }
 
 func (s *trackerSQLStore) BeginSnapshot(ctx context.Context) (trackerdb.Snapshot, error) {
@@ -111,11 +111,11 @@ func (s *trackerSQLStore) TransactionWithRetryClearFn(fn trackerdb.TransactionFn
 func (s *trackerSQLStore) TransactionContext(ctx context.Context, fn trackerdb.TransactionFn) (err error) {
 	return wrapIOError(s.pair.Wdb.AtomicContext(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		return fn(ctx, &sqlTransactionScope{tx, false, &sqlReader{tx}, &sqlWriter{tx}, &sqlCatchpoint{tx}})
-	}))
+	}, nil))
 }
 
 func (s *trackerSQLStore) TransactionContextWithRetryClearFn(ctx context.Context, fn trackerdb.TransactionFn, rollbackFn trackerdb.RetryClearFn) (err error) {
-	return wrapIOError(s.pair.Wdb.AtomicContextWithRetryClearFn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	return wrapIOError(s.pair.Wdb.AtomicContext(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		return fn(ctx, &sqlTransactionScope{tx, false, &sqlReader{tx}, &sqlWriter{tx}, &sqlCatchpoint{tx}})
 	}, rollbackFn))
 }
@@ -132,7 +132,7 @@ func (s trackerSQLStore) RunMigrations(ctx context.Context, params trackerdb.Par
 	err = wrapIOError(s.pair.Wdb.AtomicContext(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		mgr, err = RunMigrations(ctx, tx, params, log, targetVersion)
 		return err
-	}))
+	}, nil))
 	return
 }
 
@@ -159,7 +159,7 @@ func (s *trackerSQLStore) ResetToV6Test(ctx context.Context) error {
 			}
 		}
 		return nil
-	})
+	}, nil)
 }
 
 func (s *trackerSQLStore) Close() {

--- a/util/db/dbutil.go
+++ b/util/db/dbutil.go
@@ -218,6 +218,8 @@ func (db *Accessor) Atomic(fn idemFn, extras ...interface{}) (err error) {
 // AtomicContext executes a piece of code with respect to the database atomically.
 // For transactions where readOnly is false, sync determines whether or not to wait for the result.
 // Like for Atomic, the return error of fn should be a native sqlite3.Error type or an error wrapping it.
+// If retryClearFn is provided, it will be called in between retries of calls to fn, if the error is a
+// temporary error that will be retried. This helps a caller that might change in-memory state inside fn.
 func (db *Accessor) AtomicContext(ctx context.Context, fn idemFn, retryClearFn func(context.Context), extras ...interface{}) (err error) {
 	atomicDeadline := time.Now().Add(time.Second)
 

--- a/util/db/dbutil.go
+++ b/util/db/dbutil.go
@@ -212,21 +212,13 @@ func (db *Accessor) IsSharedCacheConnection() bool {
 // The return error of fn should be a native sqlite3.Error type or an error wrapping it.
 // DO NOT return a custom error - the internal logic of Atomic expects an sqlite error and uses that value.
 func (db *Accessor) Atomic(fn idemFn, extras ...interface{}) (err error) {
-	return db.AtomicContext(context.Background(), fn, extras...)
+	return db.AtomicContext(context.Background(), fn, nil, extras...)
 }
 
 // AtomicContext executes a piece of code with respect to the database atomically.
 // For transactions where readOnly is false, sync determines whether or not to wait for the result.
 // Like for Atomic, the return error of fn should be a native sqlite3.Error type or an error wrapping it.
-func (db *Accessor) AtomicContext(ctx context.Context, fn idemFn, extras ...interface{}) (err error) {
-
-	return db.AtomicContextWithRetryClearFn(ctx, fn, nil, extras...)
-}
-
-// AtomicContextWithRetryClearFn is like AtomicContext, but calls retryClearFn if the database
-// txn was rolled back, due to error or in between retries. This helps a caller that
-// might change in-memory state inside fn.
-func (db *Accessor) AtomicContextWithRetryClearFn(ctx context.Context, fn idemFn, retryClearFn func(context.Context), extras ...interface{}) (err error) {
+func (db *Accessor) AtomicContext(ctx context.Context, fn idemFn, retryClearFn func(context.Context), extras ...interface{}) (err error) {
 	atomicDeadline := time.Now().Add(time.Second)
 
 	// note that the sql library will drop panics inside an active transaction


### PR DESCRIPTION
## Summary

This implements some PR feedback from @gmalouf in https://github.com/algorand/go-algorand/pull/6190#discussion_r1871891845 to remove an unnecessary extra function wrapper when using db.AtomicContext function 

## Test Plan

Existing tests should pass