### PR TITLE
util: only set rlimit if needed

### DIFF
--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -133,7 +133,7 @@ func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string, genes
 		// TODO: Decide if this is too much, or not enough.
 		fdRequired = ot.Add(fdRequired, 512)
 	}
-	err = util.SetFdSoftLimit(fdRequired)
+	err = util.RaiseFdSoftLimit(fdRequired)
 	if err != nil {
 		return fmt.Errorf("Initialize() err: %w", err)
 	}
@@ -145,7 +145,7 @@ func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string, genes
 			return errors.New(
 				"Initialize() overflowed when adding up fdRequired and 1000 needed for pebbledb")
 		}
-		err = util.SetFdSoftLimit(fdRequired)
+		err = util.RaiseFdSoftLimit(fdRequired)
 		if err != nil {
 			return fmt.Errorf("Initialize() failed to set FD limit for pebbledb backend, err: %w", err)
 		}
@@ -194,7 +194,7 @@ func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string, genes
 					}
 				}
 			}
-			fdErr = util.SetFdSoftLimit(maxFDs)
+			fdErr = util.RaiseFdSoftLimit(maxFDs)
 			if fdErr != nil {
 				// do not fail but log the error
 				s.log.Errorf("Failed to set a new RLIMIT_NOFILE value to %d (max %d): %s", fdRequired, hard, fdErr.Error())

--- a/util/util.go
+++ b/util/util.go
@@ -36,16 +36,30 @@ func GetFdLimits() (soft uint64, hard uint64, err error) {
 	return rLimit.Cur, rLimit.Max, nil
 }
 
+// RaiseFdSoftLimit raises the file descriptors soft limit to the specified value,
+// or leave it unchanged if the value is less than the current.
+func RaiseFdSoftLimit(newLimit uint64) error {
+	soft, hard, err := GetFdLimits()
+	if err != nil {
+		return fmt.Errorf("RaiseFdSoftLimit() err: %w", err)
+	}
+	if newLimit <= soft {
+		// Current limit is sufficient; no need to change it.
+		return nil
+	}
+	if newLimit > hard {
+		// New limit exceeds the hard limit; set it to the hard limit.
+		newLimit = hard
+	}
+	return SetFdSoftLimit(newLimit)
+}
+
 // SetFdSoftLimit sets a new file descriptors soft limit.
 func SetFdSoftLimit(newLimit uint64) error {
 	var rLimit syscall.Rlimit
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 	if err != nil {
 		return fmt.Errorf("SetFdSoftLimit() err: %w", err)
-	}
-	if newLimit <= rLimit.Cur {
-		// Current limit is sufficient; no need to change it.
-		return nil
 	}
 
 	rLimit.Cur = newLimit

--- a/util/util_windows.go
+++ b/util/util_windows.go
@@ -31,6 +31,11 @@ func GetFdLimits() (soft uint64, hard uint64, err error) {
 	return math.MaxUint64, math.MaxUint64, nil // syscall.RLIM_INFINITY
 }
 
+// RaiseFdSoftLimit raises the file descriptors soft limit.
+func RaiseFdSoftLimit(_ uint64) error {
+	return nil
+}
+
 // SetFdSoftLimit sets a new file descriptors soft limit.
 func SetFdSoftLimit(_ uint64) error {
 	return nil


### PR DESCRIPTION
## Summary

We don't need to lower the current RLIMIT_NOFILE limit, which we were doing before. This ensures that we only raise it if needed. It also adds a constant number of additional FDs to the requested limit if P2P is enabled. This constant is arbitrary, we could decide to adjust it, or make it a separate configuration value.

## Test Plan

Existing tests should pass.