### PR TITLE
network: close p2p conn in CloseWithoutFlush

### DIFF
--- a/network/p2pPeer.go
+++ b/network/p2pPeer.go
@@ -76,7 +76,7 @@ func (c *wsPeerConnP2P) CloseWithMessage([]byte, time.Time) error {
 func (c *wsPeerConnP2P) SetReadLimit(int64) {}
 
 func (c *wsPeerConnP2P) CloseWithoutFlush() (err error) {
-	err = c.stream.Close()
+	err = c.stream.Reset()
 	defer func() {
 		err0 := c.stream.Conn().Close()
 		if err == nil {

--- a/network/p2pPeer.go
+++ b/network/p2pPeer.go
@@ -75,8 +75,14 @@ func (c *wsPeerConnP2P) CloseWithMessage([]byte, time.Time) error {
 
 func (c *wsPeerConnP2P) SetReadLimit(int64) {}
 
-func (c *wsPeerConnP2P) CloseWithoutFlush() error {
-	err := c.stream.Close()
+func (c *wsPeerConnP2P) CloseWithoutFlush() (err error) {
+	err = c.stream.Close()
+	defer func() {
+		err0 := c.stream.Conn().Close()
+		if err == nil {
+			err = err0
+		}
+	}()
 	if err != nil && err != yamux.ErrStreamClosed && err != yamux.ErrSessionShutdown && err != yamux.ErrStreamReset {
 		return err
 	}


### PR DESCRIPTION
## Summary

Out P2P implementation does not close p2p connections so it is possible non-performant peers still have open service streams (incl. DHT and pubsub).

## Test Plan

Existing tests