### PR TITLE
tests: replace deprecated 'golang.org/x/exp/rand' to 'math/rand/v2'

### DIFF
--- a/data/appRateLimiter_test.go
+++ b/data/appRateLimiter_test.go
@@ -18,6 +18,7 @@ package data
 
 import (
 	"encoding/binary"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -29,7 +30,6 @@ import (
 	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/blake2b"
-	"golang.org/x/exp/rand"
 )
 
 func TestAppRateLimiter_Make(t *testing.T) {
@@ -488,7 +488,7 @@ func TestAppRateLimiter_TxgroupToKeys(t *testing.T) {
 }
 
 func BenchmarkAppRateLimiter_TxgroupToKeys(b *testing.B) {
-	rnd := rand.New(rand.NewSource(123))
+	rnd := rand.New(rand.NewPCG(0, 123))
 
 	txgroups := make([][]transactions.SignedTxn, 0, b.N)
 	for i := 0; i < b.N; i++ {
@@ -510,13 +510,12 @@ func BenchmarkAppRateLimiter_TxgroupToKeys(b *testing.B) {
 	b.ReportAllocs()
 
 	origin := make([]byte, 4)
-	_, err := rnd.Read(origin)
-	require.NoError(b, err)
+	binary.LittleEndian.PutUint64(origin, rnd.Uint64()) 
 	require.NotEmpty(b, origin)
 
 	salt := [16]byte{}
-	_, err = rnd.Read(salt[:])
-	require.NoError(b, err)
+	binary.LittleEndian.PutUint64(salt[:8], rnd.Uint64())
+	binary.LittleEndian.PutUint64(salt[8:], rnd.Uint64())
 	require.NotEmpty(b, salt)
 
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

golang.org/x/exp/rand will be deprecated. Use math/rand/v2 in std.


For more info can see https://go.dev/issue/61716.



<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
