### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/cmd/util/cmd.go
+++ b/cmd/util/cmd.go
@@ -18,6 +18,7 @@ package cmdutil
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -49,12 +50,10 @@ func (c *CobraStringValue) IsSet() bool { return c.isSet }
 
 // Set sets a value and fails if it is not allowed
 func (c *CobraStringValue) Set(other string) error {
-	for _, s := range c.allowed {
-		if other == s {
-			c.value = other
-			c.isSet = true
-			return nil
-		}
+	if slices.Contains(c.allowed, other) {
+		c.value = other
+		c.isSet = true
+		return nil
 	}
 	return fmt.Errorf("value %s not allowed", other)
 }

--- a/network/phonebook/phonebook_test.go
+++ b/network/phonebook/phonebook_test.go
@@ -17,6 +17,7 @@
 package phonebook
 
 import (
+	"slices"
 	"testing"
 	"time"
 
@@ -27,25 +28,13 @@ import (
 func testPhonebookAll(t *testing.T, set []string, ph Phonebook) {
 	actual := ph.GetAddresses(len(set), RelayRole)
 	for _, got := range actual {
-		ok := false
-		for _, known := range set {
-			if got == known {
-				ok = true
-				break
-			}
-		}
+		ok := slices.Contains(set, got)
 		if !ok {
 			t.Errorf("get returned junk %#v", got)
 		}
 	}
 	for _, known := range set {
-		ok := false
-		for _, got := range actual {
-			if got == known {
-				ok = true
-				break
-			}
-		}
+		ok := slices.Contains(actual, known)
 		if !ok {
 			t.Errorf("get missed %#v; actual=%#v; set=%#v", known, actual, set)
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
