### PR TITLE
CI: use partitiontest for Fuzz tests

### DIFF
--- a/network/vpack/rapid_test.go
+++ b/network/vpack/rapid_test.go
@@ -40,6 +40,7 @@ func TestCheckStatelessEncoder(t *testing.T) {
 
 // FuzzCheckStatelessEncoder is the same as TestCheckStatelessEncoder, but is a fuzz test.
 func FuzzCheckStatelessEncoder(f *testing.F) {
+	partitiontest.PartitionTest(f)
 	f.Fuzz(rapid.MakeFuzz(checkStatelessEncoder))
 }
 
@@ -185,6 +186,8 @@ func generateRandomVote() *rapid.Generator[*agreement.UnauthenticatedVote] {
 // expects to be valid msgpack-encoded votes, this test is only ensures that
 // StatelessEncoder and StatelessDecoder don't crash on malformed data.
 func FuzzStatelessEncoder(f *testing.F) {
+	partitiontest.PartitionTest(f)
+
 	// Seed with valid compressed votes from random vote generator
 	voteGen := generateRandomVote()
 	var msgpBuf []byte
@@ -229,6 +232,8 @@ func FuzzStatelessEncoder(f *testing.F) {
 // FuzzStatelessDecoder is a fuzz test specifically targeting the StatelessDecoder
 // with potentially malformed input.
 func FuzzStatelessDecoder(f *testing.F) {
+	partitiontest.PartitionTest(f)
+
 	// Add valid compressed votes from random vote generator
 	voteGen := generateRandomVote()
 	var msgpBuf []byte

--- a/network/vpack/vpack_test.go
+++ b/network/vpack/vpack_test.go
@@ -189,6 +189,8 @@ func TestStatelessDecoderErrors(t *testing.T) {
 // FuzzMsgpVote is a fuzz test for parseVote, CompressVote and DecompressVote.
 // It generates random msgp-encoded votes, then compresses & decompresses them.
 func FuzzMsgpVote(f *testing.F) {
+	partitiontest.PartitionTest(f)
+
 	addVote := func(obj any) []byte {
 		var buf []byte
 		if v, ok := obj.(*agreement.UnauthenticatedVote); ok {
@@ -236,6 +238,8 @@ func FuzzMsgpVote(f *testing.F) {
 }
 
 func FuzzVoteFields(f *testing.F) {
+	partitiontest.PartitionTest(f)
+
 	f.Fuzz(func(t *testing.T, snd []byte, rnd, per, step uint64,
 		oper uint64, oprop, dig, encdig []byte,
 		pf []byte, s, p, ps, p2, p1s, p2s []byte) {

--- a/test/partitiontest/filtering.go
+++ b/test/partitiontest/filtering.go
@@ -25,7 +25,7 @@ import (
 )
 
 // PartitionTest checks if the current partition should run this test, and skips it if not.
-func PartitionTest(t *testing.T) {
+func PartitionTest(t testing.TB) {
 	pt, found := os.LookupEnv("PARTITION_TOTAL")
 	if !found {
 		return


### PR DESCRIPTION
## Summary

Fuzz tests run as regular go tests on seed values (from f.Add()), so this updates those tests so they are not run unnecessarily when parallelizing tests in CI. 

## Test Plan

Existing tests should pass, test verification job not show a messages like `github.com/algorand/go-algorand/network/vpack FuzzMsgpVote/seed#22308 -- ran 32 times. (Can probably be fixed by adding "partitiontest.PartitionTest()")`