### PR TITLE
catchup: improve classBasedPeerSelector on small peer sets

### DIFF
--- a/catchup/classBasedPeerSelector.go
+++ b/catchup/classBasedPeerSelector.go
@@ -18,9 +18,10 @@ package catchup
 
 import (
 	"errors"
+	"time"
+
 	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-deadlock"
-	"time"
 )
 
 // classBasedPeerSelector is a rankPooledPeerSelector that tracks and ranks classes of peers based on their response behavior.
@@ -58,6 +59,9 @@ func (c *classBasedPeerSelector) rankPeer(psp *peerSelectorPeer, rank int) (int,
 		// Peer was in this class, if there was any kind of download issue, we increment the failure count
 		if rank >= peerRankNoBlockForRound {
 			wp.downloadFailures++
+		} else if wp.downloadFailures > 0 {
+			// class usually multiple peers and we do not want to punish the entire class for one peer's failure
+			wp.downloadFailures--
 		}
 
 		break

--- a/catchup/classBasedPeerSelector.go
+++ b/catchup/classBasedPeerSelector.go
@@ -57,11 +57,13 @@ func (c *classBasedPeerSelector) rankPeer(psp *peerSelectorPeer, rank int) (int,
 		}
 
 		// Peer was in this class, if there was any kind of download issue, we increment the failure count
-		if rank >= peerRankNoBlockForRound {
+		failure := rank >= peerRankNoBlockForRound
+		if failure {
 			wp.downloadFailures++
-		} else if wp.downloadFailures > 0 {
+		} else {
 			// class usually multiple peers and we do not want to punish the entire class for one peer's failure
-			wp.downloadFailures--
+			// by decrementing the downloadFailures
+			wp.downloadFailures = max(wp.downloadFailures-1, 0)
 		}
 
 		break

--- a/catchup/classBasedPeerSelector_test.go
+++ b/catchup/classBasedPeerSelector_test.go
@@ -17,11 +17,12 @@
 package catchup
 
 import (
+	"testing"
+	"time"
+
 	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 // Use to mock the wrapped peer selectors where warranted
@@ -481,6 +482,7 @@ func TestClassBasedPeerSelector_integration(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, mockP1WrappedPeer, peerResult)
 	cps.rankPeer(mockP1WrappedPeer, peerRankNoBlockForRound)
+	cps.rankPeer(mockP1WrappedPeer, peerRankNoBlockForRound)
 
 	peerResult, err = cps.getNextPeer()
 	require.Nil(t, err)
@@ -495,4 +497,8 @@ func TestClassBasedPeerSelector_integration(t *testing.T) {
 
 	require.Equal(t, 4, cps.peerSelectors[0].downloadFailures)
 	require.Equal(t, 0, cps.peerSelectors[1].downloadFailures)
+
+	// make sure successful download decreases download failures
+	cps.rankPeer(mockP1WrappedPeer, durationRank)
+	require.Equal(t, 3, cps.peerSelectors[0].downloadFailures)
 }

--- a/catchup/peerSelector.go
+++ b/catchup/peerSelector.go
@@ -233,7 +233,7 @@ func (hs *historicStats) push(value int, counter uint64, class peerClass) (avera
 		return value
 	}
 
-	// This is a moving window. Remore the least recent value once the window is full
+	// This is a moving window. Remove the least recent value once the window is full
 	if len(hs.rankSamples) == hs.windowSize {
 		hs.rankSum -= uint64(hs.rankSamples[0])
 		hs.rankSamples = hs.rankSamples[1:]
@@ -280,10 +280,10 @@ func (hs *historicStats) push(value int, counter uint64, class peerClass) (avera
 		return initialRank
 	}
 
-	// A penalty is added relative to how freequently the peer is used
+	// A penalty is added relative to how frequently the peer is used
 	penalty := hs.updateRequestPenalty(counter)
 
-	// The rank based on the performance and the freequency
+	// The rank based on the performance and the frequency
 	avgWithPenalty := int(penalty * average)
 
 	// Keep the peer in the same class. The value passed will be
@@ -303,7 +303,7 @@ func makeRankPooledPeerSelector(net peersRetriever, initialPeersClasses []peerCl
 	return selector
 }
 
-// getNextPeer returns the next peer. It randomally selects a peer from a pool that has
+// getNextPeer returns the next peer. It randomly selects a peer from a pool that has
 // the lowest rank value. Given that the peers are grouped by their ranks, allow us to
 // prioritize peers based on their class and/or performance.
 func (ps *rankPooledPeerSelector) getNextPeer() (psp *peerSelectorPeer, err error) {

--- a/network/gossipNode.go
+++ b/network/gossipNode.go
@@ -60,6 +60,21 @@ const (
 	PeersPhonebookArchivalNodes PeerOption = iota
 )
 
+func (po PeerOption) String() string {
+	switch po {
+	case PeersConnectedOut:
+		return "ConnectedOut"
+	case PeersConnectedIn:
+		return "ConnectedIn"
+	case PeersPhonebookRelays:
+		return "PhonebookRelays"
+	case PeersPhonebookArchivalNodes:
+		return "PhonebookArchivalNodes"
+	default:
+		return "Unknown PeerOption"
+	}
+}
+
 // GossipNode represents a node in the gossip network
 type GossipNode interface {
 	Address() (string, bool)


### PR DESCRIPTION
## Summary

Per #6152 there was an issue with catchup on P2P networks that ended up to be a peer selector (`classBasedPeerSelector`) issue. Suppose there are only two Relays and no Archival nodes, and only one of the relays have all the blocks, and a node in question does not have DHT enabled. In this case it will only get `ConnectedOut` and `PhonebookRelay` peers (that are the same) and attempts to catchup from them. The following will happen:
1. A relay without old blocks will be randomly selected and after couple of failures gets down ranked below a relay with blocks ( exact rank number is 3 but it does not really matter)
2. Then the second relay get selected and about a hundred blocks get downloaded from it (exact number is 79 until its rank reaches 3, see below)
3. `peerSelector` has a special logic to penalize a node as it is used in order to distribute load more evenly.
4. After that the first node is selected again, fails, and the steps 2-3 repeat.
5. Next, the `classBasedPeerSelector` instance determines `ConnectedOut` class had too many failures, and it is time to temporary disable this class. It advances to `PhonebookRelay` and the process repeats.
6. Then this class gets banned as well, and no peers in remaining classes.
7. Catchup service runs out of peers and exits until it resumes in 17 (`agreement.defaultDeadlineTimeout`) seconds again.

Fixed by decrementing failures counter in `classBasedPeerSelector` so that a single failing node does not prevent the entire class to give up on - the underlying `peerSelector` will punish it harder and harder until its rank passes the usage saturation bound (rank=23 for more context).

Additionally:
1. Made `rankSamples` a linked list with node reusage instead of a slice => no extra mem allocs on long catchups.
2. Fixed some types and uniformed `fetchAndWrite` logging. 

Peer selector / catchup updates:
1. History intro https://github.com/algorand/go-algorand/pull/2060
2. Better 404 handling https://github.com/algorand/go-algorand/pull/5809
3. Class based peer selector to support archival role https://github.com/algorand/go-algorand/pull/5937

Closes #6152

## Test Plan

1. Updated a unit test
11. Run a local net catchup before and after the fix