### PR TITLE
p2p: fix DHT FindPeer internal buffer size

### DIFF
--- a/network/p2p/dht/dht.go
+++ b/network/p2p/dht/dht.go
@@ -69,7 +69,7 @@ func backoffFactory() backoff.BackoffFactory {
 	return backoff.NewExponentialDecorrelatedJitter(minBackoff, maxBackoff, baseBackoff, rand.NewSource(rand.Int63()))
 }
 
-// MakeDiscovery creates a discovery.Discovery object using backoff and cacching
+// MakeDiscovery creates a discovery.Discovery object using backoff and caching
 func MakeDiscovery(r crouting.ContentRouting) (discovery.Discovery, error) {
-	return backoff.NewBackoffDiscovery(routing.NewRoutingDiscovery(r), backoffFactory(), backoff.WithBackoffDiscoveryReturnedChannelSize(0), backoff.WithBackoffDiscoverySimultaneousQueryBufferSize(0))
+	return backoff.NewBackoffDiscovery(routing.NewRoutingDiscovery(r), backoffFactory(), backoff.WithBackoffDiscoveryReturnedChannelSize(0))
 }

--- a/network/p2p/dht/dht.go
+++ b/network/p2p/dht/dht.go
@@ -71,5 +71,5 @@ func backoffFactory() backoff.BackoffFactory {
 
 // MakeDiscovery creates a discovery.Discovery object using backoff and caching
 func MakeDiscovery(r crouting.ContentRouting) (discovery.Discovery, error) {
-	return backoff.NewBackoffDiscovery(routing.NewRoutingDiscovery(r), backoffFactory(), backoff.WithBackoffDiscoveryReturnedChannelSize(0))
+	return backoff.NewBackoffDiscovery(routing.NewRoutingDiscovery(r), backoffFactory())
 }


### PR DESCRIPTION
## Summary

There was observed behavior when p2p node sometimes cannot stop (`goal node stop`) properly. It ended up to be `p2pNetwork.Stop` waiting meshThread to finish but it cannot because it is deadlocked in `FindPeer`.

<details><summary>Relevant stack traces</summary>
<p>
<pre>
goroutine 1 [semacquire, 1006 minutes]:
sync.runtime_Semacquire(0x1037ae720?)
        runtime/sema.go:71 +0x2c
sync.(*WaitGroup).Wait(0x140009bb508)
        sync/waitgroup.go:118 +0x74
github.com/algorand/go-algorand/network.(*P2PNetwork).Stop(0x140009bb008)
        github.com/algorand/go-algorand/network/p2pNetwork.go:401 +0x1ac
github.com/algorand/go-algorand/node.(*AlgorandFullNode).Stop(0x140004ce308)
        github.com/algorand/go-algorand/node/node.go:461 +0x130
github.com/algorand/go-algorand/daemon/algod.(*Server).Stop(0x14000795900)
        github.com/algorand/go-algorand/daemon/algod/server.go:464 +0x6c
github.com/algorand/go-algorand/daemon/algod.(*Server).Start(0x14000795900)
        github.com/algorand/go-algorand/daemon/algod/server.go:450 +0x132c
main.run()
        github.com/algorand/go-algorand/cmd/algod/main.go:451 +0x2074
main.main()
        github.com/algorand/go-algorand/cmd/algod/main.go:70 +0x64
</pre>
<pre>
goroutine 654 [sync.Mutex.Lock, 1477 minutes]:
sync.runtime_SemacquireMutex(0x0?, 0x80?, 0x14000b9aec8?)
        runtime/sema.go:95 +0x28
sync.(*Mutex).lockSlow(0x1400a58fd50)
        sync/mutex.go:173 +0x174
sync.(*Mutex).Lock(...)
        sync/mutex.go:92
github.com/libp2p/go-libp2p/p2p/discovery/backoff.(*BackoffDiscovery).FindPeers(0x14000e001e0, {0x1046e0b70, 0x14016af3420}, {0x103af6433, 0x6}, {0x14020c542f0, 0x1, 0x1})
        github.com/libp2p/go-libp2p@v0.37.0/p2p/discovery/backoff/backoffcache.go:145 +0x354
github.com/algorand/go-algorand/network/p2p.(*CapabilitiesDiscovery).findPeers(...)
        github.com/algorand/go-algorand/network/p2p/capabilities.go:66
github.com/algorand/go-algorand/network/p2p.(*CapabilitiesDiscovery).PeersForCapability(0x14000f109c0, {0x103af6433, 0x6}, 0x4)
        github.com/algorand/go-algorand/network/p2p/capabilities.go:96 +0x10c
github.com/algorand/go-algorand/network.(*P2PNetwork).meshThreadInner(0x140009bb008)
        github.com/algorand/go-algorand/network/p2pNetwork.go:435 +0x2f8
github.com/algorand/go-algorand/network.(*P2PNetwork).meshThread(0x140009bb008)
        github.com/algorand/go-algorand/network/p2pNetwork.go:485 +0x244
created by github.com/algorand/go-algorand/network.(*P2PNetwork).Start in goroutine 1
        github.com/algorand/go-algorand/network/p2pNetwork.go:364 +0x324
</pre>
<pre>
goroutine 18327765 [chan send, 1478 minutes]:
github.com/libp2p/go-libp2p/p2p/discovery/backoff.findPeerDispatcher({0x1046e0b70, 0x1400c7ed8f0}, 0x1400a58fd40, 0x14016e76690)
        github.com/libp2p/go-libp2p@v0.37.0/p2p/discovery/backoff/backoffcache.go:242 +0x3b0
created by github.com/libp2p/go-libp2p/p2p/discovery/backoff.(*BackoffDiscovery).FindPeers in goroutine 654
        github.com/libp2p/go-libp2p@v0.37.0/p2p/discovery/backoff/backoffcache.go:179 +0x478
</pre>
</p>
</details> 

It ended up to libp2p's `findPeerDispatcher` attempts to write into a channel when no receivers. For some reason we preferred [unbuffered channel](https://github.com/libp2p/go-libp2p/blob/master/p2p/discovery/backoff/backoffcache.go#L183) by setting `backoff.WithBackoffDiscoverySimultaneousQueryBufferSize(0)`.

Fixed by removing `WithBackoffDiscoverySimultaneousQueryBufferSize` option.

## Test Plan

Not tested b/c low probability to reproduce.