### PR TITLE
CI: fix actions/cache deprecation warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - name: Restore libsodium from cache
         id: cache-libsodium
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.4.0
         with:
           path: crypto/libs
           key: libsodium-fork-v2-${{ runner.os }}-${{ hashFiles('crypto/libsodium-fork/**') }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -55,7 +55,7 @@ jobs:
         run: mkdir -p cicdtmp/golangci-lint
       - name: Check if custom golangci-lint is already built
         id: cache-golangci-lint
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.4.0
         with:
           path: cicdtmp/golangci-lint/golangci-lint-cgo
           key: cicd-golangci-lint-cgo-v0.0.3-${{ env.GO_VERSION }}-${{ env.GOLANGCI_LINT_VERSION }}


### PR DESCRIPTION
## Summary

Fix this error:

> Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v3.3.1`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

## Test Plan

No code changes