### PR TITLE
Build: Seems like installing swagger command is a relic of the past

### DIFF
--- a/scripts/buildtools/install_buildtools.sh
+++ b/scripts/buildtools/install_buildtools.sh
@@ -88,7 +88,6 @@ if [[ "${BUILDTOOLS_INSTALL}" != "ALL" ]]; then
 fi
 
 install_go_module golang.org/x/tools golang.org/x/tools/cmd/stringer
-install_go_module github.com/go-swagger/go-swagger github.com/go-swagger/go-swagger/cmd/swagger
 install_go_module github.com/algorand/msgp
 install_go_module gotest.tools/gotestsum
 install_go_module github.com/algorand/oapi-codegen github.com/algorand/oapi-codegen/cmd/oapi-codegen

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -38,7 +38,6 @@ GO_DEPS=(
     "msgp"
     "golangci-lint"
     "oapi-codegen"
-    "swagger"
 )
 
 check_go_binary_version() {
@@ -85,4 +84,3 @@ else
     echo -e "$RED_FG[$0]$END_FG_COLOR Required dependencies missing. Run \`${TEAL_FG}./scripts/configure_dev.sh$END_FG_COLOR\` and/or \`${TEAL_FG}./scripts/buildtools/install_buildtools.sh$END_FG_COLOR\` to install."
     exit 1
 fi
-


### PR DESCRIPTION
Remove the install from `install_buildtools.sh`

If CI can still build everything, including the codegen check, we don't seem to need it

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
