### PR TITLE
tests: fix TestStateProofRecovery

### DIFF
--- a/test/e2e-go/features/stateproofs/stateproofs_test.go
+++ b/test/e2e-go/features/stateproofs/stateproofs_test.go
@@ -644,7 +644,7 @@ func TestStateProofRecovery(t *testing.T) {
 
 	// at this point we expect the state proof chain to be completely caught up. However, In order to avoid flakiness on
 	// heavily loaded machines, we would wait some extra round for the state proofs to catch up
-	for ; rnd <= basics.Round(consensusParams.StateProofInterval)*expectedNumberOfStateProofs+numberOfGraceIntervals; rnd++ {
+	for ; rnd <= basics.Round(consensusParams.StateProofInterval)*(expectedNumberOfStateProofs+numberOfGraceIntervals); rnd++ {
 
 		err = fixture.WaitForRound(rnd, timeoutUntilNextRound)
 		r.NoError(err)


### PR DESCRIPTION

## Summary

#6306 has a [typo](https://github.com/algorand/go-algorand/pull/6306/files#diff-3dee67ca393e9c5a293c0f41e38f26bfa06a0bc3f5250b2a8b371c685884accaR647) that affected number of rounds to wait in SPF connfirmations counting

## Test Plan

This is a test fix