### PR TITLE
kmd: upgrade karalabe/usb to karalabe/hid

### DIFF
--- a/daemon/kmd/wallet/driver/ledger_hid.go
+++ b/daemon/kmd/wallet/driver/ledger_hid.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/karalabe/usb"
+	"github.com/karalabe/hid"
 )
 
 const ledgerVendorID = 0x2c97
@@ -31,8 +31,8 @@ const ledgerUsagePage = 0xffa0
 // the protocol used for sending messages to the application running on the
 // Ledger hardware wallet.
 type LedgerUSB struct {
-	hiddev usb.Device
-	info   usb.DeviceInfo
+	hiddev hid.Device
+	info   hid.DeviceInfo
 }
 
 // LedgerUSBError is a wrapper around the two-byte error code that the Ledger
@@ -197,23 +197,23 @@ func (l *LedgerUSB) Exchange(msg []byte) ([]byte, error) {
 }
 
 // USBInfo returns information about the underlying USB device.
-func (l *LedgerUSB) USBInfo() usb.DeviceInfo {
+func (l *LedgerUSB) USBInfo() hid.DeviceInfo {
 	return l.info
 }
 
 // LedgerEnumerate returns all of the Ledger devices connected to this machine.
-func LedgerEnumerate() ([]usb.DeviceInfo, error) {
-	if !usb.Supported() || os.Getenv("KMD_NOUSB") != "" {
+func LedgerEnumerate() ([]hid.DeviceInfo, error) {
+	if !hid.Supported() || os.Getenv("KMD_NOUSB") != "" {
 		return nil, fmt.Errorf("HID not supported")
 	}
 
-	var infos []usb.DeviceInfo
+	var infos []hid.DeviceInfo
 	// The enumeration process is based on:
 	//  https://github.com/LedgerHQ/blue-loader-python/blob/master/ledgerblue/comm.py#L212
 	//  we search for the Ledger Vendor id and ignore devices that don't have specific usagepage or interface
-	hids, err := usb.EnumerateHid(ledgerVendorID, 0)
+	hids, err := hid.Enumerate(ledgerVendorID, 0)
 	if err != nil {
-		return []usb.DeviceInfo{}, err
+		return []hid.DeviceInfo{}, err
 	}
 	for _, info := range hids {
 		if info.UsagePage != ledgerUsagePage && info.Interface != 0 {

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/jsimonetti/rtnetlink v1.4.2
-	github.com/karalabe/usb v0.0.3-0.20230711191512-61db3e06439c
+	github.com/karalabe/hid v1.0.1-0.20240919124526-821c38d2678e
 	github.com/klauspost/cpuid/v2 v2.2.8
 	github.com/labstack/echo/v4 v4.9.1
 	github.com/libp2p/go-libp2p v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,8 @@ github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPci
 github.com/juju/loggo v0.0.0-20180524022052-584905176618/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/testing v0.0.0-20180920084828-472a3e8b2073/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
-github.com/karalabe/usb v0.0.3-0.20230711191512-61db3e06439c h1:AqsttAyEyIEsNz5WLRwuRwjiT5CMDUfLk6cFJDVPebs=
-github.com/karalabe/usb v0.0.3-0.20230711191512-61db3e06439c/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
+github.com/karalabe/hid v1.0.1-0.20240919124526-821c38d2678e h1:ryNJIEs1fyZNVwJ/Dsz7+EFZTow0ggBdnAIVo8SAs+A=
+github.com/karalabe/hid v1.0.1-0.20240919124526-821c38d2678e/go.mod h1:qk1sX/IBgppQNcGCRoj90u6EGC056EBoIc1oEjCWla8=
 github.com/kataras/golog v0.0.9/go.mod h1:12HJgwBIZFNGL0EJnMRhmvGA0PQGx8VFwrZtM4CqbAk=
 github.com/kataras/iris/v12 v12.0.1/go.mod h1:udK4vLQKkdDqMGJJVd/msuMtN6hpYJhg/lSzuxjhO+U=
 github.com/kataras/neffos v0.0.10/go.mod h1:ZYmJC07hQPW67eKuzlfY7SO3bC0mw83A3j6im82hfqw=


### PR DESCRIPTION
Having been unable to use a Ledger device with `goal` on Mac for many months I finally tracked down the issue. The HID Path length specifically on _my_ Mac was too long, and as a result was being replaced with an empty string `""`. This meant my Ledger would never show in `goal wallet list`, despite working everywhere else.

It turns out https://github.com/karalabe/usb embeds an old version of the https://github.com/signal11/hidapi implementation that uses Apple's [io_string_t](https://developer.apple.com/documentation/kernel/io_string_t) type for the [path](https://github.com/karalabe/usb/blob/8627268f6b0ac462d2f78166262404901a2d36e0/hidapi/mac/hid.c#L437).

After reading similar [issues](https://github.com/signal11/hidapi/issues/301) in various repos, it seems https://github.com/karalabe/hid/pull/44 was the solution that updates the underlying issue, and then [go-ethereum](https://github.com/ethereum/go-ethereum/pull/28945) ultimately moved to this package last year with almost identical changes to the code.