### PR TITLE
Build: Bump Ubuntu version in codegen_verification job.

### DIFF
--- a/.github/workflows/codegen_verification.yml
+++ b/.github/workflows/codegen_verification.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   codegen_verification:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       converter:
         image: swaggerapi/swagger-converter@sha256:dcfd1c2537f5f271cb4ec942d08aa59ca41b9a24078040061a772afca7e548ae # v1.0.4


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Bump codegen verification action to run on Ubuntu 22.04.

## Test Plan

Build should successfully run with updated version.
