### PR TITLE
tests: fix TestP2PRelay data race

### DIFF
--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/algorand/go-algorand/network/phonebook"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/algorand/go-deadlock"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
@@ -896,7 +897,7 @@ func TestP2PRelay(t *testing.T) {
 
 	type logMessages struct {
 		msgs [][]byte
-		mu   sync.Mutex
+		mu   deadlock.Mutex
 	}
 	makeCounterHandler := func(numExpected int, counter *atomic.Uint32, msgSink *logMessages) ([]TaggedMessageValidatorHandler, chan struct{}) {
 		counterDone := make(chan struct{})

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -894,7 +894,11 @@ func TestP2PRelay(t *testing.T) {
 		return netA.hasPeers() && netB.hasPeers()
 	}, 2*time.Second, 50*time.Millisecond)
 
-	makeCounterHandler := func(numExpected int, counter *atomic.Uint32, msgs *[][]byte) ([]TaggedMessageValidatorHandler, chan struct{}) {
+	type logMessages struct {
+		msgs [][]byte
+		mu   sync.Mutex
+	}
+	makeCounterHandler := func(numExpected int, counter *atomic.Uint32, msgSink *logMessages) ([]TaggedMessageValidatorHandler, chan struct{}) {
 		counterDone := make(chan struct{})
 		counterHandler := []TaggedMessageValidatorHandler{
 			{
@@ -903,8 +907,10 @@ func TestP2PRelay(t *testing.T) {
 					ValidateHandleFunc
 				}{
 					ValidateHandleFunc(func(msg IncomingMessage) OutgoingMessage {
-						if msgs != nil {
-							*msgs = append(*msgs, msg.Data)
+						if msgSink != nil {
+							msgSink.mu.Lock()
+							msgSink.msgs = append(msgSink.msgs, msg.Data)
+							msgSink.mu.Unlock()
 						}
 						if count := counter.Add(1); int(count) >= numExpected {
 							close(counterDone)
@@ -970,8 +976,8 @@ func TestP2PRelay(t *testing.T) {
 
 	const expectedMsgs = 10
 	counter.Store(0)
-	var loggedMsgs [][]byte
-	counterHandler, counterDone = makeCounterHandler(expectedMsgs, &counter, &loggedMsgs)
+	var msgsSink logMessages
+	counterHandler, counterDone = makeCounterHandler(expectedMsgs, &counter, &msgsSink)
 	netA.ClearValidatorHandlers()
 	netA.RegisterValidatorHandlers(counterHandler)
 
@@ -991,10 +997,10 @@ func TestP2PRelay(t *testing.T) {
 	case <-counterDone:
 	case <-time.After(3 * time.Second):
 		if c := counter.Load(); c < expectedMsgs {
-			t.Logf("Logged messages: %v", loggedMsgs)
+			t.Logf("Logged messages: %v", msgsSink.msgs)
 			require.Failf(t, "One or more messages failed to reach destination network", "%d > %d", expectedMsgs, c)
 		} else if c > expectedMsgs {
-			t.Logf("Logged messages: %v", loggedMsgs)
+			t.Logf("Logged messages: %v", msgsSink.msgs)
 			require.Failf(t, "One or more messages that were expected to be dropped, reached destination network", "%d < %d", expectedMsgs, c)
 		}
 	}


### PR DESCRIPTION
## Summary

Fix for the following data race:
```
==================
WARNING: DATA RACE
Read at 0x00c0005202b8 by goroutine 737:
  github.com/algorand/go-algorand/network.TestP2PRelay.TestP2PRelay.func3.func7()
      /home/runner/work/go-algorand/go-algorand/network/p2pNetwork_test.go:907 +0xb4
  github.com/algorand/go-algorand/network.ValidateHandleFunc.ValidateHandle()
      /home/runner/work/go-algorand/go-algorand/network/gossipNode.go:237 +0x121
  go:struct { github.com/algorand/go-algorand/network.ValidateHandleFunc }.ValidateHandle()
      <autogenerated>:1 +0x2a

Previous write at 0x00c0005202b8 by goroutine 731:
  github.com/algorand/go-algorand/network.TestP2PRelay.TestP2PRelay.func3.func7()
      /home/runner/work/go-algorand/go-algorand/network/p2pNetwork_test.go:907 +0x16b
  github.com/algorand/go-algorand/network.ValidateHandleFunc.ValidateHandle()
      /home/runner/work/go-algorand/go-algorand/network/gossipNode.go:237 +0x121
  go:struct { github.com/algorand/go-algorand/network.ValidateHandleFunc }.ValidateHandle()
      <autogenerated>:1 +0x2a
```

## Test Plan

Existing tests