### PR TITLE
CI: upgrade to actions/cache@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - name: Restore libsodium from cache
         id: cache-libsodium
-        uses: actions/cache@v3.4.0
+        uses: actions/cache@v4
         with:
           path: crypto/libs
           key: libsodium-fork-v2-${{ runner.os }}-${{ hashFiles('crypto/libsodium-fork/**') }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -55,7 +55,7 @@ jobs:
         run: mkdir -p cicdtmp/golangci-lint
       - name: Check if custom golangci-lint is already built
         id: cache-golangci-lint
-        uses: actions/cache@v3.4.0
+        uses: actions/cache@v4
         with:
           path: cicdtmp/golangci-lint/golangci-lint-cgo
           key: cicd-golangci-lint-cgo-v0.0.3-${{ env.GO_VERSION }}-${{ env.GOLANGCI_LINT_VERSION }}


### PR DESCRIPTION
## Summary

For unknown reasons the error `Error: Unable to resolve action actions/cache@v3.4.0, package version not found` is appearing despite following instructions on the actions/cache README to use v3.4.0 (or upgrade to v4). This upgrades the actions/cache version for these two jobs to v4.

## Test Plan

reviewdog.yml and build.yml jobs should run successfully