### PR TITLE
CI: fix test verification warnings

### DIFF
--- a/daemon/algod/api/server/v2/test/genesis_types_test.go
+++ b/daemon/algod/api/server/v2/test/genesis_types_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated/model"
 	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/test/partitiontest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,6 +46,7 @@ func getJSONTag(field reflect.StructField) string {
 // TestGenesisTypeCompatibility verifies that model.Genesis matches the field structure
 // of bookkeeping.Genesis, using the codec tags from bookkeeping as the source of truth.
 func TestGenesisTypeCompatibility(t *testing.T) {
+	partitiontest.PartitionTest(t)
 	// Test Genesis struct compatibility
 	verifyStructCompatibility(t, reflect.TypeOf(bookkeeping.Genesis{}), reflect.TypeOf(model.Genesis{}))
 

--- a/ledger/store/trackerdb/testsuite/dual_test.go
+++ b/ledger/store/trackerdb/testsuite/dual_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestDualEngines(t *testing.T) {
+	// partitiontest.PartitionTest(t) // partitioning inside subtest
 	dbFactory := func(proto config.ConsensusParams) dbForTests {
 		db := testdb.OpenForTesting(t, true)
 		seedDb(t, db)

--- a/ledger/store/trackerdb/testsuite/mockdb_test.go
+++ b/ledger/store/trackerdb/testsuite/mockdb_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestMockDB(t *testing.T) {
+	// partitiontest.PartitionTest(t) // partitioning inside subtest
 	dbFactory := func(proto config.ConsensusParams) dbForTests {
 		db := makeMockDB(proto)
 

--- a/ledger/store/trackerdb/testsuite/pebbledb_test.go
+++ b/ledger/store/trackerdb/testsuite/pebbledb_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestPebbleDB(t *testing.T) {
+	// partitiontest.PartitionTest(t) // partitioning inside subtest
 	dbFactory := func(proto config.ConsensusParams) dbForTests {
 		// create a tmp dir for the db, the testing runtime will clean it up automatically
 		dir := fmt.Sprintf("%s/db", t.TempDir())

--- a/ledger/store/trackerdb/testsuite/sqlitedb_test.go
+++ b/ledger/store/trackerdb/testsuite/sqlitedb_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestSqliteDB(t *testing.T) {
+	// partitiontest.PartitionTest(t) // partitioning inside subtest
 	dbFactory := func(config.ConsensusParams) dbForTests {
 		// create a tmp dir for the db, the testing runtime will clean it up automatically
 		fn := fmt.Sprintf("%s/tracker-db.sqlite", t.TempDir())


### PR DESCRIPTION
## Summary

While reviewing #6346 I noticed these warnings, fixed in this PR:
```
=========== RAN MULTIPLE TIMES ===================
The above 5 tests ran multiple times:
github.com/algorand/go-algorand/daemon/algod/api/server/v2/test TestGenesisTypeCompatibility -- ran 4 times. (Can probably be fixed by adding "partitiontest.PartitionTest()")
github.com/algorand/go-algorand/ledger/store/trackerdb/testsuite TestDualEngines -- ran 4 times. (Can probably be fixed by adding "partitiontest.PartitionTest()")
github.com/algorand/go-algorand/ledger/store/trackerdb/testsuite TestMockDB -- ran 4 times. (Can probably be fixed by adding "partitiontest.PartitionTest()")
github.com/algorand/go-algorand/ledger/store/trackerdb/testsuite TestPebbleDB -- ran 4 times. (Can probably be fixed by adding "partitiontest.PartitionTest()")
github.com/algorand/go-algorand/ledger/store/trackerdb/testsuite TestSqliteDB -- ran 4 times. (Can probably be fixed by adding "partitiontest.PartitionTest()")
The above 5 tests ran multiple times:
```

## Test Plan

Warnings should go away in CI output for test verification job.