### PR TITLE
Debug: rotate algoh logs

### DIFF
--- a/cmd/algoh/main.go
+++ b/cmd/algoh/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -123,7 +124,7 @@ func main() {
 
 	done := make(chan struct{})
 	log := logging.Base()
-	configureLogging(genesis, log, absolutePath, done, algodConfig)
+	configureLogging(genesis, log, absolutePath, done, algodConfig, algohConfig)
 	defer log.CloseTelemetry()
 
 	exeDir, err = util.ExeDir()
@@ -270,16 +271,41 @@ func getNodeController() nodecontrol.NodeController {
 	return nc
 }
 
-func configureLogging(genesis bookkeeping.Genesis, log logging.Logger, rootPath string, abort chan struct{}, algodConfig config.Local) {
+func configureLogging(genesis bookkeeping.Genesis, log logging.Logger, rootPath string, abort chan struct{}, algodConfig config.Local, algohConfig algoh.HostConfig) {
 	log = logging.Base()
 
 	liveLog := fmt.Sprintf("%s/host.log", rootPath)
-	fmt.Println("Logging to: ", liveLog)
-	writer, err := os.OpenFile(liveLog, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
-	if err != nil {
-		panic(fmt.Sprintf("configureLogging: cannot open log file %v", err))
+	if algohConfig.LogFileDir != "" {
+		liveLog = fmt.Sprintf("%s/%s", algohConfig.LogFileDir, "host.log")
 	}
-	log.SetOutput(writer)
+
+	archive := rootPath
+	if algohConfig.LogFileDir != "" {
+		archive = algohConfig.LogArchiveDir
+	}
+	if algohConfig.LogArchiveName != "" {
+		archive = fmt.Sprintf("%s/%s", archive, algohConfig.LogArchiveName)
+	}
+
+	var maxLogAge time.Duration
+	var err error
+	if algohConfig.LogArchiveMaxAge != "" {
+		maxLogAge, err = time.ParseDuration(algohConfig.LogArchiveMaxAge)
+		if err != nil {
+			log.Fatalf("invalid algoh config LogArchiveMaxAge: %s", err)
+			maxLogAge = 0
+		}
+	}
+
+	var logWriter io.Writer
+	if algohConfig.LogSizeLimit > 0 {
+		fmt.Println("algoh logging to: ", liveLog)
+		logWriter = logging.MakeCyclicFileWriter(liveLog, archive, algohConfig.LogSizeLimit, maxLogAge)
+	} else {
+		fmt.Println("Logging to: stdout")
+		logWriter = os.Stdout
+	}
+	log.SetOutput(logWriter)
 	log.SetJSONFormatter()
 	log.SetLevel(logging.Debug)
 
@@ -287,9 +313,9 @@ func configureLogging(genesis bookkeeping.Genesis, log logging.Logger, rootPath 
 
 	// if we have the telemetry enabled, we want to use it's sessionid as part of the
 	// collected metrics decorations.
-	fmt.Fprintln(writer, "++++++++++++++++++++++++++++++++++++++++")
-	fmt.Fprintln(writer, "Logging Starting")
-	fmt.Fprintln(writer, "++++++++++++++++++++++++++++++++++++++++")
+	fmt.Fprintln(logWriter, "++++++++++++++++++++++++++++++++++++++++")
+	fmt.Fprintln(logWriter, "Logging Starting")
+	fmt.Fprintln(logWriter, "++++++++++++++++++++++++++++++++++++++++")
 }
 
 func initTelemetry(genesis bookkeeping.Genesis, log logging.Logger, dataDirectory string, abort chan struct{}, algodConfig config.Local) {

--- a/cmd/algoh/main.go
+++ b/cmd/algoh/main.go
@@ -281,6 +281,9 @@ func configureLogging(genesis bookkeeping.Genesis, log logging.Logger, rootPath 
 
 	archive := rootPath
 	if algohConfig.LogFileDir != "" {
+		archive = algohConfig.LogFileDir
+	}
+	if algohConfig.LogArchiveDir != "" {
 		archive = algohConfig.LogArchiveDir
 	}
 	if algohConfig.LogArchiveName != "" {

--- a/cmd/algoh/main.go
+++ b/cmd/algoh/main.go
@@ -307,7 +307,22 @@ func configureLogging(genesis bookkeeping.Genesis, log logging.Logger, rootPath 
 	}
 	log.SetOutput(logWriter)
 	log.SetJSONFormatter()
-	log.SetLevel(logging.Debug)
+	switch algohConfig.MinLogLevel {
+	case 0:
+		log.SetLevel(logging.Panic)
+	case 1:
+		log.SetLevel(logging.Fatal)
+	case 2:
+		log.SetLevel(logging.Error)
+	case 3:
+		log.SetLevel(logging.Warn)
+	case 4:
+		log.SetLevel(logging.Info)
+	case 5:
+		log.SetLevel(logging.Debug)
+	default:
+		log.SetLevel(logging.Warn)
+	}
 
 	initTelemetry(genesis, log, rootPath, abort, algodConfig)
 

--- a/shared/algoh/config.go
+++ b/shared/algoh/config.go
@@ -27,19 +27,29 @@ const ConfigFilename = "host-config.json"
 
 // HostConfig is algoh's configuration structure
 type HostConfig struct {
-	SendBlockStats bool
-	UploadOnError  bool
-	DeadManTimeSec int64
-	StatusDelayMS  int64
-	StallDelayMS   int64
+	SendBlockStats   bool
+	UploadOnError    bool
+	DeadManTimeSec   int64
+	StatusDelayMS    int64
+	StallDelayMS     int64
+	LogArchiveDir    string
+	LogArchiveMaxAge string
+	LogArchiveName   string
+	LogFileDir       string
+	LogSizeLimit     uint64
 }
 
 var defaultConfig = HostConfig{
-	SendBlockStats: false,
-	UploadOnError:  true,
-	DeadManTimeSec: 120,
-	StatusDelayMS:  500,
-	StallDelayMS:   60 * 1000,
+	SendBlockStats:   false,
+	UploadOnError:    true,
+	DeadManTimeSec:   120,
+	StatusDelayMS:    500,
+	StallDelayMS:     60 * 1000,
+	LogArchiveDir:    "",
+	LogArchiveMaxAge: "",
+	LogArchiveName:   "host.archive.log",
+	LogFileDir:       "",
+	LogSizeLimit:     1073741824,
 }
 
 // LoadConfigFromFile loads the configuration from the specified file, merging into the default configuration.

--- a/shared/algoh/config.go
+++ b/shared/algoh/config.go
@@ -37,6 +37,7 @@ type HostConfig struct {
 	LogArchiveName   string
 	LogFileDir       string
 	LogSizeLimit     uint64
+	MinLogLevel      uint32
 }
 
 var defaultConfig = HostConfig{
@@ -50,6 +51,7 @@ var defaultConfig = HostConfig{
 	LogArchiveName:   "host.archive.log",
 	LogFileDir:       "",
 	LogSizeLimit:     1073741824,
+	MinLogLevel:      3,
 }
 
 // LoadConfigFromFile loads the configuration from the specified file, merging into the default configuration.


### PR DESCRIPTION
## Summary

By default, algoh does not rotate logs and logs at DEBUG level. This would result in a quickly growing log that would consume all disk.

This PR adds log rotation to algoh logs, mimicing the way it is implemented in config.json.

## Test Plan

Tested config values in host-config.json and verified they did what they should. Verified the new WARN default logged less, and that (when enabled) BlockStats events were still sent to telemetry.
