### PR TITLE
Chore: Move allocbounds

### DIFF
--- a/agreement/bundle.go
+++ b/agreement/bundle.go
@@ -36,8 +36,8 @@ type unauthenticatedBundle struct {
 	Step     step          `codec:"step"`
 	Proposal proposalValue `codec:"prop"`
 
-	Votes             []voteAuthenticator             `codec:"vote,allocbound=config.MaxVoteThreshold"`
-	EquivocationVotes []equivocationVoteAuthenticator `codec:"eqv,allocbound=config.MaxVoteThreshold"`
+	Votes             []voteAuthenticator             `codec:"vote,allocbound=bounds.MaxVoteThreshold"`
+	EquivocationVotes []equivocationVoteAuthenticator `codec:"eqv,allocbound=bounds.MaxVoteThreshold"`
 }
 
 // bundle is a set of votes, all from the same round, period, and step, and from distinct senders, that reaches quorum.
@@ -48,8 +48,8 @@ type bundle struct {
 
 	U unauthenticatedBundle `codec:"u"`
 
-	Votes             []vote             `codec:"vote,allocbound=config.MaxVoteThreshold"`
-	EquivocationVotes []equivocationVote `codec:"eqv,allocbound=config.MaxVoteThreshold"`
+	Votes             []vote             `codec:"vote,allocbound=bounds.MaxVoteThreshold"`
+	EquivocationVotes []equivocationVote `codec:"eqv,allocbound=bounds.MaxVoteThreshold"`
 }
 
 // voteAuthenticators omit the Round, Period, Step, and Proposal for compression

--- a/agreement/msgp_gen.go
+++ b/agreement/msgp_gen.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/algorand/msgp/msgp"
 
-	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
@@ -680,8 +680,8 @@ func (z *Certificate) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "Votes")
 				return
 			}
-			if zb0007 > config.MaxVoteThreshold {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxVoteThreshold))
+			if zb0007 > bounds.MaxVoteThreshold {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(bounds.MaxVoteThreshold))
 				err = msgp.WrapError(err, "struct-from-array", "Votes")
 				return
 			}
@@ -709,8 +709,8 @@ func (z *Certificate) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "EquivocationVotes")
 				return
 			}
-			if zb0009 > config.MaxVoteThreshold {
-				err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxVoteThreshold))
+			if zb0009 > bounds.MaxVoteThreshold {
+				err = msgp.ErrOverflow(uint64(zb0009), uint64(bounds.MaxVoteThreshold))
 				err = msgp.WrapError(err, "struct-from-array", "EquivocationVotes")
 				return
 			}
@@ -792,8 +792,8 @@ func (z *Certificate) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "Votes")
 					return
 				}
-				if zb0013 > config.MaxVoteThreshold {
-					err = msgp.ErrOverflow(uint64(zb0013), uint64(config.MaxVoteThreshold))
+				if zb0013 > bounds.MaxVoteThreshold {
+					err = msgp.ErrOverflow(uint64(zb0013), uint64(bounds.MaxVoteThreshold))
 					err = msgp.WrapError(err, "Votes")
 					return
 				}
@@ -819,8 +819,8 @@ func (z *Certificate) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "EquivocationVotes")
 					return
 				}
-				if zb0015 > config.MaxVoteThreshold {
-					err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxVoteThreshold))
+				if zb0015 > bounds.MaxVoteThreshold {
+					err = msgp.ErrOverflow(uint64(zb0015), uint64(bounds.MaxVoteThreshold))
 					err = msgp.WrapError(err, "EquivocationVotes")
 					return
 				}
@@ -881,10 +881,10 @@ func (z *Certificate) MsgIsZero() bool {
 func CertificateMaxSize() (s int) {
 	s = 1 + 4 + basics.RoundMaxSize() + 4 + msgp.Uint64Size + 5 + msgp.Uint64Size + 5 + ProposalValueMaxSize() + 5
 	// Calculating size of slice: z.Votes
-	s += msgp.ArrayHeaderSize + ((config.MaxVoteThreshold) * (VoteAuthenticatorMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxVoteThreshold) * (VoteAuthenticatorMaxSize()))
 	s += 4
 	// Calculating size of slice: z.EquivocationVotes
-	s += msgp.ArrayHeaderSize + ((config.MaxVoteThreshold) * (EquivocationVoteAuthenticatorMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxVoteThreshold) * (EquivocationVoteAuthenticatorMaxSize()))
 	return
 }
 
@@ -1682,8 +1682,8 @@ func (z *bundle) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []
 				err = msgp.WrapError(err, "struct-from-array", "Votes")
 				return
 			}
-			if zb0005 > config.MaxVoteThreshold {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(config.MaxVoteThreshold))
+			if zb0005 > bounds.MaxVoteThreshold {
+				err = msgp.ErrOverflow(uint64(zb0005), uint64(bounds.MaxVoteThreshold))
 				err = msgp.WrapError(err, "struct-from-array", "Votes")
 				return
 			}
@@ -1711,8 +1711,8 @@ func (z *bundle) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []
 				err = msgp.WrapError(err, "struct-from-array", "EquivocationVotes")
 				return
 			}
-			if zb0007 > config.MaxVoteThreshold {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxVoteThreshold))
+			if zb0007 > bounds.MaxVoteThreshold {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(bounds.MaxVoteThreshold))
 				err = msgp.WrapError(err, "struct-from-array", "EquivocationVotes")
 				return
 			}
@@ -1768,8 +1768,8 @@ func (z *bundle) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []
 					err = msgp.WrapError(err, "Votes")
 					return
 				}
-				if zb0009 > config.MaxVoteThreshold {
-					err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxVoteThreshold))
+				if zb0009 > bounds.MaxVoteThreshold {
+					err = msgp.ErrOverflow(uint64(zb0009), uint64(bounds.MaxVoteThreshold))
 					err = msgp.WrapError(err, "Votes")
 					return
 				}
@@ -1795,8 +1795,8 @@ func (z *bundle) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []
 					err = msgp.WrapError(err, "EquivocationVotes")
 					return
 				}
-				if zb0011 > config.MaxVoteThreshold {
-					err = msgp.ErrOverflow(uint64(zb0011), uint64(config.MaxVoteThreshold))
+				if zb0011 > bounds.MaxVoteThreshold {
+					err = msgp.ErrOverflow(uint64(zb0011), uint64(bounds.MaxVoteThreshold))
 					err = msgp.WrapError(err, "EquivocationVotes")
 					return
 				}
@@ -1857,10 +1857,10 @@ func (z *bundle) MsgIsZero() bool {
 func BundleMaxSize() (s int) {
 	s = 1 + 2 + UnauthenticatedBundleMaxSize() + 5
 	// Calculating size of slice: z.Votes
-	s += msgp.ArrayHeaderSize + ((config.MaxVoteThreshold) * (VoteMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxVoteThreshold) * (VoteMaxSize()))
 	s += 4
 	// Calculating size of slice: z.EquivocationVotes
-	s += msgp.ArrayHeaderSize + ((config.MaxVoteThreshold) * (EquivocationVoteMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxVoteThreshold) * (EquivocationVoteMaxSize()))
 	return
 }
 
@@ -4916,8 +4916,8 @@ func (z *proposal) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o 
 				err = msgp.WrapError(err, "struct-from-array", "GenesisID")
 				return
 			}
-			if zb0007 > config.MaxGenesisIDLen {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxGenesisIDLen))
+			if zb0007 > bounds.MaxGenesisIDLen {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(bounds.MaxGenesisIDLen))
 				return
 			}
 			(*z).unauthenticatedProposal.Block.BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -5131,8 +5131,8 @@ func (z *proposal) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o 
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0010 > config.MaxProposedExpiredOnlineAccounts {
-				err = msgp.ErrOverflow(uint64(zb0010), uint64(config.MaxProposedExpiredOnlineAccounts))
+			if zb0010 > bounds.MaxProposedExpiredOnlineAccounts {
+				err = msgp.ErrOverflow(uint64(zb0010), uint64(bounds.MaxProposedExpiredOnlineAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
@@ -5160,8 +5160,8 @@ func (z *proposal) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o 
 				err = msgp.WrapError(err, "struct-from-array", "AbsentParticipationAccounts")
 				return
 			}
-			if zb0012 > config.MaxMarkAbsent {
-				err = msgp.ErrOverflow(uint64(zb0012), uint64(config.MaxMarkAbsent))
+			if zb0012 > bounds.MaxMarkAbsent {
+				err = msgp.ErrOverflow(uint64(zb0012), uint64(bounds.MaxMarkAbsent))
 				err = msgp.WrapError(err, "struct-from-array", "AbsentParticipationAccounts")
 				return
 			}
@@ -5282,8 +5282,8 @@ func (z *proposal) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o 
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
-				if zb0015 > config.MaxGenesisIDLen {
-					err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxGenesisIDLen))
+				if zb0015 > bounds.MaxGenesisIDLen {
+					err = msgp.ErrOverflow(uint64(zb0015), uint64(bounds.MaxGenesisIDLen))
 					return
 				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -5453,8 +5453,8 @@ func (z *proposal) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o 
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0018 > config.MaxProposedExpiredOnlineAccounts {
-					err = msgp.ErrOverflow(uint64(zb0018), uint64(config.MaxProposedExpiredOnlineAccounts))
+				if zb0018 > bounds.MaxProposedExpiredOnlineAccounts {
+					err = msgp.ErrOverflow(uint64(zb0018), uint64(bounds.MaxProposedExpiredOnlineAccounts))
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
@@ -5480,8 +5480,8 @@ func (z *proposal) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o 
 					err = msgp.WrapError(err, "AbsentParticipationAccounts")
 					return
 				}
-				if zb0020 > config.MaxMarkAbsent {
-					err = msgp.ErrOverflow(uint64(zb0020), uint64(config.MaxMarkAbsent))
+				if zb0020 > bounds.MaxMarkAbsent {
+					err = msgp.ErrOverflow(uint64(zb0020), uint64(bounds.MaxMarkAbsent))
 					err = msgp.WrapError(err, "AbsentParticipationAccounts")
 					return
 				}
@@ -5577,7 +5577,7 @@ func (z *proposal) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func ProposalMaxSize() (s int) {
-	s = 3 + 4 + basics.RoundMaxSize() + 5 + bookkeeping.BlockHashMaxSize() + 5 + committee.SeedMaxSize() + 4 + crypto.DigestMaxSize() + 7 + crypto.DigestMaxSize() + 3 + msgp.Int64Size + 4 + msgp.StringPrefixSize + config.MaxGenesisIDLen + 3 + crypto.DigestMaxSize() + 4 + basics.AddressMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 5 + basics.AddressMaxSize() + 4 + basics.AddressMaxSize() + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 7 + basics.RoundMaxSize() + 6 + protocol.ConsensusVersionMaxSize() + 10 + protocol.ConsensusVersionMaxSize() + 8 + msgp.Uint64Size + 11 + basics.RoundMaxSize() + 11 + basics.RoundMaxSize() + 12 + protocol.ConsensusVersionMaxSize() + 13 + basics.RoundMaxSize() + 11 + msgp.BoolSize + 3 + msgp.Uint64Size + 4
+	s = 3 + 4 + basics.RoundMaxSize() + 5 + bookkeeping.BlockHashMaxSize() + 5 + committee.SeedMaxSize() + 4 + crypto.DigestMaxSize() + 7 + crypto.DigestMaxSize() + 3 + msgp.Int64Size + 4 + msgp.StringPrefixSize + bounds.MaxGenesisIDLen + 3 + crypto.DigestMaxSize() + 4 + basics.AddressMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 5 + basics.AddressMaxSize() + 4 + basics.AddressMaxSize() + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 7 + basics.RoundMaxSize() + 6 + protocol.ConsensusVersionMaxSize() + 10 + protocol.ConsensusVersionMaxSize() + 8 + msgp.Uint64Size + 11 + basics.RoundMaxSize() + 11 + basics.RoundMaxSize() + 12 + protocol.ConsensusVersionMaxSize() + 13 + basics.RoundMaxSize() + 11 + msgp.BoolSize + 3 + msgp.Uint64Size + 4
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.unauthenticatedProposal.Block.BlockHeader.StateProofTracking
 	s += protocol.NumStateProofTypes * (protocol.StateProofTypeMaxSize())
@@ -5585,13 +5585,13 @@ func ProposalMaxSize() (s int) {
 	s += protocol.NumStateProofTypes * (bookkeeping.StateProofTrackingDataMaxSize())
 	s += 11
 	// Calculating size of slice: z.unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts
-	s += msgp.ArrayHeaderSize + ((config.MaxProposedExpiredOnlineAccounts) * (basics.AddressMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxProposedExpiredOnlineAccounts) * (basics.AddressMaxSize()))
 	s += 11
 	// Calculating size of slice: z.unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.AbsentParticipationAccounts
-	s += msgp.ArrayHeaderSize + ((config.MaxMarkAbsent) * (basics.AddressMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxMarkAbsent) * (basics.AddressMaxSize()))
 	s += 5
 	// Using maxtotalbytes for: z.unauthenticatedProposal.Block.Payset
-	s += config.MaxTxnBytesPerBlock
+	s += bounds.MaxTxnBytesPerBlock
 	s += 5 + crypto.VrfProofMaxSize() + 5 + msgp.Uint64Size + 6 + basics.AddressMaxSize()
 	return
 }
@@ -9459,8 +9459,8 @@ func (z *transmittedPayload) UnmarshalMsgWithState(bts []byte, st msgp.Unmarshal
 				err = msgp.WrapError(err, "struct-from-array", "GenesisID")
 				return
 			}
-			if zb0007 > config.MaxGenesisIDLen {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxGenesisIDLen))
+			if zb0007 > bounds.MaxGenesisIDLen {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(bounds.MaxGenesisIDLen))
 				return
 			}
 			(*z).unauthenticatedProposal.Block.BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -9674,8 +9674,8 @@ func (z *transmittedPayload) UnmarshalMsgWithState(bts []byte, st msgp.Unmarshal
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0010 > config.MaxProposedExpiredOnlineAccounts {
-				err = msgp.ErrOverflow(uint64(zb0010), uint64(config.MaxProposedExpiredOnlineAccounts))
+			if zb0010 > bounds.MaxProposedExpiredOnlineAccounts {
+				err = msgp.ErrOverflow(uint64(zb0010), uint64(bounds.MaxProposedExpiredOnlineAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
@@ -9703,8 +9703,8 @@ func (z *transmittedPayload) UnmarshalMsgWithState(bts []byte, st msgp.Unmarshal
 				err = msgp.WrapError(err, "struct-from-array", "AbsentParticipationAccounts")
 				return
 			}
-			if zb0012 > config.MaxMarkAbsent {
-				err = msgp.ErrOverflow(uint64(zb0012), uint64(config.MaxMarkAbsent))
+			if zb0012 > bounds.MaxMarkAbsent {
+				err = msgp.ErrOverflow(uint64(zb0012), uint64(bounds.MaxMarkAbsent))
 				err = msgp.WrapError(err, "struct-from-array", "AbsentParticipationAccounts")
 				return
 			}
@@ -9833,8 +9833,8 @@ func (z *transmittedPayload) UnmarshalMsgWithState(bts []byte, st msgp.Unmarshal
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
-				if zb0015 > config.MaxGenesisIDLen {
-					err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxGenesisIDLen))
+				if zb0015 > bounds.MaxGenesisIDLen {
+					err = msgp.ErrOverflow(uint64(zb0015), uint64(bounds.MaxGenesisIDLen))
 					return
 				}
 				(*z).unauthenticatedProposal.Block.BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -10004,8 +10004,8 @@ func (z *transmittedPayload) UnmarshalMsgWithState(bts []byte, st msgp.Unmarshal
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0018 > config.MaxProposedExpiredOnlineAccounts {
-					err = msgp.ErrOverflow(uint64(zb0018), uint64(config.MaxProposedExpiredOnlineAccounts))
+				if zb0018 > bounds.MaxProposedExpiredOnlineAccounts {
+					err = msgp.ErrOverflow(uint64(zb0018), uint64(bounds.MaxProposedExpiredOnlineAccounts))
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
@@ -10031,8 +10031,8 @@ func (z *transmittedPayload) UnmarshalMsgWithState(bts []byte, st msgp.Unmarshal
 					err = msgp.WrapError(err, "AbsentParticipationAccounts")
 					return
 				}
-				if zb0020 > config.MaxMarkAbsent {
-					err = msgp.ErrOverflow(uint64(zb0020), uint64(config.MaxMarkAbsent))
+				if zb0020 > bounds.MaxMarkAbsent {
+					err = msgp.ErrOverflow(uint64(zb0020), uint64(bounds.MaxMarkAbsent))
 					err = msgp.WrapError(err, "AbsentParticipationAccounts")
 					return
 				}
@@ -10134,7 +10134,7 @@ func (z *transmittedPayload) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func TransmittedPayloadMaxSize() (s int) {
-	s = 3 + 4 + basics.RoundMaxSize() + 5 + bookkeeping.BlockHashMaxSize() + 5 + committee.SeedMaxSize() + 4 + crypto.DigestMaxSize() + 7 + crypto.DigestMaxSize() + 3 + msgp.Int64Size + 4 + msgp.StringPrefixSize + config.MaxGenesisIDLen + 3 + crypto.DigestMaxSize() + 4 + basics.AddressMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 5 + basics.AddressMaxSize() + 4 + basics.AddressMaxSize() + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 7 + basics.RoundMaxSize() + 6 + protocol.ConsensusVersionMaxSize() + 10 + protocol.ConsensusVersionMaxSize() + 8 + msgp.Uint64Size + 11 + basics.RoundMaxSize() + 11 + basics.RoundMaxSize() + 12 + protocol.ConsensusVersionMaxSize() + 13 + basics.RoundMaxSize() + 11 + msgp.BoolSize + 3 + msgp.Uint64Size + 4
+	s = 3 + 4 + basics.RoundMaxSize() + 5 + bookkeeping.BlockHashMaxSize() + 5 + committee.SeedMaxSize() + 4 + crypto.DigestMaxSize() + 7 + crypto.DigestMaxSize() + 3 + msgp.Int64Size + 4 + msgp.StringPrefixSize + bounds.MaxGenesisIDLen + 3 + crypto.DigestMaxSize() + 4 + basics.AddressMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 5 + basics.AddressMaxSize() + 4 + basics.AddressMaxSize() + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 7 + basics.RoundMaxSize() + 6 + protocol.ConsensusVersionMaxSize() + 10 + protocol.ConsensusVersionMaxSize() + 8 + msgp.Uint64Size + 11 + basics.RoundMaxSize() + 11 + basics.RoundMaxSize() + 12 + protocol.ConsensusVersionMaxSize() + 13 + basics.RoundMaxSize() + 11 + msgp.BoolSize + 3 + msgp.Uint64Size + 4
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.unauthenticatedProposal.Block.BlockHeader.StateProofTracking
 	s += protocol.NumStateProofTypes * (protocol.StateProofTypeMaxSize())
@@ -10142,13 +10142,13 @@ func TransmittedPayloadMaxSize() (s int) {
 	s += protocol.NumStateProofTypes * (bookkeeping.StateProofTrackingDataMaxSize())
 	s += 11
 	// Calculating size of slice: z.unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts
-	s += msgp.ArrayHeaderSize + ((config.MaxProposedExpiredOnlineAccounts) * (basics.AddressMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxProposedExpiredOnlineAccounts) * (basics.AddressMaxSize()))
 	s += 11
 	// Calculating size of slice: z.unauthenticatedProposal.Block.BlockHeader.ParticipationUpdates.AbsentParticipationAccounts
-	s += msgp.ArrayHeaderSize + ((config.MaxMarkAbsent) * (basics.AddressMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxMarkAbsent) * (basics.AddressMaxSize()))
 	s += 5
 	// Using maxtotalbytes for: z.unauthenticatedProposal.Block.Payset
-	s += config.MaxTxnBytesPerBlock
+	s += bounds.MaxTxnBytesPerBlock
 	s += 5 + crypto.VrfProofMaxSize() + 5 + msgp.Uint64Size + 6 + basics.AddressMaxSize() + 3 + UnauthenticatedVoteMaxSize()
 	return
 }
@@ -10306,8 +10306,8 @@ func (z *unauthenticatedBundle) UnmarshalMsgWithState(bts []byte, st msgp.Unmars
 				err = msgp.WrapError(err, "struct-from-array", "Votes")
 				return
 			}
-			if zb0007 > config.MaxVoteThreshold {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxVoteThreshold))
+			if zb0007 > bounds.MaxVoteThreshold {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(bounds.MaxVoteThreshold))
 				err = msgp.WrapError(err, "struct-from-array", "Votes")
 				return
 			}
@@ -10335,8 +10335,8 @@ func (z *unauthenticatedBundle) UnmarshalMsgWithState(bts []byte, st msgp.Unmars
 				err = msgp.WrapError(err, "struct-from-array", "EquivocationVotes")
 				return
 			}
-			if zb0009 > config.MaxVoteThreshold {
-				err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxVoteThreshold))
+			if zb0009 > bounds.MaxVoteThreshold {
+				err = msgp.ErrOverflow(uint64(zb0009), uint64(bounds.MaxVoteThreshold))
 				err = msgp.WrapError(err, "struct-from-array", "EquivocationVotes")
 				return
 			}
@@ -10418,8 +10418,8 @@ func (z *unauthenticatedBundle) UnmarshalMsgWithState(bts []byte, st msgp.Unmars
 					err = msgp.WrapError(err, "Votes")
 					return
 				}
-				if zb0013 > config.MaxVoteThreshold {
-					err = msgp.ErrOverflow(uint64(zb0013), uint64(config.MaxVoteThreshold))
+				if zb0013 > bounds.MaxVoteThreshold {
+					err = msgp.ErrOverflow(uint64(zb0013), uint64(bounds.MaxVoteThreshold))
 					err = msgp.WrapError(err, "Votes")
 					return
 				}
@@ -10445,8 +10445,8 @@ func (z *unauthenticatedBundle) UnmarshalMsgWithState(bts []byte, st msgp.Unmars
 					err = msgp.WrapError(err, "EquivocationVotes")
 					return
 				}
-				if zb0015 > config.MaxVoteThreshold {
-					err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxVoteThreshold))
+				if zb0015 > bounds.MaxVoteThreshold {
+					err = msgp.ErrOverflow(uint64(zb0015), uint64(bounds.MaxVoteThreshold))
 					err = msgp.WrapError(err, "EquivocationVotes")
 					return
 				}
@@ -10507,10 +10507,10 @@ func (z *unauthenticatedBundle) MsgIsZero() bool {
 func UnauthenticatedBundleMaxSize() (s int) {
 	s = 1 + 4 + basics.RoundMaxSize() + 4 + msgp.Uint64Size + 5 + msgp.Uint64Size + 5 + ProposalValueMaxSize() + 5
 	// Calculating size of slice: z.Votes
-	s += msgp.ArrayHeaderSize + ((config.MaxVoteThreshold) * (VoteAuthenticatorMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxVoteThreshold) * (VoteAuthenticatorMaxSize()))
 	s += 4
 	// Calculating size of slice: z.EquivocationVotes
-	s += msgp.ArrayHeaderSize + ((config.MaxVoteThreshold) * (EquivocationVoteAuthenticatorMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxVoteThreshold) * (EquivocationVoteAuthenticatorMaxSize()))
 	return
 }
 
@@ -11281,8 +11281,8 @@ func (z *unauthenticatedProposal) UnmarshalMsgWithState(bts []byte, st msgp.Unma
 				err = msgp.WrapError(err, "struct-from-array", "GenesisID")
 				return
 			}
-			if zb0007 > config.MaxGenesisIDLen {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxGenesisIDLen))
+			if zb0007 > bounds.MaxGenesisIDLen {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(bounds.MaxGenesisIDLen))
 				return
 			}
 			(*z).Block.BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -11496,8 +11496,8 @@ func (z *unauthenticatedProposal) UnmarshalMsgWithState(bts []byte, st msgp.Unma
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0010 > config.MaxProposedExpiredOnlineAccounts {
-				err = msgp.ErrOverflow(uint64(zb0010), uint64(config.MaxProposedExpiredOnlineAccounts))
+			if zb0010 > bounds.MaxProposedExpiredOnlineAccounts {
+				err = msgp.ErrOverflow(uint64(zb0010), uint64(bounds.MaxProposedExpiredOnlineAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
@@ -11525,8 +11525,8 @@ func (z *unauthenticatedProposal) UnmarshalMsgWithState(bts []byte, st msgp.Unma
 				err = msgp.WrapError(err, "struct-from-array", "AbsentParticipationAccounts")
 				return
 			}
-			if zb0012 > config.MaxMarkAbsent {
-				err = msgp.ErrOverflow(uint64(zb0012), uint64(config.MaxMarkAbsent))
+			if zb0012 > bounds.MaxMarkAbsent {
+				err = msgp.ErrOverflow(uint64(zb0012), uint64(bounds.MaxMarkAbsent))
 				err = msgp.WrapError(err, "struct-from-array", "AbsentParticipationAccounts")
 				return
 			}
@@ -11647,8 +11647,8 @@ func (z *unauthenticatedProposal) UnmarshalMsgWithState(bts []byte, st msgp.Unma
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
-				if zb0015 > config.MaxGenesisIDLen {
-					err = msgp.ErrOverflow(uint64(zb0015), uint64(config.MaxGenesisIDLen))
+				if zb0015 > bounds.MaxGenesisIDLen {
+					err = msgp.ErrOverflow(uint64(zb0015), uint64(bounds.MaxGenesisIDLen))
 					return
 				}
 				(*z).Block.BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -11818,8 +11818,8 @@ func (z *unauthenticatedProposal) UnmarshalMsgWithState(bts []byte, st msgp.Unma
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0018 > config.MaxProposedExpiredOnlineAccounts {
-					err = msgp.ErrOverflow(uint64(zb0018), uint64(config.MaxProposedExpiredOnlineAccounts))
+				if zb0018 > bounds.MaxProposedExpiredOnlineAccounts {
+					err = msgp.ErrOverflow(uint64(zb0018), uint64(bounds.MaxProposedExpiredOnlineAccounts))
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
@@ -11845,8 +11845,8 @@ func (z *unauthenticatedProposal) UnmarshalMsgWithState(bts []byte, st msgp.Unma
 					err = msgp.WrapError(err, "AbsentParticipationAccounts")
 					return
 				}
-				if zb0020 > config.MaxMarkAbsent {
-					err = msgp.ErrOverflow(uint64(zb0020), uint64(config.MaxMarkAbsent))
+				if zb0020 > bounds.MaxMarkAbsent {
+					err = msgp.ErrOverflow(uint64(zb0020), uint64(bounds.MaxMarkAbsent))
 					err = msgp.WrapError(err, "AbsentParticipationAccounts")
 					return
 				}
@@ -11942,7 +11942,7 @@ func (z *unauthenticatedProposal) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func UnauthenticatedProposalMaxSize() (s int) {
-	s = 3 + 4 + basics.RoundMaxSize() + 5 + bookkeeping.BlockHashMaxSize() + 5 + committee.SeedMaxSize() + 4 + crypto.DigestMaxSize() + 7 + crypto.DigestMaxSize() + 3 + msgp.Int64Size + 4 + msgp.StringPrefixSize + config.MaxGenesisIDLen + 3 + crypto.DigestMaxSize() + 4 + basics.AddressMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 5 + basics.AddressMaxSize() + 4 + basics.AddressMaxSize() + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 7 + basics.RoundMaxSize() + 6 + protocol.ConsensusVersionMaxSize() + 10 + protocol.ConsensusVersionMaxSize() + 8 + msgp.Uint64Size + 11 + basics.RoundMaxSize() + 11 + basics.RoundMaxSize() + 12 + protocol.ConsensusVersionMaxSize() + 13 + basics.RoundMaxSize() + 11 + msgp.BoolSize + 3 + msgp.Uint64Size + 4
+	s = 3 + 4 + basics.RoundMaxSize() + 5 + bookkeeping.BlockHashMaxSize() + 5 + committee.SeedMaxSize() + 4 + crypto.DigestMaxSize() + 7 + crypto.DigestMaxSize() + 3 + msgp.Int64Size + 4 + msgp.StringPrefixSize + bounds.MaxGenesisIDLen + 3 + crypto.DigestMaxSize() + 4 + basics.AddressMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 5 + basics.AddressMaxSize() + 4 + basics.AddressMaxSize() + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 7 + basics.RoundMaxSize() + 6 + protocol.ConsensusVersionMaxSize() + 10 + protocol.ConsensusVersionMaxSize() + 8 + msgp.Uint64Size + 11 + basics.RoundMaxSize() + 11 + basics.RoundMaxSize() + 12 + protocol.ConsensusVersionMaxSize() + 13 + basics.RoundMaxSize() + 11 + msgp.BoolSize + 3 + msgp.Uint64Size + 4
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.Block.BlockHeader.StateProofTracking
 	s += protocol.NumStateProofTypes * (protocol.StateProofTypeMaxSize())
@@ -11950,13 +11950,13 @@ func UnauthenticatedProposalMaxSize() (s int) {
 	s += protocol.NumStateProofTypes * (bookkeeping.StateProofTrackingDataMaxSize())
 	s += 11
 	// Calculating size of slice: z.Block.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts
-	s += msgp.ArrayHeaderSize + ((config.MaxProposedExpiredOnlineAccounts) * (basics.AddressMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxProposedExpiredOnlineAccounts) * (basics.AddressMaxSize()))
 	s += 11
 	// Calculating size of slice: z.Block.BlockHeader.ParticipationUpdates.AbsentParticipationAccounts
-	s += msgp.ArrayHeaderSize + ((config.MaxMarkAbsent) * (basics.AddressMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxMarkAbsent) * (basics.AddressMaxSize()))
 	s += 5
 	// Using maxtotalbytes for: z.Block.Payset
-	s += config.MaxTxnBytesPerBlock
+	s += bounds.MaxTxnBytesPerBlock
 	s += 5 + crypto.VrfProofMaxSize() + 5 + msgp.Uint64Size + 6 + basics.AddressMaxSize()
 	return
 }

--- a/config/bounds/bounds.go
+++ b/config/bounds/bounds.go
@@ -148,3 +148,7 @@ const EncodedMaxAppParams = 64
 // config.Consensus[protocol.ConsensusCurrentVersion].MaxLocalSchemaEntries and
 // config.Consensus[protocol.ConsensusCurrentVersion].MaxGlobalSchemaEntries
 const EncodedMaxKeyValueEntries = 1024
+
+// MaxConsensusVersionLen must be larger than any URL length of any consensus
+// version (which is currently URL+hash=89)
+const MaxConsensusVersionLen = 128

--- a/config/bounds/bounds.go
+++ b/config/bounds/bounds.go
@@ -1,0 +1,150 @@
+// Copyright (C) 2019-2025 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package bounds
+
+/* The bounds package is intended to hold conservative bounds on the sizes of
+   various messages.  Many cannot be static, because they depend on consensus
+   parameters. They are set at runtime iterating over every consensus version
+   and selecting the largest bound.  This allows msgpack parsing to safely
+   reject anything that NO consensus version would allow.
+*/
+
+// MaxVoteThreshold is the largest threshold for a bundle over all supported
+// consensus protocols, used for decoding purposes.
+var MaxVoteThreshold int
+
+// MaxEvalDeltaAccounts is the largest number of accounts that may appear in an
+// eval delta, used for decoding purposes.
+var MaxEvalDeltaAccounts int
+
+// MaxStateDeltaKeys is the largest number of key/value pairs that may appear in
+// a StateDelta, used for decoding purposes.
+var MaxStateDeltaKeys int
+
+// MaxLogCalls is the highest allowable log messages that may appear in any
+// version, used only for decoding purposes. Never decrease this value.
+var MaxLogCalls int
+
+// MaxInnerTransactionsPerDelta is the maximum number of inner transactions in
+// one EvalDelta
+var MaxInnerTransactionsPerDelta int
+
+// MaxLogicSigMaxSize is the largest logical signature appear in any of the
+// supported protocols, used for decoding purposes.
+var MaxLogicSigMaxSize int
+
+// MaxTxnNoteBytes is the largest supported nodes field array size supported by
+// any of the consensus protocols. used for decoding purposes.
+var MaxTxnNoteBytes int
+
+// MaxTxGroupSize is the largest supported number of transactions per
+// transaction group supported by any of the consensus protocols. used for
+// decoding purposes.
+var MaxTxGroupSize int
+
+// MaxAppProgramLen is the largest supported app program size supported by any
+// of the consensus protocols. used for decoding purposes.
+var MaxAppProgramLen int
+
+// MaxBytesKeyValueLen is a maximum length of key or value across all protocols.
+// used for decoding purposes.
+var MaxBytesKeyValueLen int
+
+// MaxExtraAppProgramLen is the maximum extra app program length supported by
+// any of the consensus protocols. used for decoding purposes.
+var MaxExtraAppProgramLen int
+
+// MaxAvailableAppProgramLen is the largest supported app program size including
+// the extra pages supported by any of the consensus protocols. used for
+// decoding purposes.
+var MaxAvailableAppProgramLen int
+
+// MaxProposedExpiredOnlineAccounts is the maximum number of online accounts
+// that a proposer can take offline for having expired voting keys.
+var MaxProposedExpiredOnlineAccounts int
+
+// MaxMarkAbsent is the maximum number of online accounts that a proposer can
+// suspend for not proposing "lately"
+var MaxMarkAbsent int
+
+// MaxAppTotalArgLen is the maximum number of bytes across all arguments of an
+// application max sum([len(arg) for arg in txn.ApplicationArgs])
+var MaxAppTotalArgLen int
+
+// MaxAssetNameBytes is the maximum asset name length in bytes
+var MaxAssetNameBytes int
+
+// MaxAssetUnitNameBytes is the maximum asset unit name length in bytes
+var MaxAssetUnitNameBytes int
+
+// MaxAssetURLBytes is the maximum asset URL length in bytes
+var MaxAssetURLBytes int
+
+// MaxAppBytesValueLen is the maximum length of a bytes value used in an
+// application's global or local key/value store
+var MaxAppBytesValueLen int
+
+// MaxAppBytesKeyLen is the maximum length of a key used in an application's
+// global or local key/value store
+var MaxAppBytesKeyLen int
+
+// StateProofTopVoters is a bound on how many online accounts get to participate
+// in forming the state proof, by including the top StateProofTopVoters accounts
+// (by normalized balance) into the vector commitment.
+var StateProofTopVoters int
+
+// MaxTxnBytesPerBlock determines the maximum number of bytes that transactions
+// can take up in a block.  Specifically, the sum of the lengths of encodings of
+// each transaction in a block must not exceed MaxTxnBytesPerBlock.
+var MaxTxnBytesPerBlock int
+
+// MaxAppTxnForeignApps is the max number of foreign apps per txn across all consensus versions
+var MaxAppTxnForeignApps int
+
+// MaxEvalDeltaTotalLogSize is the maximum size of the sum of all log sizes in a single eval delta.
+const MaxEvalDeltaTotalLogSize = 1024
+
+// MaxGenesisIDLen is the maximum length of the genesis ID set for purpose of
+// setting allocbounds on structs containing GenesisID and for purposes of
+// calculating MaxSize functions on those types. Current value is larger than
+// the existing network IDs and the ones used in testing
+const MaxGenesisIDLen = 128
+
+// EncodedMaxAssetsPerAccount is the decoder limit of number of assets stored
+// per account.  it's being verified by the unit test
+// TestEncodedAccountAllocationBounds to align with
+// config.Consensus[protocol.ConsensusCurrentVersion].MaxAssetsPerAccount; note
+// that the decoded parameter is used only for protecting the decoder against
+// malicious encoded account data stream.  protocol-specific contents would be
+// tested once the decoding is complete.
+const EncodedMaxAssetsPerAccount = 1024
+
+// EncodedMaxAppLocalStates is the decoder limit for number of opted-in apps in a single account.
+// It is verified in TestEncodedAccountAllocationBounds to align with
+// config.Consensus[protocol.ConsensusCurrentVersion].MaxAppsOptedIn
+const EncodedMaxAppLocalStates = 64
+
+// EncodedMaxAppParams is the decoder limit for number of created apps in a single account.
+// It is verified in TestEncodedAccountAllocationBounds to align with
+// config.Consensus[protocol.ConsensusCurrentVersion].MaxAppsCreated
+const EncodedMaxAppParams = 64
+
+// EncodedMaxKeyValueEntries is the decoder limit for the length of a key/value store.
+// It is verified in TestEncodedAccountAllocationBounds to align with
+// config.Consensus[protocol.ConsensusCurrentVersion].MaxLocalSchemaEntries and
+// config.Consensus[protocol.ConsensusCurrentVersion].MaxGlobalSchemaEntries
+const EncodedMaxKeyValueEntries = 1024

--- a/config/config.go
+++ b/config/config.go
@@ -82,14 +82,6 @@ const ConfigurableConsensusProtocolsFilename = "consensus.json"
 // do not expose in normal config so it is not in code generated local_defaults.go
 const defaultRelayGossipFanout = 8
 
-// MaxGenesisIDLen is the maximum length of the genesis ID set for purpose of setting
-// allocbounds on structs containing GenesisID and for purposes of calculating MaxSize functions
-// on those types. Current value is larger than the existing network IDs and the ones used in testing
-const MaxGenesisIDLen = 128
-
-// MaxEvalDeltaTotalLogSize is the maximum size of the sum of all log sizes in a single eval delta.
-const MaxEvalDeltaTotalLogSize = 1024
-
 // CatchpointTrackingModeUntracked defines the CatchpointTracking mode that does _not_ track catchpoints
 const CatchpointTrackingModeUntracked = -1
 

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -19,6 +19,7 @@ package config
 import (
 	"time"
 
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -664,97 +665,6 @@ type ConsensusProtocols map[protocol.ConsensusVersion]ConsensusParams
 // consensus protocol.
 var Consensus ConsensusProtocols
 
-// MaxVoteThreshold is the largest threshold for a bundle over all supported
-// consensus protocols, used for decoding purposes.
-var MaxVoteThreshold int
-
-// MaxEvalDeltaAccounts is the largest number of accounts that may appear in
-// an eval delta, used for decoding purposes.
-var MaxEvalDeltaAccounts int
-
-// MaxStateDeltaKeys is the largest number of key/value pairs that may appear
-// in a StateDelta, used for decoding purposes.
-var MaxStateDeltaKeys int
-
-// MaxLogCalls is the highest allowable log messages that may appear in
-// any version, used only for decoding purposes. Never decrease this value.
-var MaxLogCalls int
-
-// MaxInnerTransactionsPerDelta is the maximum number of inner transactions in one EvalDelta
-var MaxInnerTransactionsPerDelta int
-
-// MaxLogicSigMaxSize is the largest logical signature appear in any of the supported
-// protocols, used for decoding purposes.
-var MaxLogicSigMaxSize int
-
-// MaxTxnNoteBytes is the largest supported nodes field array size supported by any
-// of the consensus protocols. used for decoding purposes.
-var MaxTxnNoteBytes int
-
-// MaxTxGroupSize is the largest supported number of transactions per transaction group supported by any
-// of the consensus protocols. used for decoding purposes.
-var MaxTxGroupSize int
-
-// MaxAppProgramLen is the largest supported app program size supported by any
-// of the consensus protocols. used for decoding purposes.
-var MaxAppProgramLen int
-
-// MaxBytesKeyValueLen is a maximum length of key or value across all protocols.
-// used for decoding purposes.
-var MaxBytesKeyValueLen int
-
-// MaxExtraAppProgramLen is the maximum extra app program length supported by any
-// of the consensus protocols. used for decoding purposes.
-var MaxExtraAppProgramLen int
-
-// MaxAvailableAppProgramLen is the largest supported app program size including the extra
-// pages supported by any of the consensus protocols. used for decoding purposes.
-var MaxAvailableAppProgramLen int
-
-// MaxProposedExpiredOnlineAccounts is the maximum number of online accounts
-// that a proposer can take offline for having expired voting keys.
-var MaxProposedExpiredOnlineAccounts int
-
-// MaxMarkAbsent is the maximum number of online accounts that a proposer can
-// suspend for not proposing "lately"
-var MaxMarkAbsent int
-
-// MaxAppTotalArgLen is the maximum number of bytes across all arguments of an application
-// max sum([len(arg) for arg in txn.ApplicationArgs])
-var MaxAppTotalArgLen int
-
-// MaxAssetNameBytes is the maximum asset name length in bytes
-var MaxAssetNameBytes int
-
-// MaxAssetUnitNameBytes is the maximum asset unit name length in bytes
-var MaxAssetUnitNameBytes int
-
-// MaxAssetURLBytes is the maximum asset URL length in bytes
-var MaxAssetURLBytes int
-
-// MaxAppBytesValueLen is the maximum length of a bytes value used in an application's global or
-// local key/value store
-var MaxAppBytesValueLen int
-
-// MaxAppBytesKeyLen is the maximum length of a key used in an application's global or local
-// key/value store
-var MaxAppBytesKeyLen int
-
-// StateProofTopVoters is a bound on how many online accounts get to
-// participate in forming the state proof, by including the
-// top StateProofTopVoters accounts (by normalized balance) into the
-// vector commitment.
-var StateProofTopVoters int
-
-// MaxTxnBytesPerBlock determines the maximum number of bytes
-// that transactions can take up in a block.  Specifically,
-// the sum of the lengths of encodings of each transaction
-// in a block must not exceed MaxTxnBytesPerBlock.
-var MaxTxnBytesPerBlock int
-
-// MaxAppTxnForeignApps is the max number of foreign apps per txn across all consensus versions
-var MaxAppTxnForeignApps int
-
 func checkSetMax(value int, curMax *int) {
 	if value > *curMax {
 		*curMax = value
@@ -765,47 +675,47 @@ func checkSetMax(value int, curMax *int) {
 // to enforce memory allocation limits. The values should be generous to
 // prevent correctness bugs, but not so large that DoS attacks are trivial
 func checkSetAllocBounds(p ConsensusParams) {
-	checkSetMax(int(p.SoftCommitteeThreshold), &MaxVoteThreshold)
-	checkSetMax(int(p.CertCommitteeThreshold), &MaxVoteThreshold)
-	checkSetMax(int(p.NextCommitteeThreshold), &MaxVoteThreshold)
-	checkSetMax(int(p.LateCommitteeThreshold), &MaxVoteThreshold)
-	checkSetMax(int(p.RedoCommitteeThreshold), &MaxVoteThreshold)
-	checkSetMax(int(p.DownCommitteeThreshold), &MaxVoteThreshold)
+	checkSetMax(int(p.SoftCommitteeThreshold), &bounds.MaxVoteThreshold)
+	checkSetMax(int(p.CertCommitteeThreshold), &bounds.MaxVoteThreshold)
+	checkSetMax(int(p.NextCommitteeThreshold), &bounds.MaxVoteThreshold)
+	checkSetMax(int(p.LateCommitteeThreshold), &bounds.MaxVoteThreshold)
+	checkSetMax(int(p.RedoCommitteeThreshold), &bounds.MaxVoteThreshold)
+	checkSetMax(int(p.DownCommitteeThreshold), &bounds.MaxVoteThreshold)
 
 	// These bounds could be tighter, but since these values are just to
 	// prevent DoS, setting them to be the maximum number of allowed
 	// executed TEAL instructions should be fine (order of ~1000)
-	checkSetMax(p.MaxAppProgramLen, &MaxStateDeltaKeys)
-	checkSetMax(p.MaxAppProgramLen, &MaxEvalDeltaAccounts)
-	checkSetMax(p.MaxAppProgramLen, &MaxAppProgramLen)
-	checkSetMax((int(p.LogicSigMaxSize) * p.MaxTxGroupSize), &MaxLogicSigMaxSize)
-	checkSetMax(p.MaxTxnNoteBytes, &MaxTxnNoteBytes)
-	checkSetMax(p.MaxTxGroupSize, &MaxTxGroupSize)
+	checkSetMax(p.MaxAppProgramLen, &bounds.MaxStateDeltaKeys)
+	checkSetMax(p.MaxAppProgramLen, &bounds.MaxEvalDeltaAccounts)
+	checkSetMax(p.MaxAppProgramLen, &bounds.MaxAppProgramLen)
+	checkSetMax((int(p.LogicSigMaxSize) * p.MaxTxGroupSize), &bounds.MaxLogicSigMaxSize)
+	checkSetMax(p.MaxTxnNoteBytes, &bounds.MaxTxnNoteBytes)
+	checkSetMax(p.MaxTxGroupSize, &bounds.MaxTxGroupSize)
 	// MaxBytesKeyValueLen is max of MaxAppKeyLen and MaxAppBytesValueLen
-	checkSetMax(p.MaxAppKeyLen, &MaxBytesKeyValueLen)
-	checkSetMax(p.MaxAppBytesValueLen, &MaxBytesKeyValueLen)
-	checkSetMax(p.MaxExtraAppProgramPages, &MaxExtraAppProgramLen)
+	checkSetMax(p.MaxAppKeyLen, &bounds.MaxBytesKeyValueLen)
+	checkSetMax(p.MaxAppBytesValueLen, &bounds.MaxBytesKeyValueLen)
+	checkSetMax(p.MaxExtraAppProgramPages, &bounds.MaxExtraAppProgramLen)
 	// MaxAvailableAppProgramLen is the max of supported app program size
-	MaxAvailableAppProgramLen = MaxAppProgramLen * (1 + MaxExtraAppProgramLen)
+	bounds.MaxAvailableAppProgramLen = bounds.MaxAppProgramLen * (1 + bounds.MaxExtraAppProgramLen)
 	// There is no consensus parameter for MaxLogCalls and MaxAppProgramLen as an approximation
 	// Its value is much larger than any possible reasonable MaxLogCalls value in future
-	checkSetMax(p.MaxAppProgramLen, &MaxLogCalls)
-	checkSetMax(p.MaxInnerTransactions*p.MaxTxGroupSize, &MaxInnerTransactionsPerDelta)
-	checkSetMax(p.MaxProposedExpiredOnlineAccounts, &MaxProposedExpiredOnlineAccounts)
-	checkSetMax(p.Payouts.MaxMarkAbsent, &MaxMarkAbsent)
+	checkSetMax(p.MaxAppProgramLen, &bounds.MaxLogCalls)
+	checkSetMax(p.MaxInnerTransactions*p.MaxTxGroupSize, &bounds.MaxInnerTransactionsPerDelta)
+	checkSetMax(p.MaxProposedExpiredOnlineAccounts, &bounds.MaxProposedExpiredOnlineAccounts)
+	checkSetMax(p.Payouts.MaxMarkAbsent, &bounds.MaxMarkAbsent)
 
 	// These bounds are exported to make them available to the msgp generator for calculating
 	// maximum valid message size for each message going across the wire.
-	checkSetMax(p.MaxAppTotalArgLen, &MaxAppTotalArgLen)
-	checkSetMax(p.MaxAssetNameBytes, &MaxAssetNameBytes)
-	checkSetMax(p.MaxAssetUnitNameBytes, &MaxAssetUnitNameBytes)
-	checkSetMax(p.MaxAssetURLBytes, &MaxAssetURLBytes)
-	checkSetMax(p.MaxAppBytesValueLen, &MaxAppBytesValueLen)
-	checkSetMax(p.MaxAppKeyLen, &MaxAppBytesKeyLen)
-	checkSetMax(int(p.StateProofTopVoters), &StateProofTopVoters)
-	checkSetMax(p.MaxTxnBytesPerBlock, &MaxTxnBytesPerBlock)
+	checkSetMax(p.MaxAppTotalArgLen, &bounds.MaxAppTotalArgLen)
+	checkSetMax(p.MaxAssetNameBytes, &bounds.MaxAssetNameBytes)
+	checkSetMax(p.MaxAssetUnitNameBytes, &bounds.MaxAssetUnitNameBytes)
+	checkSetMax(p.MaxAssetURLBytes, &bounds.MaxAssetURLBytes)
+	checkSetMax(p.MaxAppBytesValueLen, &bounds.MaxAppBytesValueLen)
+	checkSetMax(p.MaxAppKeyLen, &bounds.MaxAppBytesKeyLen)
+	checkSetMax(int(p.StateProofTopVoters), &bounds.StateProofTopVoters)
+	checkSetMax(p.MaxTxnBytesPerBlock, &bounds.MaxTxnBytesPerBlock)
 
-	checkSetMax(p.MaxAppTxnForeignApps, &MaxAppTxnForeignApps)
+	checkSetMax(p.MaxAppTxnForeignApps, &bounds.MaxAppTxnForeignApps)
 }
 
 // DeepCopy creates a deep copy of a consensus protocols map.

--- a/crypto/stateproof/structs.go
+++ b/crypto/stateproof/structs.go
@@ -83,7 +83,7 @@ type StateProof struct {
 }
 
 // SigPartProofMaxSize is the maximum valid size of SigProofs and PartProofs elements of the Stateproof struct in bytes.
-// It is equal to merklearray.ProofMaxSizeByElements(config.StateProofTopVoters/2)
+// It is equal to merklearray.ProofMaxSizeByElements(bounds.StateProofTopVoters/2)
 // See merklearray.Proof comment for explanation on the bound calculation
 const SigPartProofMaxSize = 35353
 

--- a/crypto/stateproof/weights_test.go
+++ b/crypto/stateproof/weights_test.go
@@ -21,7 +21,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto/merklearray"
 	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/stretchr/testify/require"
@@ -192,7 +192,7 @@ func TestSigPartProofMaxSize(t *testing.T) {
 	// Ensures that the SigPartProofMaxSize constant used for maxtotalbytes for StateProof.(Sig|Part)Proof(s) is
 	// correct. It should be logically bound by the maximum number of StateProofTopVoters. It is scaled by 1/2
 	// see merkelarray.Proof comment for explanation of the size calculation.
-	require.Equal(t, SigPartProofMaxSize, merklearray.ProofMaxSizeByElements(config.StateProofTopVoters/2))
+	require.Equal(t, SigPartProofMaxSize, merklearray.ProofMaxSizeByElements(bounds.StateProofTopVoters/2))
 }
 
 func BenchmarkVerifyWeights(b *testing.B) {

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -42,6 +42,7 @@ import (
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/catchup"
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/merklearray"
 	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated/model"
@@ -1144,7 +1145,7 @@ func (v2 *Handlers) RawTransactionAsync(ctx echo.Context) error {
 	if !v2.Node.Config().EnableDeveloperAPI {
 		return ctx.String(http.StatusNotFound, "/transactions/async was not enabled in the configuration file by setting the EnableDeveloperAPI to true")
 	}
-	txgroup, err := decodeTxGroup(ctx.Request().Body, config.MaxTxGroupSize)
+	txgroup, err := decodeTxGroup(ctx.Request().Body, bounds.MaxTxGroupSize)
 	if err != nil {
 		return badRequest(ctx, err, err.Error(), v2.Log)
 	}

--- a/data/appRateLimiter.go
+++ b/data/appRateLimiter.go
@@ -22,7 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -214,10 +214,10 @@ func (r *appRateLimiter) len() int {
 var appKeyPool = sync.Pool{
 	New: func() interface{} {
 		return &appKeyBuf{
-			// max config.MaxTxGroupSize apps per txgroup, each app has up to MaxAppTxnForeignApps extra foreign apps
-			// at moment of writing config.MaxTxGroupSize = 16, config.MaxAppTxnForeignApps = 8
-			keys:    make([]keyType, 0, config.MaxTxGroupSize*(1+config.MaxAppTxnForeignApps)),
-			buckets: make([]int, 0, config.MaxTxGroupSize*(1+config.MaxAppTxnForeignApps)),
+			// max bounds.MaxTxGroupSize apps per txgroup, each app has up to MaxAppTxnForeignApps extra foreign apps
+			// at moment of writing bounds.MaxTxGroupSize = 16, bounds.MaxAppTxnForeignApps = 8
+			keys:    make([]keyType, 0, bounds.MaxTxGroupSize*(1+bounds.MaxAppTxnForeignApps)),
+			buckets: make([]int, 0, bounds.MaxTxGroupSize*(1+bounds.MaxAppTxnForeignApps)),
 		}
 	},
 }
@@ -265,7 +265,7 @@ func txgroupToKeys(txgroup []transactions.SignedTxn, origin []byte, seed uint64,
 	txnToBucket := func(appIdx basics.AppIndex) int {
 		return int(memhash64(uint64(appIdx), seed) % uint64(numBuckets))
 	}
-	seen := make(map[basics.AppIndex]struct{}, len(txgroup)*(1+config.MaxAppTxnForeignApps))
+	seen := make(map[basics.AppIndex]struct{}, len(txgroup)*(1+bounds.MaxAppTxnForeignApps))
 	valid := func(appIdx basics.AppIndex) bool {
 		if appIdx != 0 {
 			_, ok := seen[appIdx]

--- a/data/appRateLimiter_test.go
+++ b/data/appRateLimiter_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -492,8 +493,8 @@ func BenchmarkAppRateLimiter_TxgroupToKeys(b *testing.B) {
 
 	txgroups := make([][]transactions.SignedTxn, 0, b.N)
 	for i := 0; i < b.N; i++ {
-		txgroup := make([]transactions.SignedTxn, 0, config.MaxTxGroupSize)
-		for j := 0; j < config.MaxTxGroupSize; j++ {
+		txgroup := make([]transactions.SignedTxn, 0, bounds.MaxTxGroupSize)
+		for j := 0; j < bounds.MaxTxGroupSize; j++ {
 			apptxn := transactions.Transaction{
 				Type: protocol.ApplicationCallTx,
 				ApplicationCallTxnFields: transactions.ApplicationCallTxnFields{

--- a/data/basics/msgp_gen.go
+++ b/data/basics/msgp_gen.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/algorand/msgp/msgp"
 
-	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/merklesignature"
 )
@@ -711,8 +711,8 @@ func (z *AccountData) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "AssetParams")
 				return
 			}
-			if zb0016 > encodedMaxAssetsPerAccount {
-				err = msgp.ErrOverflow(uint64(zb0016), uint64(encodedMaxAssetsPerAccount))
+			if zb0016 > bounds.EncodedMaxAssetsPerAccount {
+				err = msgp.ErrOverflow(uint64(zb0016), uint64(bounds.EncodedMaxAssetsPerAccount))
 				err = msgp.WrapError(err, "struct-from-array", "AssetParams")
 				return
 			}
@@ -747,8 +747,8 @@ func (z *AccountData) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "Assets")
 				return
 			}
-			if zb0018 > encodedMaxAssetsPerAccount {
-				err = msgp.ErrOverflow(uint64(zb0018), uint64(encodedMaxAssetsPerAccount))
+			if zb0018 > bounds.EncodedMaxAssetsPerAccount {
+				err = msgp.ErrOverflow(uint64(zb0018), uint64(bounds.EncodedMaxAssetsPerAccount))
 				err = msgp.WrapError(err, "struct-from-array", "Assets")
 				return
 			}
@@ -863,8 +863,8 @@ func (z *AccountData) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "AppLocalStates")
 				return
 			}
-			if zb0022 > EncodedMaxAppLocalStates {
-				err = msgp.ErrOverflow(uint64(zb0022), uint64(EncodedMaxAppLocalStates))
+			if zb0022 > bounds.EncodedMaxAppLocalStates {
+				err = msgp.ErrOverflow(uint64(zb0022), uint64(bounds.EncodedMaxAppLocalStates))
 				err = msgp.WrapError(err, "struct-from-array", "AppLocalStates")
 				return
 			}
@@ -899,8 +899,8 @@ func (z *AccountData) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "AppParams")
 				return
 			}
-			if zb0024 > EncodedMaxAppParams {
-				err = msgp.ErrOverflow(uint64(zb0024), uint64(EncodedMaxAppParams))
+			if zb0024 > bounds.EncodedMaxAppParams {
+				err = msgp.ErrOverflow(uint64(zb0024), uint64(bounds.EncodedMaxAppParams))
 				err = msgp.WrapError(err, "struct-from-array", "AppParams")
 				return
 			}
@@ -1145,8 +1145,8 @@ func (z *AccountData) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "AssetParams")
 					return
 				}
-				if zb0033 > encodedMaxAssetsPerAccount {
-					err = msgp.ErrOverflow(uint64(zb0033), uint64(encodedMaxAssetsPerAccount))
+				if zb0033 > bounds.EncodedMaxAssetsPerAccount {
+					err = msgp.ErrOverflow(uint64(zb0033), uint64(bounds.EncodedMaxAssetsPerAccount))
 					err = msgp.WrapError(err, "AssetParams")
 					return
 				}
@@ -1179,8 +1179,8 @@ func (z *AccountData) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "Assets")
 					return
 				}
-				if zb0035 > encodedMaxAssetsPerAccount {
-					err = msgp.ErrOverflow(uint64(zb0035), uint64(encodedMaxAssetsPerAccount))
+				if zb0035 > bounds.EncodedMaxAssetsPerAccount {
+					err = msgp.ErrOverflow(uint64(zb0035), uint64(bounds.EncodedMaxAssetsPerAccount))
 					err = msgp.WrapError(err, "Assets")
 					return
 				}
@@ -1289,8 +1289,8 @@ func (z *AccountData) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "AppLocalStates")
 					return
 				}
-				if zb0039 > EncodedMaxAppLocalStates {
-					err = msgp.ErrOverflow(uint64(zb0039), uint64(EncodedMaxAppLocalStates))
+				if zb0039 > bounds.EncodedMaxAppLocalStates {
+					err = msgp.ErrOverflow(uint64(zb0039), uint64(bounds.EncodedMaxAppLocalStates))
 					err = msgp.WrapError(err, "AppLocalStates")
 					return
 				}
@@ -1323,8 +1323,8 @@ func (z *AccountData) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "AppParams")
 					return
 				}
-				if zb0041 > EncodedMaxAppParams {
-					err = msgp.ErrOverflow(uint64(zb0041), uint64(EncodedMaxAppParams))
+				if zb0041 > bounds.EncodedMaxAppParams {
+					err = msgp.ErrOverflow(uint64(zb0041), uint64(bounds.EncodedMaxAppParams))
 					err = msgp.WrapError(err, "AppParams")
 					return
 				}
@@ -1506,28 +1506,28 @@ func AccountDataMaxSize() (s int) {
 	s = 3 + 4 + msgp.ByteSize + 5 + MicroAlgosMaxSize() + 6 + msgp.Uint64Size + 4 + MicroAlgosMaxSize() + 5 + crypto.OneTimeSignatureVerifierMaxSize() + 4 + crypto.VRFVerifierMaxSize() + 6 + merklesignature.CommitmentMaxSize() + 8 + msgp.Uint64Size + 8 + msgp.Uint64Size + 7 + msgp.Uint64Size + 4 + msgp.Uint64Size + 4 + msgp.Uint64Size + 5
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.AssetParams
-	s += encodedMaxAssetsPerAccount * (AssetIndexMaxSize())
+	s += bounds.EncodedMaxAssetsPerAccount * (AssetIndexMaxSize())
 	// Adding size of map values for z.AssetParams
-	s += encodedMaxAssetsPerAccount * (AssetParamsMaxSize())
+	s += bounds.EncodedMaxAssetsPerAccount * (AssetParamsMaxSize())
 	s += 6
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.Assets
-	s += encodedMaxAssetsPerAccount * (AssetIndexMaxSize())
+	s += bounds.EncodedMaxAssetsPerAccount * (AssetIndexMaxSize())
 	// Adding size of map values for z.Assets
-	s += encodedMaxAssetsPerAccount * (1)
+	s += bounds.EncodedMaxAssetsPerAccount * (1)
 	s += 2 + msgp.Uint64Size + 2 + msgp.BoolSize
 	s += 6 + AddressMaxSize() + 3 + msgp.BoolSize + 5
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.AppLocalStates
-	s += EncodedMaxAppLocalStates * (AppIndexMaxSize())
+	s += bounds.EncodedMaxAppLocalStates * (AppIndexMaxSize())
 	// Adding size of map values for z.AppLocalStates
-	s += EncodedMaxAppLocalStates * (AppLocalStateMaxSize())
+	s += bounds.EncodedMaxAppLocalStates * (AppLocalStateMaxSize())
 	s += 5
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.AppParams
-	s += EncodedMaxAppParams * (AppIndexMaxSize())
+	s += bounds.EncodedMaxAppParams * (AppIndexMaxSize())
 	// Adding size of map values for z.AppParams
-	s += EncodedMaxAppParams * (AppParamsMaxSize())
+	s += bounds.EncodedMaxAppParams * (AppParamsMaxSize())
 	s += 5 + 1 + 4 + msgp.Uint64Size + 4 + msgp.Uint64Size + 5 + msgp.Uint32Size + 4 + msgp.Uint64Size + 5 + msgp.Uint64Size
 	return
 }
@@ -1800,8 +1800,8 @@ func (z *AppLocalState) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState
 				err = msgp.WrapError(err, "struct-from-array", "KeyValue")
 				return
 			}
-			if zb0007 > EncodedMaxKeyValueEntries {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(EncodedMaxKeyValueEntries))
+			if zb0007 > bounds.EncodedMaxKeyValueEntries {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(bounds.EncodedMaxKeyValueEntries))
 				err = msgp.WrapError(err, "struct-from-array", "KeyValue")
 				return
 			}
@@ -1928,8 +1928,8 @@ func (z *AppLocalState) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState
 					err = msgp.WrapError(err, "KeyValue")
 					return
 				}
-				if zb0011 > EncodedMaxKeyValueEntries {
-					err = msgp.ErrOverflow(uint64(zb0011), uint64(EncodedMaxKeyValueEntries))
+				if zb0011 > bounds.EncodedMaxKeyValueEntries {
+					err = msgp.ErrOverflow(uint64(zb0011), uint64(bounds.EncodedMaxKeyValueEntries))
 					err = msgp.WrapError(err, "KeyValue")
 					return
 				}
@@ -1998,9 +1998,9 @@ func AppLocalStateMaxSize() (s int) {
 	s = 1 + 5 + 1 + 4 + msgp.Uint64Size + 4 + msgp.Uint64Size + 4
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.KeyValue
-	s += EncodedMaxKeyValueEntries * (msgp.StringPrefixSize + config.MaxAppBytesKeyLen)
+	s += bounds.EncodedMaxKeyValueEntries * (msgp.StringPrefixSize + bounds.MaxAppBytesKeyLen)
 	// Adding size of map values for z.KeyValue
-	s += EncodedMaxKeyValueEntries * (TealValueMaxSize())
+	s += bounds.EncodedMaxKeyValueEntries * (TealValueMaxSize())
 	return
 }
 
@@ -2170,8 +2170,8 @@ func (z *AppParams) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 				err = msgp.WrapError(err, "struct-from-array", "ApprovalProgram")
 				return
 			}
-			if zb0005 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(config.MaxAvailableAppProgramLen))
+			if zb0005 > bounds.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0005), uint64(bounds.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
@@ -2188,8 +2188,8 @@ func (z *AppParams) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 				err = msgp.WrapError(err, "struct-from-array", "ClearStateProgram")
 				return
 			}
-			if zb0006 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxAvailableAppProgramLen))
+			if zb0006 > bounds.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(bounds.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
@@ -2207,8 +2207,8 @@ func (z *AppParams) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 				err = msgp.WrapError(err, "struct-from-array", "GlobalState")
 				return
 			}
-			if zb0007 > EncodedMaxKeyValueEntries {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(EncodedMaxKeyValueEntries))
+			if zb0007 > bounds.EncodedMaxKeyValueEntries {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(bounds.EncodedMaxKeyValueEntries))
 				err = msgp.WrapError(err, "struct-from-array", "GlobalState")
 				return
 			}
@@ -2424,8 +2424,8 @@ func (z *AppParams) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 					err = msgp.WrapError(err, "ApprovalProgram")
 					return
 				}
-				if zb0013 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0013), uint64(config.MaxAvailableAppProgramLen))
+				if zb0013 > bounds.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0013), uint64(bounds.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
@@ -2440,8 +2440,8 @@ func (z *AppParams) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 					err = msgp.WrapError(err, "ClearStateProgram")
 					return
 				}
-				if zb0014 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0014), uint64(config.MaxAvailableAppProgramLen))
+				if zb0014 > bounds.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0014), uint64(bounds.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
@@ -2457,8 +2457,8 @@ func (z *AppParams) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 					err = msgp.WrapError(err, "GlobalState")
 					return
 				}
-				if zb0015 > EncodedMaxKeyValueEntries {
-					err = msgp.ErrOverflow(uint64(zb0015), uint64(EncodedMaxKeyValueEntries))
+				if zb0015 > bounds.EncodedMaxKeyValueEntries {
+					err = msgp.ErrOverflow(uint64(zb0015), uint64(bounds.EncodedMaxKeyValueEntries))
 					err = msgp.WrapError(err, "GlobalState")
 					return
 				}
@@ -2677,12 +2677,12 @@ func (z *AppParams) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func AppParamsMaxSize() (s int) {
-	s = 1 + 7 + msgp.BytesPrefixSize + config.MaxAvailableAppProgramLen + 7 + msgp.BytesPrefixSize + config.MaxAvailableAppProgramLen + 3
+	s = 1 + 7 + msgp.BytesPrefixSize + bounds.MaxAvailableAppProgramLen + 7 + msgp.BytesPrefixSize + bounds.MaxAvailableAppProgramLen + 3
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.GlobalState
-	s += EncodedMaxKeyValueEntries * (msgp.StringPrefixSize + config.MaxAppBytesKeyLen)
+	s += bounds.EncodedMaxKeyValueEntries * (msgp.StringPrefixSize + bounds.MaxAppBytesKeyLen)
 	// Adding size of map values for z.GlobalState
-	s += EncodedMaxKeyValueEntries * (TealValueMaxSize())
+	s += bounds.EncodedMaxKeyValueEntries * (TealValueMaxSize())
 	s += 5 + 1 + 4 + msgp.Uint64Size + 4 + msgp.Uint64Size + 5 + 1 + 4 + msgp.Uint64Size + 4 + msgp.Uint64Size + 4 + msgp.Uint32Size + 2 + msgp.Uint64Size
 	return
 }
@@ -3057,8 +3057,8 @@ func (z *AssetParams) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "UnitName")
 				return
 			}
-			if zb0004 > config.MaxAssetUnitNameBytes {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxAssetUnitNameBytes))
+			if zb0004 > bounds.MaxAssetUnitNameBytes {
+				err = msgp.ErrOverflow(uint64(zb0004), uint64(bounds.MaxAssetUnitNameBytes))
 				return
 			}
 			(*z).UnitName, bts, err = msgp.ReadStringBytes(bts)
@@ -3075,8 +3075,8 @@ func (z *AssetParams) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "AssetName")
 				return
 			}
-			if zb0005 > config.MaxAssetNameBytes {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(config.MaxAssetNameBytes))
+			if zb0005 > bounds.MaxAssetNameBytes {
+				err = msgp.ErrOverflow(uint64(zb0005), uint64(bounds.MaxAssetNameBytes))
 				return
 			}
 			(*z).AssetName, bts, err = msgp.ReadStringBytes(bts)
@@ -3093,8 +3093,8 @@ func (z *AssetParams) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "URL")
 				return
 			}
-			if zb0006 > config.MaxAssetURLBytes {
-				err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxAssetURLBytes))
+			if zb0006 > bounds.MaxAssetURLBytes {
+				err = msgp.ErrOverflow(uint64(zb0006), uint64(bounds.MaxAssetURLBytes))
 				return
 			}
 			(*z).URL, bts, err = msgp.ReadStringBytes(bts)
@@ -3191,8 +3191,8 @@ func (z *AssetParams) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "UnitName")
 					return
 				}
-				if zb0007 > config.MaxAssetUnitNameBytes {
-					err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxAssetUnitNameBytes))
+				if zb0007 > bounds.MaxAssetUnitNameBytes {
+					err = msgp.ErrOverflow(uint64(zb0007), uint64(bounds.MaxAssetUnitNameBytes))
 					return
 				}
 				(*z).UnitName, bts, err = msgp.ReadStringBytes(bts)
@@ -3207,8 +3207,8 @@ func (z *AssetParams) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "AssetName")
 					return
 				}
-				if zb0008 > config.MaxAssetNameBytes {
-					err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxAssetNameBytes))
+				if zb0008 > bounds.MaxAssetNameBytes {
+					err = msgp.ErrOverflow(uint64(zb0008), uint64(bounds.MaxAssetNameBytes))
 					return
 				}
 				(*z).AssetName, bts, err = msgp.ReadStringBytes(bts)
@@ -3223,8 +3223,8 @@ func (z *AssetParams) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "URL")
 					return
 				}
-				if zb0009 > config.MaxAssetURLBytes {
-					err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxAssetURLBytes))
+				if zb0009 > bounds.MaxAssetURLBytes {
+					err = msgp.ErrOverflow(uint64(zb0009), uint64(bounds.MaxAssetURLBytes))
 					return
 				}
 				(*z).URL, bts, err = msgp.ReadStringBytes(bts)
@@ -3296,7 +3296,7 @@ func (z *AssetParams) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func AssetParamsMaxSize() (s int) {
-	s = 1 + 2 + msgp.Uint64Size + 3 + msgp.Uint32Size + 3 + msgp.BoolSize + 3 + msgp.StringPrefixSize + config.MaxAssetUnitNameBytes + 3 + msgp.StringPrefixSize + config.MaxAssetNameBytes + 3 + msgp.StringPrefixSize + config.MaxAssetURLBytes + 3
+	s = 1 + 2 + msgp.Uint64Size + 3 + msgp.Uint32Size + 3 + msgp.BoolSize + 3 + msgp.StringPrefixSize + bounds.MaxAssetUnitNameBytes + 3 + msgp.StringPrefixSize + bounds.MaxAssetNameBytes + 3 + msgp.StringPrefixSize + bounds.MaxAssetURLBytes + 3
 	// Calculating size of array: z.MetadataHash
 	s += msgp.ArrayHeaderSize + ((32) * (msgp.ByteSize))
 	s += 2 + AddressMaxSize() + 2 + AddressMaxSize() + 2 + AddressMaxSize() + 2 + AddressMaxSize()
@@ -3785,8 +3785,8 @@ func (z *BalanceRecord) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState
 				err = msgp.WrapError(err, "struct-from-array", "AssetParams")
 				return
 			}
-			if zb0016 > encodedMaxAssetsPerAccount {
-				err = msgp.ErrOverflow(uint64(zb0016), uint64(encodedMaxAssetsPerAccount))
+			if zb0016 > bounds.EncodedMaxAssetsPerAccount {
+				err = msgp.ErrOverflow(uint64(zb0016), uint64(bounds.EncodedMaxAssetsPerAccount))
 				err = msgp.WrapError(err, "struct-from-array", "AssetParams")
 				return
 			}
@@ -3821,8 +3821,8 @@ func (z *BalanceRecord) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState
 				err = msgp.WrapError(err, "struct-from-array", "Assets")
 				return
 			}
-			if zb0018 > encodedMaxAssetsPerAccount {
-				err = msgp.ErrOverflow(uint64(zb0018), uint64(encodedMaxAssetsPerAccount))
+			if zb0018 > bounds.EncodedMaxAssetsPerAccount {
+				err = msgp.ErrOverflow(uint64(zb0018), uint64(bounds.EncodedMaxAssetsPerAccount))
 				err = msgp.WrapError(err, "struct-from-array", "Assets")
 				return
 			}
@@ -3937,8 +3937,8 @@ func (z *BalanceRecord) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState
 				err = msgp.WrapError(err, "struct-from-array", "AppLocalStates")
 				return
 			}
-			if zb0022 > EncodedMaxAppLocalStates {
-				err = msgp.ErrOverflow(uint64(zb0022), uint64(EncodedMaxAppLocalStates))
+			if zb0022 > bounds.EncodedMaxAppLocalStates {
+				err = msgp.ErrOverflow(uint64(zb0022), uint64(bounds.EncodedMaxAppLocalStates))
 				err = msgp.WrapError(err, "struct-from-array", "AppLocalStates")
 				return
 			}
@@ -3973,8 +3973,8 @@ func (z *BalanceRecord) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState
 				err = msgp.WrapError(err, "struct-from-array", "AppParams")
 				return
 			}
-			if zb0024 > EncodedMaxAppParams {
-				err = msgp.ErrOverflow(uint64(zb0024), uint64(EncodedMaxAppParams))
+			if zb0024 > bounds.EncodedMaxAppParams {
+				err = msgp.ErrOverflow(uint64(zb0024), uint64(bounds.EncodedMaxAppParams))
 				err = msgp.WrapError(err, "struct-from-array", "AppParams")
 				return
 			}
@@ -4225,8 +4225,8 @@ func (z *BalanceRecord) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState
 					err = msgp.WrapError(err, "AssetParams")
 					return
 				}
-				if zb0033 > encodedMaxAssetsPerAccount {
-					err = msgp.ErrOverflow(uint64(zb0033), uint64(encodedMaxAssetsPerAccount))
+				if zb0033 > bounds.EncodedMaxAssetsPerAccount {
+					err = msgp.ErrOverflow(uint64(zb0033), uint64(bounds.EncodedMaxAssetsPerAccount))
 					err = msgp.WrapError(err, "AssetParams")
 					return
 				}
@@ -4259,8 +4259,8 @@ func (z *BalanceRecord) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState
 					err = msgp.WrapError(err, "Assets")
 					return
 				}
-				if zb0035 > encodedMaxAssetsPerAccount {
-					err = msgp.ErrOverflow(uint64(zb0035), uint64(encodedMaxAssetsPerAccount))
+				if zb0035 > bounds.EncodedMaxAssetsPerAccount {
+					err = msgp.ErrOverflow(uint64(zb0035), uint64(bounds.EncodedMaxAssetsPerAccount))
 					err = msgp.WrapError(err, "Assets")
 					return
 				}
@@ -4369,8 +4369,8 @@ func (z *BalanceRecord) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState
 					err = msgp.WrapError(err, "AppLocalStates")
 					return
 				}
-				if zb0039 > EncodedMaxAppLocalStates {
-					err = msgp.ErrOverflow(uint64(zb0039), uint64(EncodedMaxAppLocalStates))
+				if zb0039 > bounds.EncodedMaxAppLocalStates {
+					err = msgp.ErrOverflow(uint64(zb0039), uint64(bounds.EncodedMaxAppLocalStates))
 					err = msgp.WrapError(err, "AppLocalStates")
 					return
 				}
@@ -4403,8 +4403,8 @@ func (z *BalanceRecord) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState
 					err = msgp.WrapError(err, "AppParams")
 					return
 				}
-				if zb0041 > EncodedMaxAppParams {
-					err = msgp.ErrOverflow(uint64(zb0041), uint64(EncodedMaxAppParams))
+				if zb0041 > bounds.EncodedMaxAppParams {
+					err = msgp.ErrOverflow(uint64(zb0041), uint64(bounds.EncodedMaxAppParams))
 					err = msgp.WrapError(err, "AppParams")
 					return
 				}
@@ -4586,28 +4586,28 @@ func BalanceRecordMaxSize() (s int) {
 	s = 3 + 5 + AddressMaxSize() + 4 + msgp.ByteSize + 5 + MicroAlgosMaxSize() + 6 + msgp.Uint64Size + 4 + MicroAlgosMaxSize() + 5 + crypto.OneTimeSignatureVerifierMaxSize() + 4 + crypto.VRFVerifierMaxSize() + 6 + merklesignature.CommitmentMaxSize() + 8 + msgp.Uint64Size + 8 + msgp.Uint64Size + 7 + msgp.Uint64Size + 4 + msgp.Uint64Size + 4 + msgp.Uint64Size + 5
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.AccountData.AssetParams
-	s += encodedMaxAssetsPerAccount * (AssetIndexMaxSize())
+	s += bounds.EncodedMaxAssetsPerAccount * (AssetIndexMaxSize())
 	// Adding size of map values for z.AccountData.AssetParams
-	s += encodedMaxAssetsPerAccount * (AssetParamsMaxSize())
+	s += bounds.EncodedMaxAssetsPerAccount * (AssetParamsMaxSize())
 	s += 6
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.AccountData.Assets
-	s += encodedMaxAssetsPerAccount * (AssetIndexMaxSize())
+	s += bounds.EncodedMaxAssetsPerAccount * (AssetIndexMaxSize())
 	// Adding size of map values for z.AccountData.Assets
-	s += encodedMaxAssetsPerAccount * (1)
+	s += bounds.EncodedMaxAssetsPerAccount * (1)
 	s += 2 + msgp.Uint64Size + 2 + msgp.BoolSize
 	s += 6 + AddressMaxSize() + 3 + msgp.BoolSize + 5
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.AccountData.AppLocalStates
-	s += EncodedMaxAppLocalStates * (AppIndexMaxSize())
+	s += bounds.EncodedMaxAppLocalStates * (AppIndexMaxSize())
 	// Adding size of map values for z.AccountData.AppLocalStates
-	s += EncodedMaxAppLocalStates * (AppLocalStateMaxSize())
+	s += bounds.EncodedMaxAppLocalStates * (AppLocalStateMaxSize())
 	s += 5
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.AccountData.AppParams
-	s += EncodedMaxAppParams * (AppIndexMaxSize())
+	s += bounds.EncodedMaxAppParams * (AppIndexMaxSize())
 	// Adding size of map values for z.AccountData.AppParams
-	s += EncodedMaxAppParams * (AppParamsMaxSize())
+	s += bounds.EncodedMaxAppParams * (AppParamsMaxSize())
 	s += 5 + 1 + 4 + msgp.Uint64Size + 4 + msgp.Uint64Size + 5 + msgp.Uint32Size + 4 + msgp.Uint64Size + 5 + msgp.Uint64Size
 	return
 }
@@ -5099,8 +5099,8 @@ func (z *StateDelta) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (
 		err = msgp.WrapError(err)
 		return
 	}
-	if zb0003 > config.MaxStateDeltaKeys {
-		err = msgp.ErrOverflow(uint64(zb0003), uint64(config.MaxStateDeltaKeys))
+	if zb0003 > bounds.MaxStateDeltaKeys {
+		err = msgp.ErrOverflow(uint64(zb0003), uint64(bounds.MaxStateDeltaKeys))
 		err = msgp.WrapError(err)
 		return
 	}
@@ -5159,9 +5159,9 @@ func (z StateDelta) MsgIsZero() bool {
 func StateDeltaMaxSize() (s int) {
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z
-	s += config.MaxStateDeltaKeys * (msgp.StringPrefixSize + config.MaxAppBytesKeyLen)
+	s += bounds.MaxStateDeltaKeys * (msgp.StringPrefixSize + bounds.MaxAppBytesKeyLen)
 	// Adding size of map values for z
-	s += config.MaxStateDeltaKeys * (ValueDeltaMaxSize())
+	s += bounds.MaxStateDeltaKeys * (ValueDeltaMaxSize())
 	return
 }
 
@@ -5855,8 +5855,8 @@ func (z *TealKeyValue) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState)
 		err = msgp.WrapError(err)
 		return
 	}
-	if zb0003 > EncodedMaxKeyValueEntries {
-		err = msgp.ErrOverflow(uint64(zb0003), uint64(EncodedMaxKeyValueEntries))
+	if zb0003 > bounds.EncodedMaxKeyValueEntries {
+		err = msgp.ErrOverflow(uint64(zb0003), uint64(bounds.EncodedMaxKeyValueEntries))
 		err = msgp.WrapError(err)
 		return
 	}
@@ -5915,9 +5915,9 @@ func (z TealKeyValue) MsgIsZero() bool {
 func TealKeyValueMaxSize() (s int) {
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z
-	s += EncodedMaxKeyValueEntries * (msgp.StringPrefixSize + config.MaxAppBytesKeyLen)
+	s += bounds.EncodedMaxKeyValueEntries * (msgp.StringPrefixSize + bounds.MaxAppBytesKeyLen)
 	// Adding size of map values for z
-	s += EncodedMaxKeyValueEntries * (TealValueMaxSize())
+	s += bounds.EncodedMaxKeyValueEntries * (TealValueMaxSize())
 	return
 }
 
@@ -6240,8 +6240,8 @@ func (z *ValueDelta) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (
 				err = msgp.WrapError(err, "struct-from-array", "Bytes")
 				return
 			}
-			if zb0004 > config.MaxAppBytesValueLen {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxAppBytesValueLen))
+			if zb0004 > bounds.MaxAppBytesValueLen {
+				err = msgp.ErrOverflow(uint64(zb0004), uint64(bounds.MaxAppBytesValueLen))
 				return
 			}
 			(*z).Bytes, bts, err = msgp.ReadStringBytes(bts)
@@ -6298,8 +6298,8 @@ func (z *ValueDelta) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (
 					err = msgp.WrapError(err, "Bytes")
 					return
 				}
-				if zb0006 > config.MaxAppBytesValueLen {
-					err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxAppBytesValueLen))
+				if zb0006 > bounds.MaxAppBytesValueLen {
+					err = msgp.ErrOverflow(uint64(zb0006), uint64(bounds.MaxAppBytesValueLen))
 					return
 				}
 				(*z).Bytes, bts, err = msgp.ReadStringBytes(bts)
@@ -6347,6 +6347,6 @@ func (z *ValueDelta) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func ValueDeltaMaxSize() (s int) {
-	s = 1 + 3 + msgp.Uint64Size + 3 + msgp.StringPrefixSize + config.MaxAppBytesValueLen + 3 + msgp.Uint64Size
+	s = 1 + 3 + msgp.Uint64Size + 3 + msgp.StringPrefixSize + bounds.MaxAppBytesValueLen + 3 + msgp.Uint64Size
 	return
 }

--- a/data/basics/teal.go
+++ b/data/basics/teal.go
@@ -81,33 +81,6 @@ func (sd StateDelta) Equal(o StateDelta) bool {
 	return maps.Equal(sd, o)
 }
 
-// Valid checks whether the keys and values in a StateDelta conform to the
-// consensus parameters' maximum lengths
-func (sd StateDelta) Valid(proto *config.ConsensusParams) error {
-	if len(sd) > 0 && proto.MaxAppKeyLen == 0 {
-		return fmt.Errorf("delta not empty, but proto.MaxAppKeyLen is 0 (why did we make a delta?)")
-	}
-	for key, delta := range sd {
-		if len(key) > proto.MaxAppKeyLen {
-			return fmt.Errorf("key too long: length was %d, maximum is %d", len(key), proto.MaxAppKeyLen)
-		}
-		switch delta.Action {
-		case SetBytesAction:
-			if len(delta.Bytes) > proto.MaxAppBytesValueLen {
-				return fmt.Errorf("value too long for key 0x%x: length was %d", key, len(delta.Bytes))
-			}
-			if sum := len(key) + len(delta.Bytes); sum > proto.MaxAppSumKeyValueLens {
-				return fmt.Errorf("key/value total too long for key 0x%x: sum was %d", key, sum)
-			}
-		case SetUintAction:
-		case DeleteAction:
-		default:
-			return fmt.Errorf("unknown delta action: %v", delta.Action)
-		}
-	}
-	return nil
-}
-
 // StateSchema sets maximums on the number of each type that may be stored
 type StateSchema struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`

--- a/data/basics/teal.go
+++ b/data/basics/teal.go
@@ -44,7 +44,7 @@ type ValueDelta struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
 	Action DeltaAction `codec:"at"`
-	Bytes  string      `codec:"bs,allocbound=config.MaxAppBytesValueLen"`
+	Bytes  string      `codec:"bs,allocbound=bounds.MaxAppBytesValueLen"`
 	Uint   uint64      `codec:"ui"`
 }
 
@@ -71,7 +71,7 @@ func (vd *ValueDelta) ToTealValue() (value TealValue, ok bool) {
 // StateDelta is a map from key/value store keys to ValueDeltas, indicating
 // what should happen for that key
 //
-//msgp:allocbound StateDelta config.MaxStateDeltaKeys,config.MaxAppBytesKeyLen
+//msgp:allocbound StateDelta bounds.MaxStateDeltaKeys,bounds.MaxAppBytesKeyLen
 type StateDelta map[string]ValueDelta
 
 // Equal checks whether two StateDeltas are equal. We don't check for nilness
@@ -185,7 +185,7 @@ func (tv *TealValue) String() string {
 // TealKeyValue represents a key/value store for use in an application's
 // LocalState or GlobalState
 //
-//msgp:allocbound TealKeyValue EncodedMaxKeyValueEntries,config.MaxAppBytesKeyLen
+//msgp:allocbound TealKeyValue bounds.EncodedMaxKeyValueEntries,bounds.MaxAppBytesKeyLen
 type TealKeyValue map[string]TealValue
 
 // Clone returns a copy of a TealKeyValue that may be modified without

--- a/data/basics/teal_test.go
+++ b/data/basics/teal_test.go
@@ -17,95 +17,12 @@
 package basics
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/algorand/go-algorand/config"
-	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
-
-func TestStateDeltaValid(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	a := require.New(t)
-
-	// test pre-applications proto
-	protoPreF := config.Consensus[protocol.ConsensusV23]
-	a.False(protoPreF.Application)
-	sd := StateDelta{"key": ValueDelta{Action: SetBytesAction, Bytes: "val"}}
-	err := sd.Valid(&protoPreF)
-	a.Error(err)
-	a.Contains(err.Error(), "proto.MaxAppKeyLen is 0")
-
-	sd = StateDelta{"": ValueDelta{Action: SetUintAction, Uint: 1}}
-	err = sd.Valid(&protoPreF)
-	a.Error(err)
-	a.Contains(err.Error(), "proto.MaxAppKeyLen is 0")
-
-	sd = StateDelta{"": ValueDelta{Action: SetBytesAction, Bytes: ""}}
-	err = sd.Valid(&protoPreF)
-	a.Error(err)
-	a.Contains(err.Error(), "proto.MaxAppKeyLen is 0")
-
-	// test vFuture proto with applications
-	sd = StateDelta{"key": ValueDelta{Action: SetBytesAction, Bytes: "val"}}
-	protoF := config.Consensus[protocol.ConsensusFuture]
-	err = sd.Valid(&protoF)
-	a.NoError(err)
-
-	// vFuture: key too long, short value
-	tooLongKey := strings.Repeat("a", protoF.MaxAppKeyLen+1)
-	sd = StateDelta{tooLongKey: ValueDelta{Action: SetBytesAction, Bytes: "val"}}
-	err = sd.Valid(&protoF)
-	a.Error(err)
-	a.Contains(err.Error(), "key too long")
-	delete(sd, tooLongKey)
-
-	// vFuture: max size key, value too long: total size bigger than MaxAppSumKeyValueLens
-	longKey := tooLongKey[1:]
-	tooLongValue := strings.Repeat("b", protoF.MaxAppSumKeyValueLens-len(longKey)+1)
-	sd = StateDelta{longKey: ValueDelta{Action: SetBytesAction, Bytes: tooLongValue}}
-	err = sd.Valid(&protoF)
-	a.Error(err)
-	a.Contains(err.Error(), "key/value total too long for key")
-
-	sd[longKey] = ValueDelta{Action: SetBytesAction, Bytes: tooLongValue[1:]}
-	sd["intval"] = ValueDelta{Action: DeltaAction(10), Uint: 0}
-	err = sd.Valid(&protoF)
-	a.Error(err)
-	a.Contains(err.Error(), "unknown delta action")
-
-	sd["intval"] = ValueDelta{Action: SetUintAction, Uint: 0}
-	sd["delval"] = ValueDelta{Action: DeleteAction, Uint: 0, Bytes: tooLongValue}
-	err = sd.Valid(&protoF)
-	a.NoError(err)
-}
-
-func TestStateDeltaValidV24(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	a := require.New(t)
-
-	// v24: short key, value too long: hits MaxAppBytesValueLen
-	protoV24 := config.Consensus[protocol.ConsensusV24]
-	shortKey := "k"
-	reallyLongValue := strings.Repeat("b", protoV24.MaxAppBytesValueLen+1)
-	sd := StateDelta{shortKey: ValueDelta{Action: SetBytesAction, Bytes: reallyLongValue}}
-	err := sd.Valid(&protoV24)
-	a.Error(err)
-	a.Contains(err.Error(), "value too long for key")
-
-	// v24: key too long, short value
-	tooLongKey := strings.Repeat("a", protoV24.MaxAppKeyLen+1)
-	sd = StateDelta{tooLongKey: ValueDelta{Action: SetBytesAction, Bytes: "val"}}
-	err = sd.Valid(&protoV24)
-	a.Error(err)
-	a.Contains(err.Error(), "key too long")
-	delete(sd, tooLongKey)
-}
 
 func TestStateDeltaEqual(t *testing.T) {
 	partitiontest.PartitionTest(t)

--- a/data/basics/userBalance.go
+++ b/data/basics/userBalance.go
@@ -41,29 +41,6 @@ const (
 	// Two special accounts that are defined as NotParticipating are the incentive pool (also know as rewards pool) and the fee sink.
 	// These two accounts also have additional Algo transfer restrictions.
 	NotParticipating
-
-	// encodedMaxAssetsPerAccount is the decoder limit of number of assets stored per account.
-	// it's being verified by the unit test TestEncodedAccountAllocationBounds to align
-	// with config.Consensus[protocol.ConsensusCurrentVersion].MaxAssetsPerAccount; note that the decoded
-	// parameter is used only for protecting the decoder against malicious encoded account data stream.
-	// protocol-specific contains would be tested once the decoding is complete.
-	encodedMaxAssetsPerAccount = 1024
-
-	// EncodedMaxAppLocalStates is the decoder limit for number of opted-in apps in a single account.
-	// It is verified in TestEncodedAccountAllocationBounds to align with
-	// config.Consensus[protocol.ConsensusCurrentVersion].MaxAppsOptedIn
-	EncodedMaxAppLocalStates = 64
-
-	// EncodedMaxAppParams is the decoder limit for number of created apps in a single account.
-	// It is verified in TestEncodedAccountAllocationBounds to align with
-	// config.Consensus[protocol.ConsensusCurrentVersion].MaxAppsCreated
-	EncodedMaxAppParams = 64
-
-	// EncodedMaxKeyValueEntries is the decoder limit for the length of a key/value store.
-	// It is verified in TestEncodedAccountAllocationBounds to align with
-	// config.Consensus[protocol.ConsensusCurrentVersion].MaxLocalSchemaEntries and
-	// config.Consensus[protocol.ConsensusCurrentVersion].MaxGlobalSchemaEntries
-	EncodedMaxKeyValueEntries = 1024
 )
 
 func (s Status) String() string {
@@ -199,7 +176,7 @@ type AccountData struct {
 	// NOTE: do not modify this value in-place in existing AccountData
 	// structs; allocate a copy and modify that instead.  AccountData
 	// is expected to have copy-by-value semantics.
-	AssetParams map[AssetIndex]AssetParams `codec:"apar,allocbound=encodedMaxAssetsPerAccount"`
+	AssetParams map[AssetIndex]AssetParams `codec:"apar,allocbound=bounds.EncodedMaxAssetsPerAccount"`
 
 	// Assets is the set of assets that can be held by this
 	// account.  Assets (i.e., slots in this map) are explicitly
@@ -216,7 +193,7 @@ type AccountData struct {
 	// NOTE: do not modify this value in-place in existing AccountData
 	// structs; allocate a copy and modify that instead.  AccountData
 	// is expected to have copy-by-value semantics.
-	Assets map[AssetIndex]AssetHolding `codec:"asset,allocbound=encodedMaxAssetsPerAccount"`
+	Assets map[AssetIndex]AssetHolding `codec:"asset,allocbound=bounds.EncodedMaxAssetsPerAccount"`
 
 	// AuthAddr is the address against which signatures/multisigs/logicsigs should be checked.
 	// If empty, the address of the account whose AccountData this is is used.
@@ -231,11 +208,11 @@ type AccountData struct {
 
 	// AppLocalStates stores the local states associated with any applications
 	// that this account has opted in to.
-	AppLocalStates map[AppIndex]AppLocalState `codec:"appl,allocbound=EncodedMaxAppLocalStates"`
+	AppLocalStates map[AppIndex]AppLocalState `codec:"appl,allocbound=bounds.EncodedMaxAppLocalStates"`
 
 	// AppParams stores the global parameters and state associated with any
 	// applications that this account has created.
-	AppParams map[AppIndex]AppParams `codec:"appp,allocbound=EncodedMaxAppParams"`
+	AppParams map[AppIndex]AppParams `codec:"appp,allocbound=bounds.EncodedMaxAppParams"`
 
 	// TotalAppSchema stores the sum of all of the LocalStateSchemas
 	// and GlobalStateSchemas in this account (global for applications
@@ -269,8 +246,8 @@ type AppLocalState struct {
 type AppParams struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-	ApprovalProgram   []byte       `codec:"approv,allocbound=config.MaxAvailableAppProgramLen"`
-	ClearStateProgram []byte       `codec:"clearp,allocbound=config.MaxAvailableAppProgramLen"`
+	ApprovalProgram   []byte       `codec:"approv,allocbound=bounds.MaxAvailableAppProgramLen"`
+	ClearStateProgram []byte       `codec:"clearp,allocbound=bounds.MaxAvailableAppProgramLen"`
 	GlobalState       TealKeyValue `codec:"gs"`
 	StateSchemas
 	ExtraProgramPages uint32 `codec:"epp"`
@@ -393,14 +370,14 @@ type AssetParams struct {
 
 	// UnitName specifies a hint for the name of a unit of
 	// this asset.
-	UnitName string `codec:"un,allocbound=config.MaxAssetUnitNameBytes"`
+	UnitName string `codec:"un,allocbound=bounds.MaxAssetUnitNameBytes"`
 
 	// AssetName specifies a hint for the name of the asset.
-	AssetName string `codec:"an,allocbound=config.MaxAssetNameBytes"`
+	AssetName string `codec:"an,allocbound=bounds.MaxAssetNameBytes"`
 
 	// URL specifies a URL where more information about the asset can be
 	// retrieved
-	URL string `codec:"au,allocbound=config.MaxAssetURLBytes"`
+	URL string `codec:"au,allocbound=bounds.MaxAssetURLBytes"`
 
 	// MetadataHash specifies a commitment to some unspecified asset
 	// metadata. The format of this metadata is up to the application.

--- a/data/basics/userBalance_test.go
+++ b/data/basics/userBalance_test.go
@@ -96,31 +96,6 @@ func TestWithUpdatedRewardsPanics(t *testing.T) {
 	})
 }
 
-func TestEncodedAccountAllocationBounds(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	// ensure that all the supported protocols have value limits less or
-	// equal to their corresponding codec allocbounds
-	for protoVer, proto := range config.Consensus {
-		if proto.MaxAssetsPerAccount > 0 && proto.MaxAssetsPerAccount > encodedMaxAssetsPerAccount {
-			require.Failf(t, "proto.MaxAssetsPerAccount > encodedMaxAssetsPerAccount", "protocol version = %s", protoVer)
-		}
-		if proto.MaxAppsCreated > 0 && proto.MaxAppsCreated > EncodedMaxAppParams {
-			require.Failf(t, "proto.MaxAppsCreated > encodedMaxAppParams", "protocol version = %s", protoVer)
-		}
-		if proto.MaxAppsOptedIn > 0 && proto.MaxAppsOptedIn > EncodedMaxAppLocalStates {
-			require.Failf(t, "proto.MaxAppsOptedIn > encodedMaxAppLocalStates", "protocol version = %s", protoVer)
-		}
-		if proto.MaxLocalSchemaEntries > EncodedMaxKeyValueEntries {
-			require.Failf(t, "proto.MaxLocalSchemaEntries > encodedMaxKeyValueEntries", "protocol version = %s", protoVer)
-		}
-		if proto.MaxGlobalSchemaEntries > EncodedMaxKeyValueEntries {
-			require.Failf(t, "proto.MaxGlobalSchemaEntries > encodedMaxKeyValueEntries", "protocol version = %s", protoVer)
-		}
-		// There is no protocol limit to the number of Boxes per account, so that allocbound is not checked.
-	}
-}
-
 func TestAppIndexHashing(t *testing.T) {
 	partitiontest.PartitionTest(t)
 

--- a/data/bookkeeping/block.go
+++ b/data/bookkeeping/block.go
@@ -53,7 +53,7 @@ type (
 		TimeStamp int64 `codec:"ts"`
 
 		// Genesis ID to which this block belongs.
-		GenesisID string `codec:"gen,allocbound=config.MaxGenesisIDLen"`
+		GenesisID string `codec:"gen,allocbound=bounds.MaxGenesisIDLen"`
 
 		// Genesis hash to which this block belongs.
 		GenesisHash crypto.Digest `codec:"gh"`
@@ -164,11 +164,11 @@ type (
 		// ExpiredParticipationAccounts contains a list of online accounts
 		// that needs to be converted to offline since their
 		// participation key expired.
-		ExpiredParticipationAccounts []basics.Address `codec:"partupdrmv,allocbound=config.MaxProposedExpiredOnlineAccounts"`
+		ExpiredParticipationAccounts []basics.Address `codec:"partupdrmv,allocbound=bounds.MaxProposedExpiredOnlineAccounts"`
 
 		// AbsentParticipationAccounts contains a list of online accounts that
 		// needs to be converted to offline since they are not proposing.
-		AbsentParticipationAccounts []basics.Address `codec:"partupdabs,allocbound=config.MaxMarkAbsent"`
+		AbsentParticipationAccounts []basics.Address `codec:"partupdabs,allocbound=bounds.MaxMarkAbsent"`
 	}
 
 	// RewardsState represents the global parameters controlling the rate
@@ -258,7 +258,7 @@ type (
 	// A Block contains the Payset and metadata corresponding to a given Round.
 	Block struct {
 		BlockHeader
-		Payset transactions.Payset `codec:"txns,maxtotalbytes=config.MaxTxnBytesPerBlock"`
+		Payset transactions.Payset `codec:"txns,maxtotalbytes=bounds.MaxTxnBytesPerBlock"`
 	}
 )
 

--- a/data/bookkeeping/msgp_gen.go
+++ b/data/bookkeeping/msgp_gen.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/algorand/msgp/msgp"
 
-	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/merklesignature"
 	"github.com/algorand/go-algorand/data/basics"
@@ -539,8 +539,8 @@ func (z *Block) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []b
 				err = msgp.WrapError(err, "struct-from-array", "GenesisID")
 				return
 			}
-			if zb0007 > config.MaxGenesisIDLen {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxGenesisIDLen))
+			if zb0007 > bounds.MaxGenesisIDLen {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(bounds.MaxGenesisIDLen))
 				return
 			}
 			(*z).BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -754,8 +754,8 @@ func (z *Block) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []b
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0010 > config.MaxProposedExpiredOnlineAccounts {
-				err = msgp.ErrOverflow(uint64(zb0010), uint64(config.MaxProposedExpiredOnlineAccounts))
+			if zb0010 > bounds.MaxProposedExpiredOnlineAccounts {
+				err = msgp.ErrOverflow(uint64(zb0010), uint64(bounds.MaxProposedExpiredOnlineAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
@@ -783,8 +783,8 @@ func (z *Block) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []b
 				err = msgp.WrapError(err, "struct-from-array", "AbsentParticipationAccounts")
 				return
 			}
-			if zb0012 > config.MaxMarkAbsent {
-				err = msgp.ErrOverflow(uint64(zb0012), uint64(config.MaxMarkAbsent))
+			if zb0012 > bounds.MaxMarkAbsent {
+				err = msgp.ErrOverflow(uint64(zb0012), uint64(bounds.MaxMarkAbsent))
 				err = msgp.WrapError(err, "struct-from-array", "AbsentParticipationAccounts")
 				return
 			}
@@ -877,8 +877,8 @@ func (z *Block) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []b
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
-				if zb0014 > config.MaxGenesisIDLen {
-					err = msgp.ErrOverflow(uint64(zb0014), uint64(config.MaxGenesisIDLen))
+				if zb0014 > bounds.MaxGenesisIDLen {
+					err = msgp.ErrOverflow(uint64(zb0014), uint64(bounds.MaxGenesisIDLen))
 					return
 				}
 				(*z).BlockHeader.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -1048,8 +1048,8 @@ func (z *Block) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []b
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0017 > config.MaxProposedExpiredOnlineAccounts {
-					err = msgp.ErrOverflow(uint64(zb0017), uint64(config.MaxProposedExpiredOnlineAccounts))
+				if zb0017 > bounds.MaxProposedExpiredOnlineAccounts {
+					err = msgp.ErrOverflow(uint64(zb0017), uint64(bounds.MaxProposedExpiredOnlineAccounts))
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
@@ -1075,8 +1075,8 @@ func (z *Block) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []b
 					err = msgp.WrapError(err, "AbsentParticipationAccounts")
 					return
 				}
-				if zb0019 > config.MaxMarkAbsent {
-					err = msgp.ErrOverflow(uint64(zb0019), uint64(config.MaxMarkAbsent))
+				if zb0019 > bounds.MaxMarkAbsent {
+					err = msgp.ErrOverflow(uint64(zb0019), uint64(bounds.MaxMarkAbsent))
 					err = msgp.WrapError(err, "AbsentParticipationAccounts")
 					return
 				}
@@ -1150,7 +1150,7 @@ func (z *Block) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func BlockMaxSize() (s int) {
-	s = 3 + 4 + basics.RoundMaxSize() + 5 + BlockHashMaxSize() + 5 + committee.SeedMaxSize() + 4 + crypto.DigestMaxSize() + 7 + crypto.DigestMaxSize() + 3 + msgp.Int64Size + 4 + msgp.StringPrefixSize + config.MaxGenesisIDLen + 3 + crypto.DigestMaxSize() + 4 + basics.AddressMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 5 + basics.AddressMaxSize() + 4 + basics.AddressMaxSize() + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 7 + basics.RoundMaxSize() + 6 + protocol.ConsensusVersionMaxSize() + 10 + protocol.ConsensusVersionMaxSize() + 8 + msgp.Uint64Size + 11 + basics.RoundMaxSize() + 11 + basics.RoundMaxSize() + 12 + protocol.ConsensusVersionMaxSize() + 13 + basics.RoundMaxSize() + 11 + msgp.BoolSize + 3 + msgp.Uint64Size + 4
+	s = 3 + 4 + basics.RoundMaxSize() + 5 + BlockHashMaxSize() + 5 + committee.SeedMaxSize() + 4 + crypto.DigestMaxSize() + 7 + crypto.DigestMaxSize() + 3 + msgp.Int64Size + 4 + msgp.StringPrefixSize + bounds.MaxGenesisIDLen + 3 + crypto.DigestMaxSize() + 4 + basics.AddressMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 5 + basics.AddressMaxSize() + 4 + basics.AddressMaxSize() + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 7 + basics.RoundMaxSize() + 6 + protocol.ConsensusVersionMaxSize() + 10 + protocol.ConsensusVersionMaxSize() + 8 + msgp.Uint64Size + 11 + basics.RoundMaxSize() + 11 + basics.RoundMaxSize() + 12 + protocol.ConsensusVersionMaxSize() + 13 + basics.RoundMaxSize() + 11 + msgp.BoolSize + 3 + msgp.Uint64Size + 4
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.BlockHeader.StateProofTracking
 	s += protocol.NumStateProofTypes * (protocol.StateProofTypeMaxSize())
@@ -1158,13 +1158,13 @@ func BlockMaxSize() (s int) {
 	s += protocol.NumStateProofTypes * (StateProofTrackingDataMaxSize())
 	s += 11
 	// Calculating size of slice: z.BlockHeader.ParticipationUpdates.ExpiredParticipationAccounts
-	s += msgp.ArrayHeaderSize + ((config.MaxProposedExpiredOnlineAccounts) * (basics.AddressMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxProposedExpiredOnlineAccounts) * (basics.AddressMaxSize()))
 	s += 11
 	// Calculating size of slice: z.BlockHeader.ParticipationUpdates.AbsentParticipationAccounts
-	s += msgp.ArrayHeaderSize + ((config.MaxMarkAbsent) * (basics.AddressMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxMarkAbsent) * (basics.AddressMaxSize()))
 	s += 5
 	// Using maxtotalbytes for: z.Payset
-	s += config.MaxTxnBytesPerBlock
+	s += bounds.MaxTxnBytesPerBlock
 	return
 }
 
@@ -1595,8 +1595,8 @@ func (z *BlockHeader) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "GenesisID")
 				return
 			}
-			if zb0007 > config.MaxGenesisIDLen {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxGenesisIDLen))
+			if zb0007 > bounds.MaxGenesisIDLen {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(bounds.MaxGenesisIDLen))
 				return
 			}
 			(*z).GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -1810,8 +1810,8 @@ func (z *BlockHeader) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0010 > config.MaxProposedExpiredOnlineAccounts {
-				err = msgp.ErrOverflow(uint64(zb0010), uint64(config.MaxProposedExpiredOnlineAccounts))
+			if zb0010 > bounds.MaxProposedExpiredOnlineAccounts {
+				err = msgp.ErrOverflow(uint64(zb0010), uint64(bounds.MaxProposedExpiredOnlineAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
@@ -1839,8 +1839,8 @@ func (z *BlockHeader) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "AbsentParticipationAccounts")
 				return
 			}
-			if zb0012 > config.MaxMarkAbsent {
-				err = msgp.ErrOverflow(uint64(zb0012), uint64(config.MaxMarkAbsent))
+			if zb0012 > bounds.MaxMarkAbsent {
+				err = msgp.ErrOverflow(uint64(zb0012), uint64(bounds.MaxMarkAbsent))
 				err = msgp.WrapError(err, "struct-from-array", "AbsentParticipationAccounts")
 				return
 			}
@@ -1925,8 +1925,8 @@ func (z *BlockHeader) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
-				if zb0014 > config.MaxGenesisIDLen {
-					err = msgp.ErrOverflow(uint64(zb0014), uint64(config.MaxGenesisIDLen))
+				if zb0014 > bounds.MaxGenesisIDLen {
+					err = msgp.ErrOverflow(uint64(zb0014), uint64(bounds.MaxGenesisIDLen))
 					return
 				}
 				(*z).GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -2096,8 +2096,8 @@ func (z *BlockHeader) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0017 > config.MaxProposedExpiredOnlineAccounts {
-					err = msgp.ErrOverflow(uint64(zb0017), uint64(config.MaxProposedExpiredOnlineAccounts))
+				if zb0017 > bounds.MaxProposedExpiredOnlineAccounts {
+					err = msgp.ErrOverflow(uint64(zb0017), uint64(bounds.MaxProposedExpiredOnlineAccounts))
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
@@ -2123,8 +2123,8 @@ func (z *BlockHeader) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "AbsentParticipationAccounts")
 					return
 				}
-				if zb0019 > config.MaxMarkAbsent {
-					err = msgp.ErrOverflow(uint64(zb0019), uint64(config.MaxMarkAbsent))
+				if zb0019 > bounds.MaxMarkAbsent {
+					err = msgp.ErrOverflow(uint64(zb0019), uint64(bounds.MaxMarkAbsent))
 					err = msgp.WrapError(err, "AbsentParticipationAccounts")
 					return
 				}
@@ -2191,7 +2191,7 @@ func (z *BlockHeader) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func BlockHeaderMaxSize() (s int) {
-	s = 3 + 4 + basics.RoundMaxSize() + 5 + BlockHashMaxSize() + 5 + committee.SeedMaxSize() + 4 + crypto.DigestMaxSize() + 7 + crypto.DigestMaxSize() + 3 + msgp.Int64Size + 4 + msgp.StringPrefixSize + config.MaxGenesisIDLen + 3 + crypto.DigestMaxSize() + 4 + basics.AddressMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 5 + basics.AddressMaxSize() + 4 + basics.AddressMaxSize() + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 7 + basics.RoundMaxSize() + 6 + protocol.ConsensusVersionMaxSize() + 10 + protocol.ConsensusVersionMaxSize() + 8 + msgp.Uint64Size + 11 + basics.RoundMaxSize() + 11 + basics.RoundMaxSize() + 12 + protocol.ConsensusVersionMaxSize() + 13 + basics.RoundMaxSize() + 11 + msgp.BoolSize + 3 + msgp.Uint64Size + 4
+	s = 3 + 4 + basics.RoundMaxSize() + 5 + BlockHashMaxSize() + 5 + committee.SeedMaxSize() + 4 + crypto.DigestMaxSize() + 7 + crypto.DigestMaxSize() + 3 + msgp.Int64Size + 4 + msgp.StringPrefixSize + bounds.MaxGenesisIDLen + 3 + crypto.DigestMaxSize() + 4 + basics.AddressMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 5 + basics.AddressMaxSize() + 4 + basics.AddressMaxSize() + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 5 + msgp.Uint64Size + 7 + basics.RoundMaxSize() + 6 + protocol.ConsensusVersionMaxSize() + 10 + protocol.ConsensusVersionMaxSize() + 8 + msgp.Uint64Size + 11 + basics.RoundMaxSize() + 11 + basics.RoundMaxSize() + 12 + protocol.ConsensusVersionMaxSize() + 13 + basics.RoundMaxSize() + 11 + msgp.BoolSize + 3 + msgp.Uint64Size + 4
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.StateProofTracking
 	s += protocol.NumStateProofTypes * (protocol.StateProofTypeMaxSize())
@@ -2199,10 +2199,10 @@ func BlockHeaderMaxSize() (s int) {
 	s += protocol.NumStateProofTypes * (StateProofTrackingDataMaxSize())
 	s += 11
 	// Calculating size of slice: z.ParticipationUpdates.ExpiredParticipationAccounts
-	s += msgp.ArrayHeaderSize + ((config.MaxProposedExpiredOnlineAccounts) * (basics.AddressMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxProposedExpiredOnlineAccounts) * (basics.AddressMaxSize()))
 	s += 11
 	// Calculating size of slice: z.ParticipationUpdates.AbsentParticipationAccounts
-	s += msgp.ArrayHeaderSize + ((config.MaxMarkAbsent) * (basics.AddressMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxMarkAbsent) * (basics.AddressMaxSize()))
 	return
 }
 
@@ -3290,8 +3290,8 @@ func (z *ParticipationUpdates) UnmarshalMsgWithState(bts []byte, st msgp.Unmarsh
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
-			if zb0005 > config.MaxProposedExpiredOnlineAccounts {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(config.MaxProposedExpiredOnlineAccounts))
+			if zb0005 > bounds.MaxProposedExpiredOnlineAccounts {
+				err = msgp.ErrOverflow(uint64(zb0005), uint64(bounds.MaxProposedExpiredOnlineAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "ExpiredParticipationAccounts")
 				return
 			}
@@ -3319,8 +3319,8 @@ func (z *ParticipationUpdates) UnmarshalMsgWithState(bts []byte, st msgp.Unmarsh
 				err = msgp.WrapError(err, "struct-from-array", "AbsentParticipationAccounts")
 				return
 			}
-			if zb0007 > config.MaxMarkAbsent {
-				err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxMarkAbsent))
+			if zb0007 > bounds.MaxMarkAbsent {
+				err = msgp.ErrOverflow(uint64(zb0007), uint64(bounds.MaxMarkAbsent))
 				err = msgp.WrapError(err, "struct-from-array", "AbsentParticipationAccounts")
 				return
 			}
@@ -3370,8 +3370,8 @@ func (z *ParticipationUpdates) UnmarshalMsgWithState(bts []byte, st msgp.Unmarsh
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
-				if zb0009 > config.MaxProposedExpiredOnlineAccounts {
-					err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxProposedExpiredOnlineAccounts))
+				if zb0009 > bounds.MaxProposedExpiredOnlineAccounts {
+					err = msgp.ErrOverflow(uint64(zb0009), uint64(bounds.MaxProposedExpiredOnlineAccounts))
 					err = msgp.WrapError(err, "ExpiredParticipationAccounts")
 					return
 				}
@@ -3397,8 +3397,8 @@ func (z *ParticipationUpdates) UnmarshalMsgWithState(bts []byte, st msgp.Unmarsh
 					err = msgp.WrapError(err, "AbsentParticipationAccounts")
 					return
 				}
-				if zb0011 > config.MaxMarkAbsent {
-					err = msgp.ErrOverflow(uint64(zb0011), uint64(config.MaxMarkAbsent))
+				if zb0011 > bounds.MaxMarkAbsent {
+					err = msgp.ErrOverflow(uint64(zb0011), uint64(bounds.MaxMarkAbsent))
 					err = msgp.WrapError(err, "AbsentParticipationAccounts")
 					return
 				}
@@ -3459,10 +3459,10 @@ func (z *ParticipationUpdates) MsgIsZero() bool {
 func ParticipationUpdatesMaxSize() (s int) {
 	s = 1 + 11
 	// Calculating size of slice: z.ExpiredParticipationAccounts
-	s += msgp.ArrayHeaderSize + ((config.MaxProposedExpiredOnlineAccounts) * (basics.AddressMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxProposedExpiredOnlineAccounts) * (basics.AddressMaxSize()))
 	s += 11
 	// Calculating size of slice: z.AbsentParticipationAccounts
-	s += msgp.ArrayHeaderSize + ((config.MaxMarkAbsent) * (basics.AddressMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxMarkAbsent) * (basics.AddressMaxSize()))
 	return
 }
 

--- a/data/transactions/application.go
+++ b/data/transactions/application.go
@@ -109,7 +109,7 @@ type ApplicationCallTxnFields struct {
 
 	// ApplicationArgs are arguments accessible to the executing
 	// ApprovalProgram or ClearStateProgram.
-	ApplicationArgs [][]byte `codec:"apaa,allocbound=encodedMaxApplicationArgs,maxtotalbytes=config.MaxAppTotalArgLen"`
+	ApplicationArgs [][]byte `codec:"apaa,allocbound=encodedMaxApplicationArgs,maxtotalbytes=bounds.MaxAppTotalArgLen"`
 
 	// Accounts are accounts whose balance records are accessible
 	// by the executing ApprovalProgram or ClearStateProgram. To
@@ -152,14 +152,14 @@ type ApplicationCallTxnFields struct {
 	// except for those where OnCompletion is equal to ClearStateOC. If
 	// this program fails, the transaction is rejected. This program may
 	// read and write local and global state for this application.
-	ApprovalProgram []byte `codec:"apap,allocbound=config.MaxAvailableAppProgramLen"`
+	ApprovalProgram []byte `codec:"apap,allocbound=bounds.MaxAvailableAppProgramLen"`
 
 	// ClearStateProgram is the stateful TEAL bytecode that executes on
 	// ApplicationCall transactions associated with this application when
 	// OnCompletion is equal to ClearStateOC. This program will not cause
 	// the transaction to be rejected, even if it fails. This program may
 	// read and write local and global state for this application.
-	ClearStateProgram []byte `codec:"apsu,allocbound=config.MaxAvailableAppProgramLen"`
+	ClearStateProgram []byte `codec:"apsu,allocbound=bounds.MaxAvailableAppProgramLen"`
 
 	// ExtraProgramPages specifies the additional app program len requested in pages.
 	// A page is MaxAppProgramLen bytes. This field enables execution of app programs
@@ -179,7 +179,7 @@ type BoxRef struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
 	Index uint64 `codec:"i"`
-	Name  []byte `codec:"n,allocbound=config.MaxBytesKeyValueLen"`
+	Name  []byte `codec:"n,allocbound=bounds.MaxBytesKeyValueLen"`
 }
 
 // Empty indicates whether or not all the fields in the

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -33,6 +33,7 @@ import (
 	"strings"
 
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
@@ -52,7 +53,7 @@ const maxStringSize = 4096
 const maxByteMathSize = 64
 
 // maxLogSize is the limit of total log size from n log calls in a program
-const maxLogSize = config.MaxEvalDeltaTotalLogSize
+const maxLogSize = bounds.MaxEvalDeltaTotalLogSize
 
 // maxLogCalls is the limit of total log calls during a program execution
 const maxLogCalls = 32
@@ -66,7 +67,7 @@ var maxAppCallDepth = 8
 // maxStackDepth should not change unless controlled by an AVM version change
 const maxStackDepth = 1000
 
-// maxTxGroupSize is the same as config.MaxTxGroupSize, but is a constant so
+// maxTxGroupSize is the same as bounds.MaxTxGroupSize, but is a constant so
 // that we can declare an array of this size. A unit test confirms that they
 // match.
 const maxTxGroupSize = 16

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
@@ -6226,5 +6227,5 @@ func TestMaxTxGroup(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	require.Equal(t, config.MaxTxGroupSize, maxTxGroupSize)
+	require.Equal(t, bounds.MaxTxGroupSize, maxTxGroupSize)
 }

--- a/data/transactions/logicsig.go
+++ b/data/transactions/logicsig.go
@@ -38,13 +38,13 @@ type LogicSig struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
 	// Logic signed by Sig or Msig, OR hashed to be the Address of an account.
-	Logic []byte `codec:"l,allocbound=config.MaxLogicSigMaxSize"`
+	Logic []byte `codec:"l,allocbound=bounds.MaxLogicSigMaxSize"`
 
 	Sig  crypto.Signature   `codec:"sig"`
 	Msig crypto.MultisigSig `codec:"msig"`
 
 	// Args are not signed, but checked by Logic
-	Args [][]byte `codec:"arg,allocbound=EvalMaxArgs,allocbound=MaxLogicSigArgSize,maxtotalbytes=config.MaxLogicSigMaxSize"`
+	Args [][]byte `codec:"arg,allocbound=EvalMaxArgs,allocbound=MaxLogicSigArgSize,maxtotalbytes=bounds.MaxLogicSigMaxSize"`
 }
 
 // Blank returns true if there is no content in this LogicSig

--- a/data/transactions/msgp_gen.go
+++ b/data/transactions/msgp_gen.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/algorand/msgp/msgp"
 
-	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/merklesignature"
 	"github.com/algorand/go-algorand/crypto/stateproof"
@@ -595,8 +595,8 @@ func (z *ApplicationCallTxnFields) UnmarshalMsgWithState(bts []byte, st msgp.Unm
 							err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0004, "struct-from-array", "Name")
 							return
 						}
-						if zb0019 > config.MaxBytesKeyValueLen {
-							err = msgp.ErrOverflow(uint64(zb0019), uint64(config.MaxBytesKeyValueLen))
+						if zb0019 > bounds.MaxBytesKeyValueLen {
+							err = msgp.ErrOverflow(uint64(zb0019), uint64(bounds.MaxBytesKeyValueLen))
 							return
 						}
 						(*z).Boxes[zb0004].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).Boxes[zb0004].Name)
@@ -641,8 +641,8 @@ func (z *ApplicationCallTxnFields) UnmarshalMsgWithState(bts []byte, st msgp.Unm
 								err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0004, "Name")
 								return
 							}
-							if zb0020 > config.MaxBytesKeyValueLen {
-								err = msgp.ErrOverflow(uint64(zb0020), uint64(config.MaxBytesKeyValueLen))
+							if zb0020 > bounds.MaxBytesKeyValueLen {
+								err = msgp.ErrOverflow(uint64(zb0020), uint64(bounds.MaxBytesKeyValueLen))
 								return
 							}
 							(*z).Boxes[zb0004].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).Boxes[zb0004].Name)
@@ -714,8 +714,8 @@ func (z *ApplicationCallTxnFields) UnmarshalMsgWithState(bts []byte, st msgp.Unm
 				err = msgp.WrapError(err, "struct-from-array", "ApprovalProgram")
 				return
 			}
-			if zb0023 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0023), uint64(config.MaxAvailableAppProgramLen))
+			if zb0023 > bounds.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0023), uint64(bounds.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
@@ -732,8 +732,8 @@ func (z *ApplicationCallTxnFields) UnmarshalMsgWithState(bts []byte, st msgp.Unm
 				err = msgp.WrapError(err, "struct-from-array", "ClearStateProgram")
 				return
 			}
-			if zb0024 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0024), uint64(config.MaxAvailableAppProgramLen))
+			if zb0024 > bounds.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0024), uint64(bounds.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
@@ -924,8 +924,8 @@ func (z *ApplicationCallTxnFields) UnmarshalMsgWithState(bts []byte, st msgp.Unm
 								err = msgp.WrapError(err, "Boxes", zb0004, "struct-from-array", "Name")
 								return
 							}
-							if zb0036 > config.MaxBytesKeyValueLen {
-								err = msgp.ErrOverflow(uint64(zb0036), uint64(config.MaxBytesKeyValueLen))
+							if zb0036 > bounds.MaxBytesKeyValueLen {
+								err = msgp.ErrOverflow(uint64(zb0036), uint64(bounds.MaxBytesKeyValueLen))
 								return
 							}
 							(*z).Boxes[zb0004].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).Boxes[zb0004].Name)
@@ -970,8 +970,8 @@ func (z *ApplicationCallTxnFields) UnmarshalMsgWithState(bts []byte, st msgp.Unm
 									err = msgp.WrapError(err, "Boxes", zb0004, "Name")
 									return
 								}
-								if zb0037 > config.MaxBytesKeyValueLen {
-									err = msgp.ErrOverflow(uint64(zb0037), uint64(config.MaxBytesKeyValueLen))
+								if zb0037 > bounds.MaxBytesKeyValueLen {
+									err = msgp.ErrOverflow(uint64(zb0037), uint64(bounds.MaxBytesKeyValueLen))
 									return
 								}
 								(*z).Boxes[zb0004].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).Boxes[zb0004].Name)
@@ -1035,8 +1035,8 @@ func (z *ApplicationCallTxnFields) UnmarshalMsgWithState(bts []byte, st msgp.Unm
 					err = msgp.WrapError(err, "ApprovalProgram")
 					return
 				}
-				if zb0040 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0040), uint64(config.MaxAvailableAppProgramLen))
+				if zb0040 > bounds.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0040), uint64(bounds.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
@@ -1051,8 +1051,8 @@ func (z *ApplicationCallTxnFields) UnmarshalMsgWithState(bts []byte, st msgp.Unm
 					err = msgp.WrapError(err, "ClearStateProgram")
 					return
 				}
-				if zb0041 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0041), uint64(config.MaxAvailableAppProgramLen))
+				if zb0041 > bounds.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0041), uint64(bounds.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
@@ -1128,7 +1128,7 @@ func (z *ApplicationCallTxnFields) MsgIsZero() bool {
 func ApplicationCallTxnFieldsMaxSize() (s int) {
 	s = 1 + 5 + basics.AppIndexMaxSize() + 5 + msgp.Uint64Size + 5
 	// Calculating size of slice: z.ApplicationArgs
-	s += msgp.ArrayHeaderSize + config.MaxAppTotalArgLen + 5
+	s += msgp.ArrayHeaderSize + bounds.MaxAppTotalArgLen + 5
 	// Calculating size of slice: z.Accounts
 	s += msgp.ArrayHeaderSize + ((encodedMaxAccounts) * (basics.AddressMaxSize()))
 	s += 5
@@ -1140,7 +1140,7 @@ func ApplicationCallTxnFieldsMaxSize() (s int) {
 	s += 5
 	// Calculating size of slice: z.ForeignAssets
 	s += msgp.ArrayHeaderSize + ((encodedMaxForeignAssets) * (basics.AssetIndexMaxSize()))
-	s += 5 + basics.StateSchemaMaxSize() + 5 + basics.StateSchemaMaxSize() + 5 + msgp.BytesPrefixSize + config.MaxAvailableAppProgramLen + 5 + msgp.BytesPrefixSize + config.MaxAvailableAppProgramLen + 5 + msgp.Uint32Size + 5 + msgp.Uint64Size
+	s += 5 + basics.StateSchemaMaxSize() + 5 + basics.StateSchemaMaxSize() + 5 + msgp.BytesPrefixSize + bounds.MaxAvailableAppProgramLen + 5 + msgp.BytesPrefixSize + bounds.MaxAvailableAppProgramLen + 5 + msgp.Uint32Size + 5 + msgp.Uint64Size
 	return
 }
 
@@ -2016,8 +2016,8 @@ func (z *BoxRef) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []
 				err = msgp.WrapError(err, "struct-from-array", "Name")
 				return
 			}
-			if zb0003 > config.MaxBytesKeyValueLen {
-				err = msgp.ErrOverflow(uint64(zb0003), uint64(config.MaxBytesKeyValueLen))
+			if zb0003 > bounds.MaxBytesKeyValueLen {
+				err = msgp.ErrOverflow(uint64(zb0003), uint64(bounds.MaxBytesKeyValueLen))
 				return
 			}
 			(*z).Name, bts, err = msgp.ReadBytesBytes(bts, (*z).Name)
@@ -2062,8 +2062,8 @@ func (z *BoxRef) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []
 					err = msgp.WrapError(err, "Name")
 					return
 				}
-				if zb0004 > config.MaxBytesKeyValueLen {
-					err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxBytesKeyValueLen))
+				if zb0004 > bounds.MaxBytesKeyValueLen {
+					err = msgp.ErrOverflow(uint64(zb0004), uint64(bounds.MaxBytesKeyValueLen))
 					return
 				}
 				(*z).Name, bts, err = msgp.ReadBytesBytes(bts, (*z).Name)
@@ -2105,7 +2105,7 @@ func (z *BoxRef) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func BoxRefMaxSize() (s int) {
-	s = 1 + 2 + msgp.Uint64Size + 2 + msgp.BytesPrefixSize + config.MaxBytesKeyValueLen
+	s = 1 + 2 + msgp.Uint64Size + 2 + msgp.BytesPrefixSize + bounds.MaxBytesKeyValueLen
 	return
 }
 
@@ -2243,8 +2243,8 @@ func (z *EvalDelta) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 				err = msgp.WrapError(err, "struct-from-array", "LocalDeltas")
 				return
 			}
-			if zb0008 > config.MaxEvalDeltaAccounts {
-				err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxEvalDeltaAccounts))
+			if zb0008 > bounds.MaxEvalDeltaAccounts {
+				err = msgp.ErrOverflow(uint64(zb0008), uint64(bounds.MaxEvalDeltaAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "LocalDeltas")
 				return
 			}
@@ -2279,8 +2279,8 @@ func (z *EvalDelta) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 				err = msgp.WrapError(err, "struct-from-array", "SharedAccts")
 				return
 			}
-			if zb0010 > config.MaxEvalDeltaAccounts {
-				err = msgp.ErrOverflow(uint64(zb0010), uint64(config.MaxEvalDeltaAccounts))
+			if zb0010 > bounds.MaxEvalDeltaAccounts {
+				err = msgp.ErrOverflow(uint64(zb0010), uint64(bounds.MaxEvalDeltaAccounts))
 				err = msgp.WrapError(err, "struct-from-array", "SharedAccts")
 				return
 			}
@@ -2308,8 +2308,8 @@ func (z *EvalDelta) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 				err = msgp.WrapError(err, "struct-from-array", "Logs")
 				return
 			}
-			if zb0012 > config.MaxLogCalls {
-				err = msgp.ErrOverflow(uint64(zb0012), uint64(config.MaxLogCalls))
+			if zb0012 > bounds.MaxLogCalls {
+				err = msgp.ErrOverflow(uint64(zb0012), uint64(bounds.MaxLogCalls))
 				err = msgp.WrapError(err, "struct-from-array", "Logs")
 				return
 			}
@@ -2337,8 +2337,8 @@ func (z *EvalDelta) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 				err = msgp.WrapError(err, "struct-from-array", "InnerTxns")
 				return
 			}
-			if zb0014 > config.MaxInnerTransactionsPerDelta {
-				err = msgp.ErrOverflow(uint64(zb0014), uint64(config.MaxInnerTransactionsPerDelta))
+			if zb0014 > bounds.MaxInnerTransactionsPerDelta {
+				err = msgp.ErrOverflow(uint64(zb0014), uint64(bounds.MaxInnerTransactionsPerDelta))
 				err = msgp.WrapError(err, "struct-from-array", "InnerTxns")
 				return
 			}
@@ -2394,8 +2394,8 @@ func (z *EvalDelta) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 					err = msgp.WrapError(err, "LocalDeltas")
 					return
 				}
-				if zb0016 > config.MaxEvalDeltaAccounts {
-					err = msgp.ErrOverflow(uint64(zb0016), uint64(config.MaxEvalDeltaAccounts))
+				if zb0016 > bounds.MaxEvalDeltaAccounts {
+					err = msgp.ErrOverflow(uint64(zb0016), uint64(bounds.MaxEvalDeltaAccounts))
 					err = msgp.WrapError(err, "LocalDeltas")
 					return
 				}
@@ -2428,8 +2428,8 @@ func (z *EvalDelta) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 					err = msgp.WrapError(err, "SharedAccts")
 					return
 				}
-				if zb0018 > config.MaxEvalDeltaAccounts {
-					err = msgp.ErrOverflow(uint64(zb0018), uint64(config.MaxEvalDeltaAccounts))
+				if zb0018 > bounds.MaxEvalDeltaAccounts {
+					err = msgp.ErrOverflow(uint64(zb0018), uint64(bounds.MaxEvalDeltaAccounts))
 					err = msgp.WrapError(err, "SharedAccts")
 					return
 				}
@@ -2455,8 +2455,8 @@ func (z *EvalDelta) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 					err = msgp.WrapError(err, "Logs")
 					return
 				}
-				if zb0020 > config.MaxLogCalls {
-					err = msgp.ErrOverflow(uint64(zb0020), uint64(config.MaxLogCalls))
+				if zb0020 > bounds.MaxLogCalls {
+					err = msgp.ErrOverflow(uint64(zb0020), uint64(bounds.MaxLogCalls))
 					err = msgp.WrapError(err, "Logs")
 					return
 				}
@@ -2482,8 +2482,8 @@ func (z *EvalDelta) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 					err = msgp.WrapError(err, "InnerTxns")
 					return
 				}
-				if zb0022 > config.MaxInnerTransactionsPerDelta {
-					err = msgp.ErrOverflow(uint64(zb0022), uint64(config.MaxInnerTransactionsPerDelta))
+				if zb0022 > bounds.MaxInnerTransactionsPerDelta {
+					err = msgp.ErrOverflow(uint64(zb0022), uint64(bounds.MaxInnerTransactionsPerDelta))
 					err = msgp.WrapError(err, "InnerTxns")
 					return
 				}
@@ -2557,17 +2557,17 @@ func EvalDeltaMaxSize() (s int) {
 	s = 1 + 3 + basics.StateDeltaMaxSize() + 3
 	s += msgp.MapHeaderSize
 	// Adding size of map keys for z.LocalDeltas
-	s += config.MaxEvalDeltaAccounts * (msgp.Uint64Size)
+	s += bounds.MaxEvalDeltaAccounts * (msgp.Uint64Size)
 	// Adding size of map values for z.LocalDeltas
-	s += config.MaxEvalDeltaAccounts * (basics.StateDeltaMaxSize())
+	s += bounds.MaxEvalDeltaAccounts * (basics.StateDeltaMaxSize())
 	s += 3
 	// Calculating size of slice: z.SharedAccts
-	s += msgp.ArrayHeaderSize + ((config.MaxEvalDeltaAccounts) * (basics.AddressMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxEvalDeltaAccounts) * (basics.AddressMaxSize()))
 	s += 3
 	// Calculating size of slice: z.Logs
-	s += msgp.ArrayHeaderSize + (config.MaxLogCalls * msgp.StringPrefixSize) + config.MaxEvalDeltaTotalLogSize + 4
+	s += msgp.ArrayHeaderSize + (bounds.MaxLogCalls * msgp.StringPrefixSize) + bounds.MaxEvalDeltaTotalLogSize + 4
 	// Calculating size of slice: z.InnerTxns
-	s += msgp.ArrayHeaderSize + ((config.MaxInnerTransactionsPerDelta) * (SignedTxnWithADMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxInnerTransactionsPerDelta) * (SignedTxnWithADMaxSize()))
 	return
 }
 
@@ -2737,8 +2737,8 @@ func (z *Header) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []
 				err = msgp.WrapError(err, "struct-from-array", "Note")
 				return
 			}
-			if zb0004 > config.MaxTxnNoteBytes {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxTxnNoteBytes))
+			if zb0004 > bounds.MaxTxnNoteBytes {
+				err = msgp.ErrOverflow(uint64(zb0004), uint64(bounds.MaxTxnNoteBytes))
 				return
 			}
 			(*z).Note, bts, err = msgp.ReadBytesBytes(bts, (*z).Note)
@@ -2755,8 +2755,8 @@ func (z *Header) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []
 				err = msgp.WrapError(err, "struct-from-array", "GenesisID")
 				return
 			}
-			if zb0005 > config.MaxGenesisIDLen {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(config.MaxGenesisIDLen))
+			if zb0005 > bounds.MaxGenesisIDLen {
+				err = msgp.ErrOverflow(uint64(zb0005), uint64(bounds.MaxGenesisIDLen))
 				return
 			}
 			(*z).GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -2851,8 +2851,8 @@ func (z *Header) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []
 					err = msgp.WrapError(err, "Note")
 					return
 				}
-				if zb0006 > config.MaxTxnNoteBytes {
-					err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxTxnNoteBytes))
+				if zb0006 > bounds.MaxTxnNoteBytes {
+					err = msgp.ErrOverflow(uint64(zb0006), uint64(bounds.MaxTxnNoteBytes))
 					return
 				}
 				(*z).Note, bts, err = msgp.ReadBytesBytes(bts, (*z).Note)
@@ -2867,8 +2867,8 @@ func (z *Header) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
-				if zb0007 > config.MaxGenesisIDLen {
-					err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxGenesisIDLen))
+				if zb0007 > bounds.MaxGenesisIDLen {
+					err = msgp.ErrOverflow(uint64(zb0007), uint64(bounds.MaxGenesisIDLen))
 					return
 				}
 				(*z).GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -2934,7 +2934,7 @@ func (z *Header) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func HeaderMaxSize() (s int) {
-	s = 1 + 4 + basics.AddressMaxSize() + 4 + basics.MicroAlgosMaxSize() + 3 + basics.RoundMaxSize() + 3 + basics.RoundMaxSize() + 5 + msgp.BytesPrefixSize + config.MaxTxnNoteBytes + 4 + msgp.StringPrefixSize + config.MaxGenesisIDLen + 3 + crypto.DigestMaxSize() + 4 + crypto.DigestMaxSize() + 3
+	s = 1 + 4 + basics.AddressMaxSize() + 4 + basics.MicroAlgosMaxSize() + 3 + basics.RoundMaxSize() + 3 + basics.RoundMaxSize() + 5 + msgp.BytesPrefixSize + bounds.MaxTxnNoteBytes + 4 + msgp.StringPrefixSize + bounds.MaxGenesisIDLen + 3 + crypto.DigestMaxSize() + 4 + crypto.DigestMaxSize() + 3
 	// Calculating size of array: z.Lease
 	s += msgp.ArrayHeaderSize + ((32) * (msgp.ByteSize))
 	s += 6 + basics.AddressMaxSize()
@@ -3498,8 +3498,8 @@ func (z *LogicSig) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o 
 				err = msgp.WrapError(err, "struct-from-array", "Logic")
 				return
 			}
-			if zb0004 > config.MaxLogicSigMaxSize {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxLogicSigMaxSize))
+			if zb0004 > bounds.MaxLogicSigMaxSize {
+				err = msgp.ErrOverflow(uint64(zb0004), uint64(bounds.MaxLogicSigMaxSize))
 				return
 			}
 			(*z).Logic, bts, err = msgp.ReadBytesBytes(bts, (*z).Logic)
@@ -3593,8 +3593,8 @@ func (z *LogicSig) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o 
 					err = msgp.WrapError(err, "Logic")
 					return
 				}
-				if zb0008 > config.MaxLogicSigMaxSize {
-					err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxLogicSigMaxSize))
+				if zb0008 > bounds.MaxLogicSigMaxSize {
+					err = msgp.ErrOverflow(uint64(zb0008), uint64(bounds.MaxLogicSigMaxSize))
 					return
 				}
 				(*z).Logic, bts, err = msgp.ReadBytesBytes(bts, (*z).Logic)
@@ -3688,9 +3688,9 @@ func (z *LogicSig) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func LogicSigMaxSize() (s int) {
-	s = 1 + 2 + msgp.BytesPrefixSize + config.MaxLogicSigMaxSize + 4 + crypto.SignatureMaxSize() + 5 + crypto.MultisigSigMaxSize() + 4
+	s = 1 + 2 + msgp.BytesPrefixSize + bounds.MaxLogicSigMaxSize + 4 + crypto.SignatureMaxSize() + 5 + crypto.MultisigSigMaxSize() + 4
 	// Calculating size of slice: z.Args
-	s += msgp.ArrayHeaderSize + config.MaxLogicSigMaxSize
+	s += msgp.ArrayHeaderSize + bounds.MaxLogicSigMaxSize
 	return
 }
 
@@ -5801,8 +5801,8 @@ func (z *Transaction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "Note")
 				return
 			}
-			if zb0009 > config.MaxTxnNoteBytes {
-				err = msgp.ErrOverflow(uint64(zb0009), uint64(config.MaxTxnNoteBytes))
+			if zb0009 > bounds.MaxTxnNoteBytes {
+				err = msgp.ErrOverflow(uint64(zb0009), uint64(bounds.MaxTxnNoteBytes))
 				return
 			}
 			(*z).Header.Note, bts, err = msgp.ReadBytesBytes(bts, (*z).Header.Note)
@@ -5819,8 +5819,8 @@ func (z *Transaction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "GenesisID")
 				return
 			}
-			if zb0010 > config.MaxGenesisIDLen {
-				err = msgp.ErrOverflow(uint64(zb0010), uint64(config.MaxGenesisIDLen))
+			if zb0010 > bounds.MaxGenesisIDLen {
+				err = msgp.ErrOverflow(uint64(zb0010), uint64(bounds.MaxGenesisIDLen))
 				return
 			}
 			(*z).Header.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -6175,8 +6175,8 @@ func (z *Transaction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 							err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0005, "struct-from-array", "Name")
 							return
 						}
-						if zb0022 > config.MaxBytesKeyValueLen {
-							err = msgp.ErrOverflow(uint64(zb0022), uint64(config.MaxBytesKeyValueLen))
+						if zb0022 > bounds.MaxBytesKeyValueLen {
+							err = msgp.ErrOverflow(uint64(zb0022), uint64(bounds.MaxBytesKeyValueLen))
 							return
 						}
 						(*z).ApplicationCallTxnFields.Boxes[zb0005].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.Boxes[zb0005].Name)
@@ -6221,8 +6221,8 @@ func (z *Transaction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 								err = msgp.WrapError(err, "struct-from-array", "Boxes", zb0005, "Name")
 								return
 							}
-							if zb0023 > config.MaxBytesKeyValueLen {
-								err = msgp.ErrOverflow(uint64(zb0023), uint64(config.MaxBytesKeyValueLen))
+							if zb0023 > bounds.MaxBytesKeyValueLen {
+								err = msgp.ErrOverflow(uint64(zb0023), uint64(bounds.MaxBytesKeyValueLen))
 								return
 							}
 							(*z).ApplicationCallTxnFields.Boxes[zb0005].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.Boxes[zb0005].Name)
@@ -6294,8 +6294,8 @@ func (z *Transaction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "ApprovalProgram")
 				return
 			}
-			if zb0026 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0026), uint64(config.MaxAvailableAppProgramLen))
+			if zb0026 > bounds.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0026), uint64(bounds.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ApplicationCallTxnFields.ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.ApprovalProgram)
@@ -6312,8 +6312,8 @@ func (z *Transaction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 				err = msgp.WrapError(err, "struct-from-array", "ClearStateProgram")
 				return
 			}
-			if zb0027 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0027), uint64(config.MaxAvailableAppProgramLen))
+			if zb0027 > bounds.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0027), uint64(bounds.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ApplicationCallTxnFields.ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.ClearStateProgram)
@@ -6441,8 +6441,8 @@ func (z *Transaction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "Note")
 					return
 				}
-				if zb0028 > config.MaxTxnNoteBytes {
-					err = msgp.ErrOverflow(uint64(zb0028), uint64(config.MaxTxnNoteBytes))
+				if zb0028 > bounds.MaxTxnNoteBytes {
+					err = msgp.ErrOverflow(uint64(zb0028), uint64(bounds.MaxTxnNoteBytes))
 					return
 				}
 				(*z).Header.Note, bts, err = msgp.ReadBytesBytes(bts, (*z).Header.Note)
@@ -6457,8 +6457,8 @@ func (z *Transaction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "GenesisID")
 					return
 				}
-				if zb0029 > config.MaxGenesisIDLen {
-					err = msgp.ErrOverflow(uint64(zb0029), uint64(config.MaxGenesisIDLen))
+				if zb0029 > bounds.MaxGenesisIDLen {
+					err = msgp.ErrOverflow(uint64(zb0029), uint64(bounds.MaxGenesisIDLen))
 					return
 				}
 				(*z).Header.GenesisID, bts, err = msgp.ReadStringBytes(bts)
@@ -6753,8 +6753,8 @@ func (z *Transaction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 								err = msgp.WrapError(err, "Boxes", zb0005, "struct-from-array", "Name")
 								return
 							}
-							if zb0041 > config.MaxBytesKeyValueLen {
-								err = msgp.ErrOverflow(uint64(zb0041), uint64(config.MaxBytesKeyValueLen))
+							if zb0041 > bounds.MaxBytesKeyValueLen {
+								err = msgp.ErrOverflow(uint64(zb0041), uint64(bounds.MaxBytesKeyValueLen))
 								return
 							}
 							(*z).ApplicationCallTxnFields.Boxes[zb0005].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.Boxes[zb0005].Name)
@@ -6799,8 +6799,8 @@ func (z *Transaction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 									err = msgp.WrapError(err, "Boxes", zb0005, "Name")
 									return
 								}
-								if zb0042 > config.MaxBytesKeyValueLen {
-									err = msgp.ErrOverflow(uint64(zb0042), uint64(config.MaxBytesKeyValueLen))
+								if zb0042 > bounds.MaxBytesKeyValueLen {
+									err = msgp.ErrOverflow(uint64(zb0042), uint64(bounds.MaxBytesKeyValueLen))
 									return
 								}
 								(*z).ApplicationCallTxnFields.Boxes[zb0005].Name, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.Boxes[zb0005].Name)
@@ -6864,8 +6864,8 @@ func (z *Transaction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "ApprovalProgram")
 					return
 				}
-				if zb0045 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0045), uint64(config.MaxAvailableAppProgramLen))
+				if zb0045 > bounds.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0045), uint64(bounds.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ApplicationCallTxnFields.ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.ApprovalProgram)
@@ -6880,8 +6880,8 @@ func (z *Transaction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) 
 					err = msgp.WrapError(err, "ClearStateProgram")
 					return
 				}
-				if zb0046 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0046), uint64(config.MaxAvailableAppProgramLen))
+				if zb0046 > bounds.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0046), uint64(bounds.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ApplicationCallTxnFields.ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApplicationCallTxnFields.ClearStateProgram)
@@ -6995,12 +6995,12 @@ func (z *Transaction) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func TransactionMaxSize() (s int) {
-	s = 3 + 5 + protocol.TxTypeMaxSize() + 4 + basics.AddressMaxSize() + 4 + basics.MicroAlgosMaxSize() + 3 + basics.RoundMaxSize() + 3 + basics.RoundMaxSize() + 5 + msgp.BytesPrefixSize + config.MaxTxnNoteBytes + 4 + msgp.StringPrefixSize + config.MaxGenesisIDLen + 3 + crypto.DigestMaxSize() + 4 + crypto.DigestMaxSize() + 3
+	s = 3 + 5 + protocol.TxTypeMaxSize() + 4 + basics.AddressMaxSize() + 4 + basics.MicroAlgosMaxSize() + 3 + basics.RoundMaxSize() + 3 + basics.RoundMaxSize() + 5 + msgp.BytesPrefixSize + bounds.MaxTxnNoteBytes + 4 + msgp.StringPrefixSize + bounds.MaxGenesisIDLen + 3 + crypto.DigestMaxSize() + 4 + crypto.DigestMaxSize() + 3
 	// Calculating size of array: z.Header.Lease
 	s += msgp.ArrayHeaderSize + ((32) * (msgp.ByteSize))
 	s += 6 + basics.AddressMaxSize() + 8 + crypto.OneTimeSignatureVerifierMaxSize() + 7 + crypto.VRFVerifierMaxSize() + 8 + merklesignature.CommitmentMaxSize() + 8 + basics.RoundMaxSize() + 8 + basics.RoundMaxSize() + 7 + msgp.Uint64Size + 8 + msgp.BoolSize + 4 + basics.AddressMaxSize() + 4 + basics.MicroAlgosMaxSize() + 6 + basics.AddressMaxSize() + 5 + basics.AssetIndexMaxSize() + 5 + basics.AssetParamsMaxSize() + 5 + basics.AssetIndexMaxSize() + 5 + msgp.Uint64Size + 5 + basics.AddressMaxSize() + 5 + basics.AddressMaxSize() + 7 + basics.AddressMaxSize() + 5 + basics.AddressMaxSize() + 5 + basics.AssetIndexMaxSize() + 5 + msgp.BoolSize + 5 + basics.AppIndexMaxSize() + 5 + msgp.Uint64Size + 5
 	// Calculating size of slice: z.ApplicationCallTxnFields.ApplicationArgs
-	s += msgp.ArrayHeaderSize + config.MaxAppTotalArgLen + 5
+	s += msgp.ArrayHeaderSize + bounds.MaxAppTotalArgLen + 5
 	// Calculating size of slice: z.ApplicationCallTxnFields.Accounts
 	s += msgp.ArrayHeaderSize + ((encodedMaxAccounts) * (basics.AddressMaxSize()))
 	s += 5
@@ -7012,7 +7012,7 @@ func TransactionMaxSize() (s int) {
 	s += 5
 	// Calculating size of slice: z.ApplicationCallTxnFields.ForeignAssets
 	s += msgp.ArrayHeaderSize + ((encodedMaxForeignAssets) * (basics.AssetIndexMaxSize()))
-	s += 5 + basics.StateSchemaMaxSize() + 5 + basics.StateSchemaMaxSize() + 5 + msgp.BytesPrefixSize + config.MaxAvailableAppProgramLen + 5 + msgp.BytesPrefixSize + config.MaxAvailableAppProgramLen + 5 + msgp.Uint32Size + 5 + msgp.Uint64Size + 7 + protocol.StateProofTypeMaxSize() + 3 + stateproof.StateProofMaxSize() + 6 + stateproofmsg.MessageMaxSize() + 3
+	s += 5 + basics.StateSchemaMaxSize() + 5 + basics.StateSchemaMaxSize() + 5 + msgp.BytesPrefixSize + bounds.MaxAvailableAppProgramLen + 5 + msgp.BytesPrefixSize + bounds.MaxAvailableAppProgramLen + 5 + msgp.Uint32Size + 5 + msgp.Uint64Size + 7 + protocol.StateProofTypeMaxSize() + 3 + stateproof.StateProofMaxSize() + 6 + stateproofmsg.MessageMaxSize() + 3
 	s += HeartbeatTxnFieldsMaxSize()
 	return
 }
@@ -7078,8 +7078,8 @@ func (z *TxGroup) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o [
 				err = msgp.WrapError(err, "struct-from-array", "TxGroupHashes")
 				return
 			}
-			if zb0004 > config.MaxTxGroupSize {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxTxGroupSize))
+			if zb0004 > bounds.MaxTxGroupSize {
+				err = msgp.ErrOverflow(uint64(zb0004), uint64(bounds.MaxTxGroupSize))
 				err = msgp.WrapError(err, "struct-from-array", "TxGroupHashes")
 				return
 			}
@@ -7129,8 +7129,8 @@ func (z *TxGroup) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o [
 					err = msgp.WrapError(err, "TxGroupHashes")
 					return
 				}
-				if zb0006 > config.MaxTxGroupSize {
-					err = msgp.ErrOverflow(uint64(zb0006), uint64(config.MaxTxGroupSize))
+				if zb0006 > bounds.MaxTxGroupSize {
+					err = msgp.ErrOverflow(uint64(zb0006), uint64(bounds.MaxTxGroupSize))
 					err = msgp.WrapError(err, "TxGroupHashes")
 					return
 				}
@@ -7187,7 +7187,7 @@ func (z *TxGroup) MsgIsZero() bool {
 func TxGroupMaxSize() (s int) {
 	s = 1 + 7
 	// Calculating size of slice: z.TxGroupHashes
-	s += msgp.ArrayHeaderSize + ((config.MaxTxGroupSize) * (crypto.DigestMaxSize()))
+	s += msgp.ArrayHeaderSize + ((bounds.MaxTxGroupSize) * (crypto.DigestMaxSize()))
 	return
 }
 

--- a/data/transactions/teal.go
+++ b/data/transactions/teal.go
@@ -35,18 +35,18 @@ type EvalDelta struct {
 
 	// When decoding EvalDeltas, the integer key represents an offset into
 	// [txn.Sender, txn.Accounts[0], txn.Accounts[1], ..., SharedAccts[0], SharedAccts[1], ...]
-	LocalDeltas map[uint64]basics.StateDelta `codec:"ld,allocbound=config.MaxEvalDeltaAccounts"`
+	LocalDeltas map[uint64]basics.StateDelta `codec:"ld,allocbound=bounds.MaxEvalDeltaAccounts"`
 
 	// If a program modifies the local of an account that is not the Sender, or
 	// in txn.Accounts, it must be recorded here, so that the key in LocalDeltas
 	// can refer to it.
-	SharedAccts []basics.Address `codec:"sa,allocbound=config.MaxEvalDeltaAccounts"`
+	SharedAccts []basics.Address `codec:"sa,allocbound=bounds.MaxEvalDeltaAccounts"`
 
-	// The total allocbound calculation here accounts for the worse possible case of having config.MaxLogCalls individual log entries
-	// with the legnth of all of them summing up to config.MaxEvalDeltaTotalLogSize which is the limit for the sum of individual log lengths
-	Logs []string `codec:"lg,allocbound=config.MaxLogCalls,maxtotalbytes=(config.MaxLogCalls*msgp.StringPrefixSize) + config.MaxEvalDeltaTotalLogSize"`
+	// The total allocbound calculation here accounts for the worse possible case of having bounds.MaxLogCalls individual log entries
+	// with the length of all of them summing up to bounds.MaxEvalDeltaTotalLogSize which is the limit for the sum of individual log lengths
+	Logs []string `codec:"lg,allocbound=bounds.MaxLogCalls,maxtotalbytes=(bounds.MaxLogCalls*msgp.StringPrefixSize) + bounds.MaxEvalDeltaTotalLogSize"`
 
-	InnerTxns []SignedTxnWithAD `codec:"itx,allocbound=config.MaxInnerTransactionsPerDelta"`
+	InnerTxns []SignedTxnWithAD `codec:"itx,allocbound=bounds.MaxInnerTransactionsPerDelta"`
 }
 
 // Equal compares two EvalDeltas and returns whether or not they are

--- a/data/transactions/teal_test.go
+++ b/data/transactions/teal_test.go
@@ -202,7 +202,7 @@ func TestUnchangedAllocBounds(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	delta := &EvalDelta{}
-	max := 256 // Hardcodes config.MaxEvalDeltaAccounts
+	max := 256 // Hardcodes bounds.MaxEvalDeltaAccounts
 	for i := 0; i < max; i++ {
 		delta.InnerTxns = append(delta.InnerTxns, SignedTxnWithAD{})
 		msg := delta.MarshalMsg(nil)
@@ -215,7 +215,7 @@ func TestUnchangedAllocBounds(t *testing.T) {
 	require.Error(t, err)
 
 	delta = &EvalDelta{}
-	max = 2048 // Hardcodes config.MaxLogCalls, currently MaxAppProgramLen
+	max = 2048 // Hardcodes bounds.MaxLogCalls, currently MaxAppProgramLen
 	for i := 0; i < max; i++ {
 		delta.Logs = append(delta.Logs, "junk")
 		msg := delta.MarshalMsg(nil)
@@ -228,7 +228,7 @@ func TestUnchangedAllocBounds(t *testing.T) {
 	require.Error(t, err)
 
 	delta = &EvalDelta{}
-	max = 256 // Hardcodes config.MaxInnerTransactionsPerDelta
+	max = 256 // Hardcodes bounds.MaxInnerTransactionsPerDelta
 	for i := 0; i < max; i++ {
 		delta.InnerTxns = append(delta.InnerTxns, SignedTxnWithAD{})
 		msg := delta.MarshalMsg(nil)
@@ -244,7 +244,7 @@ func TestUnchangedAllocBounds(t *testing.T) {
 	// MaxAppTxnAccounts (4) + 1, since the key must be an index in the static
 	// array of touchable accounts.
 	delta = &EvalDelta{LocalDeltas: make(map[uint64]basics.StateDelta)}
-	max = 2048 // Hardcodes config.MaxEvalDeltaAccounts
+	max = 2048 // Hardcodes bounds.MaxEvalDeltaAccounts
 	for i := 0; i < max; i++ {
 		delta.LocalDeltas[uint64(i)] = basics.StateDelta{}
 		msg := delta.MarshalMsg(nil)
@@ -260,7 +260,7 @@ func TestUnchangedAllocBounds(t *testing.T) {
 	// globals, but I don't know what happens if you set and delete 65 (or way
 	// more) keys in a single transaction.
 	delta = &EvalDelta{GlobalDelta: make(basics.StateDelta)}
-	max = 2048 // Hardcodes config.MaxStateDeltaKeys
+	max = 2048 // Hardcodes bounds.MaxStateDeltaKeys
 	for i := 0; i < max; i++ {
 		delta.GlobalDelta[fmt.Sprintf("%d", i)] = basics.ValueDelta{}
 		msg := delta.MarshalMsg(nil)

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -58,8 +58,8 @@ type Header struct {
 	Fee         basics.MicroAlgos `codec:"fee"`
 	FirstValid  basics.Round      `codec:"fv"`
 	LastValid   basics.Round      `codec:"lv"`
-	Note        []byte            `codec:"note,allocbound=config.MaxTxnNoteBytes"` // Uniqueness or app-level data about txn
-	GenesisID   string            `codec:"gen,allocbound=config.MaxGenesisIDLen"`
+	Note        []byte            `codec:"note,allocbound=bounds.MaxTxnNoteBytes"` // Uniqueness or app-level data about txn
+	GenesisID   string            `codec:"gen,allocbound=bounds.MaxGenesisIDLen"`
 	GenesisHash crypto.Digest     `codec:"gh"`
 
 	// Group specifies that this transaction is part of a
@@ -169,7 +169,7 @@ type TxGroup struct {
 	// valid.  Each hash in the list is a hash of a transaction with
 	// the `Group` field omitted.
 	// These are all `Txid` which is equivalent to `crypto.Digest`
-	TxGroupHashes []crypto.Digest `codec:"txlist,allocbound=config.MaxTxGroupSize"`
+	TxGroupHashes []crypto.Digest `codec:"txlist,allocbound=bounds.MaxTxGroupSize"`
 }
 
 // ToBeHashed implements the crypto.Hashable interface.

--- a/data/txDupCache.go
+++ b/data/txDupCache.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-deadlock"
 
@@ -263,6 +263,6 @@ var saltedPool = sync.Pool{
 		// 2 x MaxAvailableAppProgramLen that covers
 		// max approve + clear state programs with max args for app create txn.
 		// other transactions are much smaller.
-		return make([]byte, 2*config.MaxAvailableAppProgramLen)
+		return make([]byte, 2*bounds.MaxAvailableAppProgramLen)
 	},
 }

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/pools"
@@ -781,7 +782,7 @@ func decodeMsg(data []byte) (unverifiedTxGroup []transactions.SignedTxn, consume
 		}
 		consumed = dec.Consumed()
 		ntx++
-		if ntx >= config.MaxTxGroupSize {
+		if ntx >= bounds.MaxTxGroupSize {
 			// max ever possible group size reached, done reading input.
 			if dec.Remaining() > 0 {
 				// if something else left in the buffer - this is an error, drop
@@ -797,7 +798,7 @@ func decodeMsg(data []byte) (unverifiedTxGroup []transactions.SignedTxn, consume
 
 	unverifiedTxGroup = unverifiedTxGroup[:ntx]
 
-	if ntx == config.MaxTxGroupSize {
+	if ntx == bounds.MaxTxGroupSize {
 		transactionMessageTxGroupFull.Inc(nil)
 	}
 

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/components/mocks"
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
@@ -619,11 +620,11 @@ func TestTxHandlerProcessIncomingGroup(t *testing.T) {
 		action     network.ForwardingPolicy
 	}
 	var checks = []T{}
-	for i := 1; i <= config.MaxTxGroupSize; i++ {
+	for i := 1; i <= bounds.MaxTxGroupSize; i++ {
 		checks = append(checks, T{i, i, network.Ignore})
 	}
 	for i := 1; i < 10; i++ {
-		checks = append(checks, T{config.MaxTxGroupSize + i, 0, network.Disconnect})
+		checks = append(checks, T{bounds.MaxTxGroupSize + i, 0, network.Disconnect})
 	}
 
 	for _, check := range checks {
@@ -728,8 +729,8 @@ func TestTxHandlerProcessIncomingCensoring(t *testing.T) {
 
 	t.Run("group", func(t *testing.T) {
 		handler := makeTestTxHandlerOrphanedWithContext(context.Background(), txBacklogSize, txBacklogSize, txHandlerConfig{true, true}, 0)
-		num := rand.Intn(config.MaxTxGroupSize-1) + 2 // 2..config.MaxTxGroupSize
-		require.LessOrEqual(t, num, config.MaxTxGroupSize)
+		num := rand.Intn(bounds.MaxTxGroupSize-1) + 2 // 2..bounds.MaxTxGroupSize
+		require.LessOrEqual(t, num, bounds.MaxTxGroupSize)
 		stxns, blob := makeRandomTransactions(num)
 		action := handler.processIncomingTxn(network.IncomingMessage{Data: blob})
 		require.Equal(t, network.OutgoingMessage{Action: network.Ignore}, action)
@@ -2187,7 +2188,7 @@ func TestTxHandlerRememberReportErrorsWithTxPool(t *testing.T) { //nolint:parall
 	const inMem = true
 	cfg := config.GetDefaultLocal()
 	cfg.Archival = true
-	cfg.TxPoolSize = config.MaxTxGroupSize + 1
+	cfg.TxPoolSize = bounds.MaxTxGroupSize + 1
 	ledger, err := LoadLedger(log, ledgerName, inMem, protocol.ConsensusCurrentVersion, genBal, genesisID, genesisHash, cfg)
 	require.NoError(t, err)
 	defer ledger.Close()
@@ -2247,7 +2248,7 @@ func TestTxHandlerRememberReportErrorsWithTxPool(t *testing.T) { //nolint:parall
 
 	// trigger group too large error
 	wi.unverifiedTxGroup = []transactions.SignedTxn{txn1.Sign(secrets[0])}
-	for i := 0; i < config.MaxTxGroupSize; i++ {
+	for i := 0; i < bounds.MaxTxGroupSize; i++ {
 		txn := txn1
 		crypto.RandBytes(txn.Note[:])
 		wi.unverifiedTxGroup = append(wi.unverifiedTxGroup, txn.Sign(secrets[0]))

--- a/ledger/acctdeltas_test.go
+++ b/ledger/acctdeltas_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/algorand/avm-abi/apps"
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/merklesignature"
 	"github.com/algorand/go-algorand/data/basics"
@@ -3391,9 +3392,9 @@ func randomAppResourceData() trackerdb.ResourcesData {
 	}
 
 	// MaxAvailableAppProgramLen is conbined size of approval and clear state since it is bound by proto.MaxAppTotalProgramLen
-	rdApp.ApprovalProgram = make([]byte, config.MaxAvailableAppProgramLen/2)
+	rdApp.ApprovalProgram = make([]byte, bounds.MaxAvailableAppProgramLen/2)
 	crypto.RandBytes(rdApp.ApprovalProgram)
-	rdApp.ClearStateProgram = make([]byte, config.MaxAvailableAppProgramLen/2)
+	rdApp.ClearStateProgram = make([]byte, bounds.MaxAvailableAppProgramLen/2)
 	crypto.RandBytes(rdApp.ClearStateProgram)
 
 	maxGlobalState := make(basics.TealKeyValue, currentConsensusParams.MaxGlobalSchemaEntries)

--- a/ledger/simulation/trace.go
+++ b/ledger/simulation/trace.go
@@ -19,7 +19,7 @@ package simulation
 import (
 	"fmt"
 
-	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -108,7 +108,7 @@ const MaxExtraOpcodeBudget = uint64(20000 * 16)
 // - otherwise, set `LogLimits` field to be nil
 func (eo ResultEvalOverrides) AllowMoreLogging(allow bool) ResultEvalOverrides {
 	if allow {
-		maxLogCalls, maxLogSize := uint64(config.MaxLogCalls), LogBytesLimit
+		maxLogCalls, maxLogSize := uint64(bounds.MaxLogCalls), LogBytesLimit
 		eo.MaxLogCalls = &maxLogCalls
 		eo.MaxLogSize = &maxLogSize
 	}

--- a/ledger/store/trackerdb/data.go
+++ b/ledger/store/trackerdb/data.go
@@ -112,8 +112,8 @@ type ResourcesData struct {
 	KeyValue           basics.TealKeyValue `codec:"p"`
 
 	// application global params ( basics.AppParams )
-	ApprovalProgram               []byte              `codec:"q,allocbound=config.MaxAvailableAppProgramLen"`
-	ClearStateProgram             []byte              `codec:"r,allocbound=config.MaxAvailableAppProgramLen"`
+	ApprovalProgram               []byte              `codec:"q,allocbound=bounds.MaxAvailableAppProgramLen"`
+	ClearStateProgram             []byte              `codec:"r,allocbound=bounds.MaxAvailableAppProgramLen"`
 	GlobalState                   basics.TealKeyValue `codec:"s"`
 	LocalStateSchemaNumUint       uint64              `codec:"t"`
 	LocalStateSchemaNumByteSlice  uint64              `codec:"u"`

--- a/ledger/store/trackerdb/msgp_gen.go
+++ b/ledger/store/trackerdb/msgp_gen.go
@@ -5,7 +5,7 @@ package trackerdb
 import (
 	"github.com/algorand/msgp/msgp"
 
-	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/merklesignature"
 	"github.com/algorand/go-algorand/data/basics"
@@ -2155,8 +2155,8 @@ func (z *ResourcesData) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState
 				err = msgp.WrapError(err, "struct-from-array", "ApprovalProgram")
 				return
 			}
-			if zb0004 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0004), uint64(config.MaxAvailableAppProgramLen))
+			if zb0004 > bounds.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0004), uint64(bounds.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
@@ -2173,8 +2173,8 @@ func (z *ResourcesData) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState
 				err = msgp.WrapError(err, "struct-from-array", "ClearStateProgram")
 				return
 			}
-			if zb0005 > config.MaxAvailableAppProgramLen {
-				err = msgp.ErrOverflow(uint64(zb0005), uint64(config.MaxAvailableAppProgramLen))
+			if zb0005 > bounds.MaxAvailableAppProgramLen {
+				err = msgp.ErrOverflow(uint64(zb0005), uint64(bounds.MaxAvailableAppProgramLen))
 				return
 			}
 			(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
@@ -2385,8 +2385,8 @@ func (z *ResourcesData) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState
 					err = msgp.WrapError(err, "ApprovalProgram")
 					return
 				}
-				if zb0007 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0007), uint64(config.MaxAvailableAppProgramLen))
+				if zb0007 > bounds.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0007), uint64(bounds.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ApprovalProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ApprovalProgram)
@@ -2401,8 +2401,8 @@ func (z *ResourcesData) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState
 					err = msgp.WrapError(err, "ClearStateProgram")
 					return
 				}
-				if zb0008 > config.MaxAvailableAppProgramLen {
-					err = msgp.ErrOverflow(uint64(zb0008), uint64(config.MaxAvailableAppProgramLen))
+				if zb0008 > bounds.MaxAvailableAppProgramLen {
+					err = msgp.ErrOverflow(uint64(zb0008), uint64(bounds.MaxAvailableAppProgramLen))
 					return
 				}
 				(*z).ClearStateProgram, bts, err = msgp.ReadBytesBytes(bts, (*z).ClearStateProgram)
@@ -2511,7 +2511,7 @@ func ResourcesDataMaxSize() (s int) {
 	s += 2
 	// Calculating size of array: z.MetadataHash
 	s += msgp.ArrayHeaderSize + ((32) * (msgp.ByteSize))
-	s += 2 + basics.AddressMaxSize() + 2 + basics.AddressMaxSize() + 2 + basics.AddressMaxSize() + 2 + basics.AddressMaxSize() + 2 + msgp.Uint64Size + 2 + msgp.BoolSize + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + basics.TealKeyValueMaxSize() + 2 + msgp.BytesPrefixSize + config.MaxAvailableAppProgramLen + 2 + msgp.BytesPrefixSize + config.MaxAvailableAppProgramLen + 2 + basics.TealKeyValueMaxSize() + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint32Size + 2 + msgp.Uint8Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size
+	s += 2 + basics.AddressMaxSize() + 2 + basics.AddressMaxSize() + 2 + basics.AddressMaxSize() + 2 + basics.AddressMaxSize() + 2 + msgp.Uint64Size + 2 + msgp.BoolSize + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + basics.TealKeyValueMaxSize() + 2 + msgp.BytesPrefixSize + bounds.MaxAvailableAppProgramLen + 2 + msgp.BytesPrefixSize + bounds.MaxAvailableAppProgramLen + 2 + basics.TealKeyValueMaxSize() + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size + 2 + msgp.Uint32Size + 2 + msgp.Uint8Size + 2 + msgp.Uint64Size + 2 + msgp.Uint64Size
 	return
 }
 

--- a/ledger/testing/randomAccounts.go
+++ b/ledger/testing/randomAccounts.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/protocol"
@@ -174,8 +175,8 @@ func RandomAppParams() basics.AppParams {
 	}
 
 	ap := basics.AppParams{
-		ApprovalProgram:   make([]byte, int(crypto.RandUint63())%config.MaxAppProgramLen),
-		ClearStateProgram: make([]byte, int(crypto.RandUint63())%config.MaxAppProgramLen),
+		ApprovalProgram:   make([]byte, int(crypto.RandUint63())%bounds.MaxAppProgramLen),
+		ClearStateProgram: make([]byte, int(crypto.RandUint63())%bounds.MaxAppProgramLen),
 		GlobalState:       make(basics.TealKeyValue),
 		StateSchemas:      schemas,
 		ExtraProgramPages: uint32(crypto.RandUint64() % 4),
@@ -214,7 +215,7 @@ func RandomAppParams() basics.AppParams {
 
 		var bytes []byte
 		if crypto.RandUint64()%5 != 0 {
-			bytes = make([]byte, crypto.RandUint64()%uint64(config.MaxBytesKeyValueLen-len(keyName)))
+			bytes = make([]byte, crypto.RandUint64()%uint64(bounds.MaxBytesKeyValueLen-len(keyName)))
 			crypto.RandBytes(bytes[:])
 		}
 
@@ -260,7 +261,7 @@ func RandomAppLocalState() basics.AppLocalState {
 		}
 		var bytes []byte
 		if crypto.RandUint64()%5 != 0 {
-			bytes = make([]byte, crypto.RandUint64()%uint64(config.MaxBytesKeyValueLen-len(keyName)))
+			bytes = make([]byte, crypto.RandUint64()%uint64(bounds.MaxBytesKeyValueLen-len(keyName)))
 			crypto.RandBytes(bytes[:])
 		}
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	csp "github.com/algorand/go-algorand/crypto/stateproof"
 	"github.com/algorand/go-algorand/data/account"
@@ -822,7 +823,7 @@ func TestMaxSizesCorrect(t *testing.T) {
 	// the logicsig size is *also* an overestimate, because it thinks that the logicsig and
 	// the logicsig args can both be up to to MaxLogicSigMaxSize, but that's the max for
 	// them combined, so it double counts and we have to subtract one.
-	maxCombinedTxnSize -= uint64(config.MaxLogicSigMaxSize)
+	maxCombinedTxnSize -= uint64(bounds.MaxLogicSigMaxSize)
 
 	// maxCombinedTxnSize is still an overestimate because it assumes all txn
 	// type fields can be in the same txn.  That's not true, but it provides an

--- a/protocol/codec_test.go
+++ b/protocol/codec_test.go
@@ -161,7 +161,7 @@ func TestEncodeJSON(t *testing.T) {
 
 	type ar []string
 	type mp struct {
-		Map map[int]ar `codec:"ld,allocbound=config.MaxEvalDeltaAccounts"`
+		Map map[int]ar `codec:"ld,allocbound=bounds.MaxEvalDeltaAccounts"`
 	}
 
 	var v mp

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -23,12 +23,8 @@ import (
 // ConsensusVersion is a string that identifies a version of the
 // consensus protocol.
 //
-//msgp:allocbound ConsensusVersion maxConsensusVersionLen
+//msgp:allocbound ConsensusVersion bounds.MaxConsensusVersionLen
 type ConsensusVersion string
-
-// maxConsensusVersionLen is used for generating MaxSize functions on types that contain ConsensusVersion
-// as it's member. 128 is slightly larger than the existing URL length of consensus version URL+hash=89
-const maxConsensusVersionLen = 128
 
 // DEPRECATEDConsensusV0 is a baseline version of the Algorand consensus protocol.
 // at the time versioning was introduced.

--- a/protocol/msgp_gen.go
+++ b/protocol/msgp_gen.go
@@ -4,6 +4,8 @@ package protocol
 
 import (
 	"github.com/algorand/msgp/msgp"
+
+	"github.com/algorand/go-algorand/config/bounds"
 )
 
 // The following msgp objects are implemented in this file:
@@ -108,8 +110,8 @@ func (z *ConsensusVersion) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalSt
 			err = msgp.WrapError(err)
 			return
 		}
-		if zb0002 > maxConsensusVersionLen {
-			err = msgp.ErrOverflow(uint64(zb0002), uint64(maxConsensusVersionLen))
+		if zb0002 > bounds.MaxConsensusVersionLen {
+			err = msgp.ErrOverflow(uint64(zb0002), uint64(bounds.MaxConsensusVersionLen))
 			return
 		}
 		zb0001, bts, err = msgp.ReadStringBytes(bts)
@@ -144,7 +146,7 @@ func (z ConsensusVersion) MsgIsZero() bool {
 
 // MaxSize returns a maximum valid message size for this message type
 func ConsensusVersionMaxSize() (s int) {
-	s = msgp.StringPrefixSize + maxConsensusVersionLen
+	s = msgp.StringPrefixSize + bounds.MaxConsensusVersionLen
 	return
 }
 

--- a/tools/debug/transplanter/main.go
+++ b/tools/debug/transplanter/main.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/pools"
@@ -83,7 +84,7 @@ func decodeTxGroup(data []byte) ([]transactions.SignedTxn, error) {
 			return nil, fmt.Errorf("received a non-decodable txn: %v", err)
 		}
 		ntx++
-		if ntx >= config.MaxTxGroupSize {
+		if ntx >= bounds.MaxTxGroupSize {
 			// max ever possible group size reached, done reading input.
 			if dec.Remaining() > 0 {
 				// if something else left in the buffer - this is an error, drop

--- a/tools/x-repo-types/xrt_test.go
+++ b/tools/x-repo-types/xrt_test.go
@@ -63,7 +63,7 @@ func TestCrossRepoTypes(t *testing.T) {
 			yBranch:    "main",
 			yType:      "Block",
 			skip:       true,
-			skipReason: `Several issues. For example: LEVEL 5 of goal bookkeeping.Block is EvalDelta with field [SharedAccts](codec:"sa,allocbound=config.MaxEvalDeltaAccounts") VS SDK types.EvalDelta is missing SharedAccts field`,
+			skipReason: `Several issues. For example: LEVEL 5 of goal bookkeeping.Block is EvalDelta with field [SharedAccts](codec:"sa,allocbound=bounds.MaxEvalDeltaAccounts") VS SDK types.EvalDelta is missing SharedAccts field`,
 		},
 		{
 			name:    "goal-v-sdk-eval-delta",


### PR DESCRIPTION
This is a first step to remove the use of the `config` package in the `basics` package.

We use many constants, derived from ConsensusParams, or checked against ConsensusParams, as allocbounds.  Therefore, types in `basics` end up needing to use the `config` package to access them, so the `config` package can't use `basics` which prevents a lot of natural typing choices.

This PR moves all such variables and constants to a `bounds` package.  I think this also helps clearly separate them from the consensus parameters themselves, and they now appear as `allocbound=bounds.Max....` which seems clearer.


<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
