### PR TITLE
libgoal: bump defaultKMDTimeoutSecs

### DIFF
--- a/libgoal/libgoal.go
+++ b/libgoal/libgoal.go
@@ -46,7 +46,7 @@ import (
 // defaultKMDTimeoutSecs is the default number of seconds after which kmd will
 // kill itself if there are no requests. This can be overridden with
 // SetKMDStartArgs
-const defaultKMDTimeoutSecs = 60
+const defaultKMDTimeoutSecs = 180
 
 // DefaultKMDDataDir is the name of the directory within the algod data directory where kmd data goes
 const DefaultKMDDataDir = nodecontrol.DefaultKMDDataDir


### PR DESCRIPTION
## Summary

[This lease e2e test](https://circleci.com/api/v1.1/project/github/algorand/go-algorand/291140/output/114/2?file=true&allocation-id=681ea6b9aea70362ddb5e5f7-2-build%2FABCDEFGH) failure indicated it is possible to have KMD stopped between two consecutive calls to KDM API due to `defaultKMDTimeoutSecs = 60`.
It is possible to overwrite it with `libgoal.Client.SetKMDStartArgs` calls but it happens after the client instantiation that calls `ensureKmdClient` causing KDM starting so that `SetKMDStartArgs` does not have any effect.

It looks like the least intrusive approach is to bump `defaultKMDTimeoutSecs`. Alternative is to refactor `libgoal.MakeClient` methods and their invocation places to take extra arguments.

Side effects: `libgoal` with `clientType=KmdClient` or `FullClient` is used in these goal subcommands: `account`, `clerk`, `wallet`, `application`, `asset`, `interact` that means `kmd` process will stay alive 3 minutes instead of 1 minute.

## Test Plan

Existing tests