### PR TITLE
Testing: Remove sd.Valid()

### DIFF
--- a/data/basics/teal.go
+++ b/data/basics/teal.go
@@ -81,33 +81,6 @@ func (sd StateDelta) Equal(o StateDelta) bool {
 	return maps.Equal(sd, o)
 }
 
-// Valid checks whether the keys and values in a StateDelta conform to the
-// consensus parameters' maximum lengths
-func (sd StateDelta) Valid(proto *config.ConsensusParams) error {
-	if len(sd) > 0 && proto.MaxAppKeyLen == 0 {
-		return fmt.Errorf("delta not empty, but proto.MaxAppKeyLen is 0 (why did we make a delta?)")
-	}
-	for key, delta := range sd {
-		if len(key) > proto.MaxAppKeyLen {
-			return fmt.Errorf("key too long: length was %d, maximum is %d", len(key), proto.MaxAppKeyLen)
-		}
-		switch delta.Action {
-		case SetBytesAction:
-			if len(delta.Bytes) > proto.MaxAppBytesValueLen {
-				return fmt.Errorf("value too long for key 0x%x: length was %d", key, len(delta.Bytes))
-			}
-			if sum := len(key) + len(delta.Bytes); sum > proto.MaxAppSumKeyValueLens {
-				return fmt.Errorf("key/value total too long for key 0x%x: sum was %d", key, sum)
-			}
-		case SetUintAction:
-		case DeleteAction:
-		default:
-			return fmt.Errorf("unknown delta action: %v", delta.Action)
-		}
-	}
-	return nil
-}
-
 // StateSchema sets maximums on the number of each type that may be stored
 type StateSchema struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`

--- a/data/basics/teal_test.go
+++ b/data/basics/teal_test.go
@@ -17,95 +17,12 @@
 package basics
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/algorand/go-algorand/config"
-	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
-
-func TestStateDeltaValid(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	a := require.New(t)
-
-	// test pre-applications proto
-	protoPreF := config.Consensus[protocol.ConsensusV23]
-	a.False(protoPreF.Application)
-	sd := StateDelta{"key": ValueDelta{Action: SetBytesAction, Bytes: "val"}}
-	err := sd.Valid(&protoPreF)
-	a.Error(err)
-	a.Contains(err.Error(), "proto.MaxAppKeyLen is 0")
-
-	sd = StateDelta{"": ValueDelta{Action: SetUintAction, Uint: 1}}
-	err = sd.Valid(&protoPreF)
-	a.Error(err)
-	a.Contains(err.Error(), "proto.MaxAppKeyLen is 0")
-
-	sd = StateDelta{"": ValueDelta{Action: SetBytesAction, Bytes: ""}}
-	err = sd.Valid(&protoPreF)
-	a.Error(err)
-	a.Contains(err.Error(), "proto.MaxAppKeyLen is 0")
-
-	// test vFuture proto with applications
-	sd = StateDelta{"key": ValueDelta{Action: SetBytesAction, Bytes: "val"}}
-	protoF := config.Consensus[protocol.ConsensusFuture]
-	err = sd.Valid(&protoF)
-	a.NoError(err)
-
-	// vFuture: key too long, short value
-	tooLongKey := strings.Repeat("a", protoF.MaxAppKeyLen+1)
-	sd = StateDelta{tooLongKey: ValueDelta{Action: SetBytesAction, Bytes: "val"}}
-	err = sd.Valid(&protoF)
-	a.Error(err)
-	a.Contains(err.Error(), "key too long")
-	delete(sd, tooLongKey)
-
-	// vFuture: max size key, value too long: total size bigger than MaxAppSumKeyValueLens
-	longKey := tooLongKey[1:]
-	tooLongValue := strings.Repeat("b", protoF.MaxAppSumKeyValueLens-len(longKey)+1)
-	sd = StateDelta{longKey: ValueDelta{Action: SetBytesAction, Bytes: tooLongValue}}
-	err = sd.Valid(&protoF)
-	a.Error(err)
-	a.Contains(err.Error(), "key/value total too long for key")
-
-	sd[longKey] = ValueDelta{Action: SetBytesAction, Bytes: tooLongValue[1:]}
-	sd["intval"] = ValueDelta{Action: DeltaAction(10), Uint: 0}
-	err = sd.Valid(&protoF)
-	a.Error(err)
-	a.Contains(err.Error(), "unknown delta action")
-
-	sd["intval"] = ValueDelta{Action: SetUintAction, Uint: 0}
-	sd["delval"] = ValueDelta{Action: DeleteAction, Uint: 0, Bytes: tooLongValue}
-	err = sd.Valid(&protoF)
-	a.NoError(err)
-}
-
-func TestStateDeltaValidV24(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	a := require.New(t)
-
-	// v24: short key, value too long: hits MaxAppBytesValueLen
-	protoV24 := config.Consensus[protocol.ConsensusV24]
-	shortKey := "k"
-	reallyLongValue := strings.Repeat("b", protoV24.MaxAppBytesValueLen+1)
-	sd := StateDelta{shortKey: ValueDelta{Action: SetBytesAction, Bytes: reallyLongValue}}
-	err := sd.Valid(&protoV24)
-	a.Error(err)
-	a.Contains(err.Error(), "value too long for key")
-
-	// v24: key too long, short value
-	tooLongKey := strings.Repeat("a", protoV24.MaxAppKeyLen+1)
-	sd = StateDelta{tooLongKey: ValueDelta{Action: SetBytesAction, Bytes: "val"}}
-	err = sd.Valid(&protoV24)
-	a.Error(err)
-	a.Contains(err.Error(), "key too long")
-	delete(sd, tooLongKey)
-}
 
 func TestStateDeltaEqual(t *testing.T) {
 	partitiontest.PartitionTest(t)


### PR DESCRIPTION
## Summary

It was not used anywhere. Presumably, it was written thinking that a StateDelta would be check after making it. But instead, each step of creating the StateDelta is checked.


<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

I guess if it compiles, I was right!

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
