### PR TITLE
tests: fix flaky TestApplicationsUpgradeOverGossip

### DIFF
--- a/ledger/catchpointfilewriter_test.go
+++ b/ledger/catchpointfilewriter_test.go
@@ -1144,8 +1144,10 @@ func TestCatchpointAfterStakeLookupTxns(t *testing.T) {
 	shortMax := max(config.Consensus[protocol.ConsensusFuture].MaxBalLookback, config.Consensus[protocol.ConsensusFuture].CatchpointLookback)
 	shortRounds := 2*shortMax + 50
 	longRounds := uint64(1500)
-	t.Run("future", func(t *testing.T) { testCatchpointAfterStakeLookupTxns(t, protocol.ConsensusFuture, longRounds, true) })
-	t.Run("future_noSP", func(t *testing.T) { testCatchpointAfterStakeLookupTxns(t, futureNoSP, longRounds, false) })
+	if !testing.Short() {
+		t.Run("future", func(t *testing.T) { testCatchpointAfterStakeLookupTxns(t, protocol.ConsensusFuture, longRounds, true) })
+		t.Run("future_noSP", func(t *testing.T) { testCatchpointAfterStakeLookupTxns(t, futureNoSP, longRounds, false) })
+	}
 	t.Run("future_short", func(t *testing.T) { testCatchpointAfterStakeLookupTxns(t, protocol.ConsensusFuture, shortRounds, true) })
 	t.Run("future_noSP_short", func(t *testing.T) { testCatchpointAfterStakeLookupTxns(t, futureNoSP, shortRounds, false) })
 }

--- a/ledger/simple_test.go
+++ b/ledger/simple_test.go
@@ -19,6 +19,7 @@ package ledger
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -74,8 +75,10 @@ func newSimpleLedgerFull(t testing.TB, balances bookkeeping.GenesisBalances, cv 
 	require.NoError(t, err)
 	require.False(t, genBlock.FeeSink.IsZero())
 	require.False(t, genBlock.RewardsPool.IsZero())
+	tempDir := t.TempDir()
 	dbName := fmt.Sprintf("%s.%d", t.Name(), crypto.RandUint64())
 	dbName = strings.Replace(dbName, "/", "_", -1)
+	dbName = filepath.Join(tempDir, dbName)
 	cfg.Archival = !slCfg.notArchival
 	log := slCfg.logger
 	if log == nil {

--- a/test/e2e-go/upgrades/application_support_test.go
+++ b/test/e2e-go/upgrades/application_support_test.go
@@ -344,9 +344,10 @@ func TestApplicationsUpgradeOverGossip(t *testing.T) {
 	a.NoError(err)
 
 	// Fund the manager, so it can issue transactions later on
-	_, err = client.SendPaymentFromUnencryptedWallet(creator, user, fee, 10000000000, nil)
+	tx0, err := client.SendPaymentFromUnencryptedWallet(creator, user, fee, 10000000000, nil)
 	a.NoError(err)
-	client.WaitForRound(round + 2)
+	isCommitted := fixture.WaitForTxnConfirmation(round+10, tx0.ID().String())
+	a.True(isCommitted)
 
 	round, err = client.CurrentRound()
 	a.NoError(err)
@@ -454,7 +455,7 @@ int 1
 	// Try polling 10 rounds to ensure txn is committed.
 	round, err = client.CurrentRound()
 	a.NoError(err)
-	isCommitted := fixture.WaitForTxnConfirmation(round+10, txid)
+	isCommitted = fixture.WaitForTxnConfirmation(round+10, txid)
 	a.True(isCommitted)
 
 	// check creator's balance record for the app entry and the state changes


### PR DESCRIPTION
## Summary

1. TestApplicationsUpgradeOverGossip was not waiting for initial account funding. Fixed.
2. TestCatchpointAfterStakeLookupTxns uses `newSimpleLedgerFull` helper to create on-disk ledger and ended up polluting local work dir with ledger db files.

## Test Plan

These are test fixes