### PR TITLE
network: fix peerstore Get/Put races

### DIFF
--- a/network/p2p/peerstore/peerstore.go
+++ b/network/p2p/peerstore/peerstore.go
@@ -138,7 +138,7 @@ func (ps *PeerStore) GetConnectionWaitTime(addrOrPeerID string) (bool, time.Dura
 	ad.mu.Lock()
 
 	originalLen := len(ad.recentConnectionTimes)
-	var numElmtsToRemove int
+	numElmtsToRemove := 0
 	for numElmtsToRemove < originalLen {
 		timeSince = curTime.Sub(ad.recentConnectionTimes[numElmtsToRemove])
 		if timeSince >= ps.connectionsRateLimitingWindow {
@@ -153,7 +153,7 @@ func (ps *PeerStore) GetConnectionWaitTime(addrOrPeerID string) (bool, time.Dura
 
 	// If there are max number of connections within the time window, wait
 	remainingLength := originalLen - numElmtsToRemove
-	var waitTime time.Duration
+	var waitTime time.Duration = 0
 	if uint(remainingLength) >= ps.connectionsRateLimitingCount {
 		waitTime = ps.connectionsRateLimitingWindow - timeSince
 	} else {

--- a/network/p2p/peerstore/peerstore.go
+++ b/network/p2p/peerstore/peerstore.go
@@ -148,7 +148,9 @@ func (ps *PeerStore) GetConnectionWaitTime(addrOrPeerID string) (bool, time.Dura
 	}
 
 	// Remove the expired elements from e.data[addr].recentConnectionTimes
-	ps.popNElements(numElmtsToRemove, peerID)
+	ad.recentConnectionTimes = ad.recentConnectionTimes[numElmtsToRemove:]
+	_ = ps.Put(peerID, addressDataKey, ad)
+
 	// If there are max number of connections within the time window, wait
 	metadata, _ = ps.Get(peerID, addressDataKey)
 	ad, ok = metadata.(addressData)
@@ -307,16 +309,6 @@ func (ps *PeerStore) appendTime(peerID peer.ID, t time.Time) {
 	data, _ := ps.Get(peerID, addressDataKey)
 	ad := data.(addressData)
 	ad.recentConnectionTimes = append(ad.recentConnectionTimes, t)
-	_ = ps.Put(peerID, addressDataKey, ad)
-}
-
-// PopEarliestTime removes the earliest time from recentConnectionTimes in
-// addressData for addr
-// It is expected to be later than ConnectionsRateLimitingWindow
-func (ps *PeerStore) popNElements(n int, peerID peer.ID) {
-	data, _ := ps.Get(peerID, addressDataKey)
-	ad := data.(addressData)
-	ad.recentConnectionTimes = ad.recentConnectionTimes[n:]
 	_ = ps.Put(peerID, addressDataKey, ad)
 }
 


### PR DESCRIPTION
## Summary

Fix for a race condition seen in [this test run](https://app.circleci.com/pipelines/github/algorand/go-algorand/19939/workflows/70017b37-4d60-4521-a953-18e6ff8b4a4f/jobs/287160?invite=true#step-114-122791_120)

peerstore's `GetConnectionWaitTime` gets a peerstore entry, calculates number of `recentConnectionTimes` to remove and then calls `popNElements` that also gets the same entry from peerstore and attempts to remove number of entries calculated on the first copy.

Fixed by removing the `addressData` mutex and adding it to `PeerStore` itself. Otherwise all these `PeerStore` methods are racy.

## Test Plan

Existing tests