### PR TITLE
network: count received traffic before decompression

### DIFF
--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -590,11 +590,6 @@ func (wp *wsPeer) readLoop() {
 		msg.processing = wp.processed
 		msg.Received = time.Now().UnixNano()
 		msg.Data = slurper.Bytes()
-		msg.Data, err = dataConverter.convert(msg.Tag, msg.Data)
-		if err != nil {
-			wp.reportReadErr(err)
-			return
-		}
 		msg.Net = wp.net
 		wp.lastPacketTime.Store(msg.Received)
 		if wp.peerType == peerTypeWs {
@@ -607,6 +602,11 @@ func (wp *wsPeer) readLoop() {
 			networkP2PMessageReceivedTotal.AddUint64(1, nil)
 			networkP2PReceivedBytesByTag.Add(string(tag[:]), uint64(len(msg.Data)+2))
 			networkP2PMessageReceivedByTag.Add(string(tag[:]), 1)
+		}
+		msg.Data, err = dataConverter.convert(msg.Tag, msg.Data)
+		if err != nil {
+			wp.reportReadErr(err)
+			return
 		}
 		msg.Sender = wp
 


### PR DESCRIPTION
## Summary

`wsPeer.readLoop` increment traffic counters after decompression that makes impossible to observe wire traffic decrease. Fixed by moving the decompression after the counters.

## Test Plan

Existing tests