### PR TITLE
API: Enable gzip middleware and test for it

### DIFF
--- a/daemon/algod/api/server/router.go
+++ b/daemon/algod/api/server/router.go
@@ -107,6 +107,7 @@ func NewRouter(logger logging.Logger, node APINodeInterface, shutdown <-chan str
 		middleware.RemoveTrailingSlash())
 	e.Use(
 		middlewares.MakeLogger(logger),
+		middleware.Gzip(),
 	)
 	// Optional middleware for Private Network Access Header (PNA). Must come before CORS middleware.
 	if node.Config().EnablePrivateNetworkAccessHeader {

--- a/test/scripts/e2e_subs/api-compression.sh
+++ b/test/scripts/e2e_subs/api-compression.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+filename=$(basename "$0")
+scriptname="${filename%.*}"
+date "+${scriptname} start %Y%m%d_%H%M%S"
+
+
+my_dir="$(dirname "$0")"
+source "$my_dir/rest.sh" "$@"
+
+function headers() {
+    curl -q -s -D - -o /dev/null -H "Authorization: Bearer $PUB_TOKEN" -H "Accept-Encoding: gzip, deflate, br" "$NET$1"
+}
+
+set -e
+set -x
+set -o pipefail
+export SHELLOPTS
+
+OUT=$(headers "/v2/blocks/1")
+[[ ${OUT} == *Content-Encoding:\ gzip* ]] || false
+
+date "+${scriptname} OK %Y%m%d_%H%M%S"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

This summary is longer than the change.  It enables `middleware.Gzip`.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

e2e test ensures that it content encodes to gzip.

Do we need any performance test? I think gzip is so fast that there's nothing worth testing.

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
