### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/crypto/statetrie/nibbles/nibbles.go
+++ b/crypto/statetrie/nibbles/nibbles.go
@@ -83,10 +83,7 @@ func ShiftLeft(nyb1 Nibbles, numNibbles int) Nibbles {
 // SharedPrefix returns a slice from nyb1 that contains the shared prefix
 // between nyb1 and nyb2
 func SharedPrefix(nyb1 Nibbles, nyb2 Nibbles) Nibbles {
-	minLength := len(nyb1)
-	if len(nyb2) < minLength {
-		minLength = len(nyb2)
-	}
+	minLength := min(len(nyb2), len(nyb1))
 	for i := 0; i < minLength; i++ {
 		if nyb1[i] != nyb2[i] {
 			return nyb1[:i]

--- a/network/limitlistener/rejectingLimitListener_test.go
+++ b/network/limitlistener/rejectingLimitListener_test.go
@@ -24,10 +24,8 @@ func TestRejectingLimitListenerBasic(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	const limit = 5
-	attempts := (maxOpenFiles() - limit) / 2
-	if attempts > 256 { // maximum length of accept queue is 128 by default
-		attempts = 256
-	}
+	// maximum length of accept queue is 128 by default
+	attempts := min((maxOpenFiles()-limit)/2, 256)
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/tools/debug/carpenter/main.go
+++ b/tools/debug/carpenter/main.go
@@ -305,10 +305,7 @@ func outputTableFormat(out string, event logspec.Event, columns []string, colPos
 	maxLen := len(out)
 	for i := 0; i < rowCount; i++ {
 		start := i * columnWidth
-		end := start + columnWidth
-		if end > maxLen {
-			end = maxLen
-		}
+		end := min(start+columnWidth, maxLen)
 		if start < len(out) {
 			row := strings.TrimSpace(out[start:end])
 			output := ""

--- a/util/bloom/bloom.go
+++ b/util/bloom/bloom.go
@@ -50,10 +50,7 @@ func Optimal(numElements int, falsePositiveRate float64) (sizeBits int, numHashe
 	m := -(n+0.5)*math.Log(p)/math.Pow(math.Log(2), 2) + 1
 	k := -math.Log(p) / math.Log(2)
 
-	numHashes = uint32(math.Ceil(k))
-	if numHashes > maxHashes {
-		numHashes = maxHashes
-	}
+	numHashes = min(uint32(math.Ceil(k)), maxHashes)
 
 	return int(math.Ceil(m)), numHashes
 }

--- a/util/watchdogStreamReader.go
+++ b/util/watchdogStreamReader.go
@@ -110,10 +110,7 @@ func (r *watchdogStreamReader) Read(p []byte) (n int, err error) {
 	}
 	if len(r.stageBuffer) > 0 {
 		// copy the data to the buffer p
-		n = len(p)
-		if n > len(r.stageBuffer) {
-			n = len(r.stageBuffer)
-		}
+		n = min(len(p), len(r.stageBuffer))
 		copy(p, r.stageBuffer)
 		r.stageBuffer = r.stageBuffer[n:]
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.


## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
