### PR TITLE
test: fix flaky TestExactAccountChunk again

### DIFF
--- a/ledger/catchpointfilewriter_test.go
+++ b/ledger/catchpointfilewriter_test.go
@@ -908,6 +908,7 @@ func testExactAccountChunk(t *testing.T, proto protocol.ConsensusVersion, extraB
 	testCatchpointFlushRound(dl.generator)
 	testCatchpointFlushRound(dl.validator)
 
+	// wait for the two ledgers to finish committing and be in sync
 	require.Eventually(t, func() bool {
 		dl.generator.accts.accountsMu.RLock()
 		dlg := len(dl.generator.accts.deltas)

--- a/ledger/catchpointfilewriter_test.go
+++ b/ledger/catchpointfilewriter_test.go
@@ -905,10 +905,8 @@ func testExactAccountChunk(t *testing.T, proto protocol.ConsensusVersion, extraB
 		dl.fullBlock(&selfpay)
 	}
 
-	genR, _ := testCatchpointFlushRound(dl.generator)
-	valR, _ := testCatchpointFlushRound(dl.validator)
-	require.Equal(t, genR, valR)
-	require.EqualValues(t, BalancesPerCatchpointFileChunk-12+extraBlocks, genR)
+	testCatchpointFlushRound(dl.generator)
+	testCatchpointFlushRound(dl.validator)
 
 	require.Eventually(t, func() bool {
 		dl.generator.accts.accountsMu.RLock()
@@ -920,6 +918,10 @@ func testExactAccountChunk(t *testing.T, proto protocol.ConsensusVersion, extraB
 		dl.validator.accts.accountsMu.RUnlock()
 		return dlg == dlv && dl.generator.Latest() == dl.validator.Latest()
 	}, 10*time.Second, 100*time.Millisecond)
+	genR, _ := dl.generator.LatestCommitted()
+	valR, _ := dl.validator.LatestCommitted()
+	require.Equal(t, genR, valR)
+	require.EqualValues(t, BalancesPerCatchpointFileChunk-12+extraBlocks, genR)
 
 	tempDir := t.TempDir()
 


### PR DESCRIPTION
## Summary

I recently this test fail on an unrelated PR:
```
=== FAIL: ledger TestExactAccountChunk/future_SPstall300 (5.12s)
    catchpointfilewriter_test.go:910: 
                Error Trace:    /opt/cibuild/project/ledger/catchpointfilewriter_test.go:910
                                                        /opt/cibuild/project/ledger/catchpointfilewriter_test.go:872
                Error:          Not equal: 
                                expected: 0x320
                                actual  : 0x31f
                Test:           TestExactAccountChunk/future_SPstall300
```

It seems the issue is that in #6214, I added an assertion that the DoubleLedger's two ledgers had committed the same round (on the rnd returned by `testCatchpointFlushRound`) BEFORE the code added to address flakiness in #5993 and wait until the two ledgers were caught up and in sync. (It makes sense that this 300-round subtest is the one that failed, since there were more rounds waiting to be flushed.) This moves the assertion after the fix in #5993.

## Test Plan

Existing test should pass, and hopefully not occasionally fail.