### PR TITLE
p2p: reduce severity of failed capabilities advertisement

### DIFF
--- a/network/p2p/capabilities.go
+++ b/network/p2p/capabilities.go
@@ -110,7 +110,7 @@ func (c *CapabilitiesDiscovery) PeersForCapability(capability Capability, n int)
 }
 
 // AdvertiseCapabilities periodically runs the Advertiser interface on the DHT
-// If a capability fails to advertise we will retry every 10 seconds until full success
+// If a capability fails to advertise we will retry every 100 seconds until full success
 // This gets rerun every at the minimum ttl or the maxAdvertisementInterval.
 func (c *CapabilitiesDiscovery) AdvertiseCapabilities(capabilities ...Capability) {
 	c.wg.Add(1)


### PR DESCRIPTION
## Summary

We observe quite a lot of messages `failed to advertise for capability gossip: context deadline exceeded` in telemetry.
From DHT [source code](https://github.com/libp2p/go-libp2p-kad-dht/blob/v0.28.0/routing.go#L438) it is not quite clear where the `context.DeadlineExceeded` returned from - from finding peers or from sending to some particular peer.

It looks more probable tho it could fetch some peers and attempts to send out capabilities. Following this assumption, this PR increases probability of advertising more by shuffling capabilities array before re-attempt. It also looks like the 10s repeat timeout is too short, so increased to 100s.

## Test Plan

Existing tests