### PR TITLE
tests: fix flaky TestApplicationsUpgradeOverREST

### DIFF
--- a/test/e2e-go/upgrades/application_support_test.go
+++ b/test/e2e-go/upgrades/application_support_test.go
@@ -101,9 +101,10 @@ func TestApplicationsUpgradeOverREST(t *testing.T) {
 	a.NoError(err)
 
 	// Fund the manager, so it can issue transactions later on
-	_, err = client.SendPaymentFromUnencryptedWallet(creator, user, fee, 10000000000, nil)
+	tx0, err := client.SendPaymentFromUnencryptedWallet(creator, user, fee, 10000000000, nil)
 	a.NoError(err)
-	client.WaitForRound(round + 2)
+	isCommitted := fixture.WaitForTxnConfirmation(round+10, tx0.ID().String())
+	a.True(isCommitted)
 
 	// There should be no apps to start with
 	ad, err := client.AccountData(creator)
@@ -155,8 +156,6 @@ int 1
 	a.NoError(err)
 	signedTxn, err := client.SignTransactionWithWallet(wh, nil, tx)
 	a.NoError(err)
-	round, err = client.CurrentRound()
-	a.NoError(err)
 
 	successfullBroadcastCount := 0
 	_, err = client.BroadcastTransaction(signedTxn)
@@ -183,8 +182,6 @@ int 1
 		a.Less(int64(time.Since(startLoopTime)), int64(3*time.Minute))
 		time.Sleep(time.Duration(smallLambdaMs) * time.Millisecond)
 	}
-
-	round = curStatus.LastRound
 
 	// make a change to the node field to ensure we're not broadcasting the same transaction as we tried before.
 	tx.Note = []byte{1, 2, 3}
@@ -295,7 +292,6 @@ int 1
 	a.NoError(err)
 	a.Equal(uint64(appIdx), app.Id)
 	a.Equal(creator, app.Params.Creator)
-	return
 }
 
 // TestApplicationsUpgrade tests that we can safely upgrade from a version that doesn't support applications
@@ -547,5 +543,4 @@ int 1
 	a.NoError(err)
 	a.Equal(uint64(appIdx), app.Id)
 	a.Equal(creator, app.Params.Creator)
-	return
 }


### PR DESCRIPTION
## Summary

Fix TestApplicationsUpgradeOverREST similarly to https://github.com/algorand/go-algorand/pull/6251

## Test Plan

This is a flaky test fix