### PR TITLE
tests: fix flaky TestLedgerErrorValidate

### DIFF
--- a/data/ledger_test.go
+++ b/data/ledger_test.go
@@ -682,6 +682,10 @@ func TestLedgerErrorValidate(t *testing.T) {
 					require.LessOrEqual(t, attemptedRound, dbRound)
 					require.GreaterOrEqual(t, int(l.Latest()), dbRound+int(cfg.MaxAcctLookback))
 					um = ""
+				} else if strings.Contains(um, "rolling back failed commitRound") {
+					// this in-memory ledger is expected to hit "database table is locked" errors
+					// so that retry logic is exercised and trackers notified of the rollback
+					um = ""
 				}
 				require.Empty(t, um, um)
 			default:


### PR DESCRIPTION
## Summary

https://github.com/algorand/go-algorand/pull/6190 introduced retry callbacks and the `TestLedgerErrorValidate` test with its in-memory ledger was not quite ready for receiving such message that is normal/expected for that kind of concurrent test like this with in-memory ledger.

## Test Plan

This is a test fix