### PR TITLE
catchpoint: handle loadFromDisk/recoverFromCrash during first stage correctly

### DIFF
--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -326,10 +326,12 @@ func (ct *catchpointTracker) finishFirstStageAfterCrash(dbRound basics.Round, bl
 		return err
 	}
 
-	// pass dbRound+1-maxBalLookback as the onlineAccountsForgetBefore parameter: since we can't be sure whether
+	// pass 0 as the onlineAccountsForgetBefore parameter: since we can't be sure whether
 	// there are more than 320 rounds of history in the online accounts tables, this ensures the catchpoint
 	// will only contain the most recent 320 rounds.
-	onlineAccountsForgetBefore := catchpointLookbackHorizonForNextRound(dbRound, config.Consensus[blockProto])
+	// Inside finishFirstStage, this has the same effect as the voters tracker returning a "lowestRound" of 0,
+	// which causes finishFirstStage to calculate the correct horizon and filter out data older than dbround+1-320.
+	onlineAccountsForgetBefore := basics.Round(0)
 	return ct.finishFirstStage(context.Background(), dbRound, onlineAccountsForgetBefore, blockProto, 0)
 }
 


### PR DESCRIPTION
## Summary

Following #6177, #6214, #6240, and #6253, this provides correct handling for nodes that are stopped and restarted while writing out the large "first stage" catchpoint file DB dump to disk. During this time, the value `trackerdb.CatchpointStateWritingFirstStageInfo` is set to 1.

If a node is restarted while the first stage is still writing to disk, in loadFromDisk/recoverFromCrash algod sees this flag, and deletes the old DB file, intending to replace it with a new one by calling `finishFirstStage` again. However, if the node's onlineaccounts table has more than 320 rounds of history in it (because the state proof worker had not yet finished processing the latest state proof), the argument passed is not correct. This leads to the error 
`couldn't initialize the node: reloadLedger.loadFromDisk tracker *ledger.catchpointTracker failed to loadFromDisk : bad online account data: multiple horizon rows for X, prev updround Y cur updround Z`

## Test Plan

Tested manually