### PR TITLE
DevOps: fix golang version handling in bash scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,13 @@ else
 endif
 S3_RELEASE_BUCKET = $$S3_RELEASE_BUCKET
 
-GOLANG_VERSIONS				:= $(shell ./scripts/get_golang_version.sh all)
-GOLANG_VERSION_BUILD		:= $(firstword $(GOLANG_VERSIONS))
-GOLANG_VERSION_SUPPORT		:= $(lastword $(GOLANG_VERSIONS))
-GOLANG_VERSION_BUILD_MAJOR	:= $(shell echo $(GOLANG_VERSION_BUILD) | cut -d'.' -f1,2)
-CURRENT_GO_VERSION			:= $(shell go version | cut -d " " -f 3 | tr -d 'go')
-CURRENT_GO_VERSION_MAJOR	:= $(shell echo $(CURRENT_GO_VERSION) | cut -d'.' -f1,2)
+GOLANG_VERSIONS            := $(shell ./scripts/get_golang_version.sh all)
+GOLANG_VERSION_BUILD       := $(firstword $(GOLANG_VERSIONS))
+GOLANG_VERSION_BUILD_MAJOR := $(shell echo $(GOLANG_VERSION_BUILD) | cut -d'.' -f1,2)
+GOLANG_VERSION_MIN         := $(lastword $(GOLANG_VERSIONS))
+GOLANG_VERSION_SUPPORT     := $(shell echo $(GOLANG_VERSION_MIN) | cut -d'.' -f1,2)
+CURRENT_GO_VERSION         := $(shell go version | cut -d " " -f 3 | tr -d 'go')
+CURRENT_GO_VERSION_MAJOR   := $(shell echo $(CURRENT_GO_VERSION) | cut -d'.' -f1,2)
 
 # If build number already set, use it - to ensure same build number across multiple platforms being built
 BUILDNUMBER      ?= $(shell ./scripts/compute_build_number.sh)

--- a/scripts/check_golang_version.sh
+++ b/scripts/check_golang_version.sh
@@ -15,33 +15,31 @@ set -eo pipefail
 read -ra GOLANG_VERSIONS <<< "$(./scripts/get_golang_version.sh all)"
 BUILD_VERSION="${GOLANG_VERSIONS[0]}"
 MIN_VERSION="${GOLANG_VERSIONS[1]}"
-GO_MOD_SUPPORT="${GOLANG_VERSIONS[2]}"
 
 # Get the field "go1.1.1" and then remove the "go" prefix.
 SYSTEM_GOLANG_VERSION=$(go version | awk '{ gsub(/go/, "", $3); print $3 }')
 
 # https://golang.org/doc/go1.11#modules
-if [[ "${SYSTEM_GOLANG_VERSION}" < "$GO_MOD_SUPPORT" ]]; then
-    echo "[$0] ERROR: The version of go on the system (${SYSTEM_GOLANG_VERSION}) is too old and does not support go modules. Please update to at least ${MIN_VERSION}"
+if [[ "$(printf '%s\n' ${SYSTEM_GOLANG_VERSION} 1.11 | sort -V | head -n1)" != "1.11" ]]; then
+    echo "[$0] ERROR: The version of go on the system (${SYSTEM_GOLANG_VERSION}) is too old and does not support go modules. Please update to at least 1.11."
     exit 1
 fi
 
-if [ "$1" == "dev" ]; then
-    if [[ "${SYSTEM_GOLANG_VERSION}" < "${MIN_VERSION}" ]]; then
-        echo "[$0] WARNING: The version of go on the system (${SYSTEM_GOLANG_VERSION}) is below the recommended version (${MIN_VERSION}) and therefore may not build correctly."
+if [[ "$(printf '%s\n' "$SYSTEM_GOLANG_VERSION" "$MIN_VERSION" | sort -V | head -n1)" != "$MIN_VERSION" ]]; then
+    # We are below the minimum version
+    if [ "$1" == "dev" ]; then
+        echo "[$0] WARNING: The version of go on the system (${SYSTEM_GOLANG_VERSION}) is below the recommended minimum version (${MIN_VERSION}) and therefore may not build correctly."
         echo "[$0] Please update to at least ${MIN_VERSION}"
-    fi
-elif [ "$1" == "build" ]; then
-    if [[ "${SYSTEM_GOLANG_VERSION}" < "${MIN_VERSION}" ]]; then
-        echo "[$0] ERROR: The version of go on the system (${SYSTEM_GOLANG_VERSION}) is below the necessary version (${MIN_VERSION}) and therefore will not build correctly."
+    elif [ "$1" == "build" ]; then
+        echo "[$0] ERROR: The version of go on the system (${SYSTEM_GOLANG_VERSION}) is below the necessary minimum version (${MIN_VERSION}) and therefore will not build correctly."
         exit 1
     fi
 else
     # Check to make sure that it matches what is specified in `go.mod`.
-    GOMOD_VERSION=$(go mod edit -print | awk '/^go[ \t]+[0-9]+\.[0-9]+(\.[0-9]+)?[ \t]*$/{print $2}')
+    GOMOD_TOOL_VERSION=$(go mod edit -print | awk '$1 == "toolchain" {sub(/^go/, "", $2); print $2}')
 
-    if [[ ! "${BUILD_VERSION}" =~ ^"${GOMOD_VERSION}" ]]; then
-        echo "[$0] ERROR: go version mismatch, go mod version ${GOMOD_VERSION} does not match required version ${BUILD_VERSION}"
+    if [[ "${BUILD_VERSION}" != "${GOMOD_TOOL_VERSION}" ]]; then
+        echo "[$0] ERROR: go version mismatch, go mod tool version ${GOMOD_TOOL_VERSION} does not match required version ${BUILD_VERSION}"
         exit 1
     else
         echo "${BUILD_VERSION}"

--- a/scripts/get_golang_version.sh
+++ b/scripts/get_golang_version.sh
@@ -12,12 +12,11 @@
 # build a new image whenever the version number has been changed.
 
 BUILD=1.23.3
- MIN=1.23
- GO_MOD_SUPPORT=1.23
+MIN=$(echo $BUILD | cut -d. -f1-2).0
 
 if [ "$1" = all ]
 then
-    echo $BUILD $MIN $GO_MOD_SUPPORT
+    echo $BUILD $MIN
 elif [ "$1" = dev ]
 then
     echo $MIN


### PR DESCRIPTION
## Summary

If you run `go mod tidy` with newer versions of golang, it will automatically change the minimum version field in `go.mod`. Before, this would be e.g. `1.23`, but after update, it will change this to `1.23.0`.

Our bash scripts needed to be updated to take this into account. The following changes were made:

- Removed third parameter from `./scripts/get_golang_version.sh all`. This was so `./scripts/check_golang_version.sh` could check for go module support, so I just moved the version information there
- Updated Makefile to reflect this
- Fixed conditionals in `check_golang_version.sh` to properly compare semantic versions

## Test Plan

Set a custom version in check_golang_version.sh and verified:

- 1.2.0 reported error
- 1.12.0 reported warning for `./scripts/check_golang_version.sh dev`
- 1.12.0 errored for `./scripts/check_golang_version.sh build`
- 1.23.0 did not error

