### PR TITLE
tests: fix TestSendSigsAfterCatchpointCatchup

### DIFF
--- a/test/e2e-go/features/catchup/stateproofsCatchup_test.go
+++ b/test/e2e-go/features/catchup/stateproofsCatchup_test.go
@@ -271,13 +271,13 @@ func TestSendSigsAfterCatchpointCatchup(t *testing.T) {
 
 	targetCatchpointRound := getFirstCatchpointRound(&consensusParams)
 
-	chunks := downloadCatchpointFile(t, a, primaryNodeAddr, targetCatchpointRound)
-	a.NotEmpty(chunks)
-	validateCatchpointChunks(t, a, chunks, consensusParams)
-
 	catchpointLabel := waitForCatchpointGeneration(t, &fixture, primaryNodeRestClient, targetCatchpointRound)
 	_, err = usingNodeRestClient.Catchup(catchpointLabel, 0)
 	a.NoError(err)
+
+	chunks := downloadCatchpointFile(t, a, primaryNodeAddr, targetCatchpointRound)
+	a.NotEmpty(chunks)
+	validateCatchpointChunks(t, a, chunks, consensusParams)
 
 	err = usingNodeRestClient.WaitForRoundWithTimeout(uint64(targetCatchpointRound) + 1)
 	a.NoError(err)


### PR DESCRIPTION
## Summary

In #6224, the changes to verify the catchpoint file generated did not wait long enough, due to code ordering before it was downloaded.

## Test Plan

Nightly tests should now pass.