### PR TITLE
agreement: fix mainLoop vs Shutdown race

### DIFF
--- a/agreement/service_test.go
+++ b/agreement/service_test.go
@@ -2543,6 +2543,7 @@ func TestAgreementServiceStartDeadline(t *testing.T) {
 	close(inputCh)
 	output := make(chan []action, 10)
 	ready := make(chan externalDemuxSignals, 1)
+	s.wg.Add(1)
 	s.mainLoop(inputCh, output, ready)
 
 	// check the ready channel:


### PR DESCRIPTION
## Summary

Based on this [test failure](https://app.circleci.com/pipelines/github/algorand/go-algorand/20528/workflows/539db913-77e0-4011-b860-3376982343b9/jobs/292289) there one test started executing before the previous finished: `mainLoop` goroutine stayed alive after calling `Shutdown`.
This means the `Shutdown`, `mainLoop` and `demuxLoop` termination logic based on `done` channel is racy.

Fixed by replacing the `done` channel with explicit wait on a wait group.

## Test Plan

Existing tests