### PR TITLE
config: remove unused EnableOnlineAccountCatchpoints consensus flag, rename EnableAccountDataResourceSeparation

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -455,9 +455,11 @@ type ConsensusParams struct {
 	// that a proposer can take offline for having expired voting keys.
 	MaxProposedExpiredOnlineAccounts int
 
-	// EnableAccountDataResourceSeparation enables the support for extended application and asset storage
-	// in a separate table.
-	EnableAccountDataResourceSeparation bool
+	// EnableLedgerDataUpdateRound enables the support for setting the UpdateRound on account and
+	// resource data in the ledger. The UpdateRound is encoded in account/resource data types used
+	// on disk and in catchpoint snapshots, and also used to construct catchpoint merkle trie keys,
+	// but does not appear in on-chain state.
+	EnableLedgerDataUpdateRound bool
 
 	// When rewards rate changes, use the new value immediately.
 	RewardsCalculationFix bool
@@ -487,9 +489,6 @@ type ConsensusParams struct {
 	// available for lookup for smart contracts and smart signatures.
 	// Setting it to 1 for example allows querying data up to MaxTxnLife + 1 rounds back from the Latest.
 	DeeperBlockHeaderHistory uint64
-
-	// EnableOnlineAccountCatchpoints specifies when to re-enable catchpoints after the online account table migration has occurred.
-	EnableOnlineAccountCatchpoints bool
 
 	// UnfundedSenders ensures that accounts with no balance (so they don't even
 	// "exist") can still be a transaction sender by avoiding updates to rewards
@@ -1371,7 +1370,7 @@ func initConsensusProtocols() {
 	// flag would already be restructuring their internal storage for extended
 	// application storage, and therefore would not produce catchpoints and/or
 	// catchpoint labels prior to this feature being enabled.
-	v32.EnableAccountDataResourceSeparation = true
+	v32.EnableLedgerDataUpdateRound = true
 
 	// Remove limits on MinimumBalance
 	v32.MaximumMinimumBalance = 0
@@ -1424,7 +1423,6 @@ func initConsensusProtocols() {
 	v34.UnifyInnerTxIDs = true
 
 	v34.EnableSHA256TxnCommitmentHeader = true
-	v34.EnableOnlineAccountCatchpoints = true
 
 	v34.UnfundedSenders = true
 

--- a/ledger/acctupdates.go
+++ b/ledger/acctupdates.go
@@ -1508,7 +1508,7 @@ func (au *accountUpdates) prepareCommit(dcc *deferredCommitContext) error {
 
 	// once the consensus upgrade to resource separation is complete, all resources/accounts are also tagged with
 	// their corresponding update round.
-	setUpdateRound := config.Consensus[au.versions[1]].EnableAccountDataResourceSeparation
+	setUpdateRound := config.Consensus[au.versions[1]].EnableLedgerDataUpdateRound
 
 	// compact all the deltas - when we're trying to persist multiple rounds, we might have the same account
 	// being updated multiple times. When that happen, we can safely omit the intermediate updates.

--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -147,7 +147,7 @@ return`
 	var expectedCreatorBase, expectedCreatorResource, expectedUserOptInBase, expectedUserOptInResource, expectedUserLocalBase, expectedUserLocalResource []byte
 	// the difference between these encoded structure is the UpdateRound variable. This variable is not being set before
 	// the consensus upgrade, and affects only nodes that have been updated.
-	if proto.EnableAccountDataResourceSeparation {
+	if proto.EnableLedgerDataUpdateRound {
 		expectedCreatorBase, err = hex.DecodeString("87a14301a144ce000186a0a16101a162ce009d2290a16704a16b01a17a01")
 		a.NoError(err)
 		expectedCreatorResource, err = hex.DecodeString("86a171c45602200200012604056c6f63616c06676c6f62616c026c6b02676b3118221240003331192212400010311923124000022243311b221240001c361a00281240000a361a0029124000092243222a28664200032b29672343a172c40102a17501a17704a17903a17a01")


### PR DESCRIPTION
## Summary

Cleaning up two consensus flags that were used to control behavior related to catchpoint versioning:
- EnableOnlineAccountCatchpoints is not checked or referenced in the code anywhere, and may now be removed.
- EnableAccountDataResourceSeparation has a misleading name and is renamed here to reflect what it actually does.

## Test Plan

No logical code changes, just renaming; existing tests should pass.