### PR TITLE
config: allow explicit values

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/algorand/go-algorand/protocol"
@@ -177,8 +178,13 @@ func mergeConfigFromFile(configpath string, source Local) (Local, map[string]int
 			latestVersion = currentVersion
 		}
 		// try to find any config default that matches to explicitFields
+		var vcfg reflect.Value
+		var ok bool
 		for v := currentVersion; v <= latestVersion; v++ {
-			vcfg := versionedDefaultLocal[v]
+			if vcfg, ok = versionedDefaultLocal[v]; !ok {
+				vcfg = getVersionedLocalInstance(v)
+				versionedDefaultLocal[v] = vcfg
+			}
 			if matchDefaultVsMap(vcfg, explicitFields, currentVersion) {
 				explicitFields = nil
 				break

--- a/config/config.go
+++ b/config/config.go
@@ -136,6 +136,8 @@ func mergeConfigFromDir(root string, source Local) (Local, error) {
 	return c, err
 }
 
+var versionedDefaultLocal = map[uint32]reflect.Value{}
+
 func mergeConfigFromFile(configpath string, source Local) (Local, map[string]interface{}, error) {
 	f, err := os.Open(configpath)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -163,7 +163,7 @@ func mergeConfigFromFile(configpath string, source Local) (Local, map[string]int
 	}
 	// it is possible that the config file is just a full dump of default values at some version
 	// in this case ignore the explicit fields all together
-	if explicitFields != nil {
+	if len(explicitFields) > 0 {
 		latestVersion := getLatestConfigVersion()
 		currentVersion := uint32(0)
 		if version, ok := explicitFields["Version"]; ok {

--- a/config/config.go
+++ b/config/config.go
@@ -157,6 +157,11 @@ func mergeConfigFromFile(configpath string, source Local) (Local, map[string]int
 			return source, nil, errors.New("config file version is greater than the latest supported version")
 		}
 
+		if currentVersion != 0 {
+			// if version is set we'll compare only two versioned defaults
+			latestVersion = currentVersion
+		}
+		// try to find any config default that matches to explicitFields
 		for v := currentVersion; v <= latestVersion; v++ {
 			vcfg := versionedDefaultLocal[v]
 			if matchDefaultVsMap(vcfg, explicitFields, currentVersion) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -275,8 +275,7 @@ func TestLocal_ConfigMigrate(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	a := require.New(t)
-
-	c0 := loadWithoutDefaults(t, versionedDefaultLocal[0].Interface())
+	c0 := loadWithoutDefaults(t, getVersionedLocalInstance(0).Interface())
 	c0, err := migrate(c0, nil)
 	a.NoError(err)
 	cLatest, err := migrate(defaultLocal, nil)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -342,6 +342,10 @@ func TestLocal_ExplicitFieldMigration(t *testing.T) {
 			c0, err := loadConfigFromFile(name)
 			require.NoError(t, err)
 			require.False(t, c0.EnableTxBacklogRateLimiting)
+
+			// make sure everything else is set to default
+			c0.EnableTxBacklogRateLimiting = true // override the default value to be able to compare
+			require.Equal(t, defaultLocal, c0)
 		})
 	}
 }

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -71,10 +71,10 @@ type Local struct {
 	// PeerPingPeriodSeconds is deprecated and unused.
 	PeerPingPeriodSeconds int `version[0]:"0"`
 
-	// TLSCertFile is the certificate file used for the websocket network if povided.
+	// TLSCertFile is the certificate file used for the websocket network if provided.
 	TLSCertFile string `version[0]:""`
 
-	// TLSKeyFile is the key file used for the websocket network if povided.
+	// TLSKeyFile is the key file used for the websocket network if provided.
 	TLSKeyFile string `version[0]:""`
 
 	// BaseLoggerDebugLevel specifies the logging level for algod (node.log). The levels range from 0 (critical error / silent) to 5 (debug / verbose). The default value is 4 (‘Info’ - fairly verbose).
@@ -495,7 +495,7 @@ type Local struct {
 	// 0  : default behavior.
 	// 3  : speed up catchup by skipping necessary validations
 	// 12 : perform all validation methods (normal and additional). These extra tests helps to verify the integrity of the compiled executable against
-	//      previously used executabled, and would not provide any additional security guarantees.
+	//      previously used executable, and would not provide any additional security guarantees.
 	CatchupBlockValidateMode int `version[16]:"0"`
 
 	// EnableAccountUpdatesStats specifies whether or not to emit the AccountUpdates telemetry event.

--- a/config/migrate.go
+++ b/config/migrate.go
@@ -30,7 +30,7 @@ import (
 // it's implemented in ./config/defaults_gen.go, and should be the only "consumer" of this exported variable
 var AutogenLocal = GetVersionedDefaultLocalConfig(getLatestConfigVersion())
 
-func migrate(cfg Local, explicitFields map[string]interface{}) (newCfg Local, err error) {
+func migrate(cfg Local, explicitFields map[string]any) (newCfg Local, err error) {
 	newCfg = cfg
 	latestConfigVersion := getLatestConfigVersion()
 
@@ -406,14 +406,3 @@ func setFieldValue(field reflect.Value, value string) {
 		}
 	}
 }
-
-// var versionedDefaultLocal []reflect.Value
-var versionedDefaultLocal = map[uint32]reflect.Value{}
-
-// // build dynamic config struct definition based on version tags in Local struct
-// func init() {
-// 	// Initialize versioned definitions on package load
-// 	for version := uint32(0); version <= getLatestConfigVersion(); version++ {
-// 		versionedDefaultLocal = append(versionedDefaultLocal, getVersionedLocalInstance(version))
-// 	}
-// }

--- a/config/migrate.go
+++ b/config/migrate.go
@@ -407,12 +407,13 @@ func setFieldValue(field reflect.Value, value string) {
 	}
 }
 
-var versionedDefaultLocal []reflect.Value
+// var versionedDefaultLocal []reflect.Value
+var versionedDefaultLocal = map[uint32]reflect.Value{}
 
-// build dynamic config struct definition based on version tags in Local struct
-func init() {
-	// Initialize versioned definitions on package load
-	for version := uint32(0); version <= getLatestConfigVersion(); version++ {
-		versionedDefaultLocal = append(versionedDefaultLocal, getVersionedLocalInstance(version))
-	}
-}
+// // build dynamic config struct definition based on version tags in Local struct
+// func init() {
+// 	// Initialize versioned definitions on package load
+// 	for version := uint32(0); version <= getLatestConfigVersion(); version++ {
+// 		versionedDefaultLocal = append(versionedDefaultLocal, getVersionedLocalInstance(version))
+// 	}
+// }

--- a/config/migrate_test.go
+++ b/config/migrate_test.go
@@ -1,0 +1,94 @@
+// Copyright (C) 2019-2025 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package config
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrate_FieldDefaultForVersion(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	localType := reflect.TypeOf(Local{})
+	for fieldNum := 0; fieldNum < localType.NumField(); fieldNum++ {
+		field := localType.Field(fieldNum)
+
+		// make sure Version field is in all local versions
+		// make sure MaxConnectionsPerIP absent in 0, 1, 2 and present in 3 and later
+		if field.Name == "Version" || field.Name == "MaxConnectionsPerIP" {
+			for i := 0; i <= 2; i++ {
+				defaultValue, ok := getFieldDefaultForVersion(field, uint32(i))
+				if field.Name == "Version" {
+					require.True(t, ok)
+					require.Equal(t, strconv.Itoa(i), defaultValue)
+				}
+				if field.Name == "MaxConnectionsPerIP" {
+					require.False(t, ok)
+					require.Equal(t, "", defaultValue)
+				}
+			}
+			for i := 3; i <= int(getLatestConfigVersion()); i++ {
+				defaultValue, ok := getFieldDefaultForVersion(field, uint32(i))
+				if field.Name == "Version" {
+					require.True(t, ok)
+					require.Equal(t, strconv.Itoa(i), defaultValue)
+				}
+				if field.Name == "MaxConnectionsPerIP" {
+					require.True(t, ok)
+					require.NotEqual(t, "", defaultValue)
+					if i < 27 {
+						require.Equal(t, "30", defaultValue)
+					} else if i >= 27 && i < 35 {
+						require.Equal(t, "15", defaultValue)
+					} else if i >= 35 {
+						require.Equal(t, "8", defaultValue)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestMigrate_VersionedLocalInstance makes sure that the versioned local instance
+// has the expected fields and default values for each version (by sampling some)
+func TestMigrate_VersionedLocalInstance(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	v0 := getVersionedLocalInstance(0)
+	require.Equal(t, uint64(0), v0.FieldByName("Version").Uint())
+	require.Equal(t, uint64(1), v0.FieldByName("BaseLoggerDebugLevel").Uint())
+	require.Equal(t, 37, v0.NumField())
+
+	v1 := getVersionedLocalInstance(1)
+	require.Equal(t, uint64(1), v1.FieldByName("Version").Uint())
+	require.Equal(t, uint64(4), v1.FieldByName("BaseLoggerDebugLevel").Uint())
+	require.Equal(t, 37+1, v1.NumField())
+
+	lastVersion := getLatestConfigVersion()
+	localType := reflect.TypeOf(Local{})
+	vLast := getVersionedLocalInstance(lastVersion)
+	require.Equal(t, uint64(lastVersion), vLast.FieldByName("Version").Uint())
+	require.Equal(t, uint64(4), vLast.FieldByName("BaseLoggerDebugLevel").Uint())
+	require.Equal(t, localType.NumField(), vLast.NumField())
+}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -55,14 +55,6 @@ var expectedAgreementTime = 2*config.Protocol.BigLambda + config.Protocol.SmallL
 var sinkAddr = basics.Address{0x7, 0xda, 0xcb, 0x4b, 0x6d, 0x9e, 0xd1, 0x41, 0xb1, 0x75, 0x76, 0xbd, 0x45, 0x9a, 0xe6, 0x42, 0x1d, 0x48, 0x6d, 0xa3, 0xd4, 0xef, 0x22, 0x47, 0xc4, 0x9, 0xa3, 0x96, 0xb8, 0x2e, 0xa2, 0x21}
 var poolAddr = basics.Address{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 
-var defaultConfig = config.Local{
-	Archival:                 false,
-	GossipFanout:             4,
-	NetAddress:               "",
-	BaseLoggerDebugLevel:     1,
-	IncomingConnectionsLimit: -1,
-}
-
 type nodeInfo struct {
 	idx     int
 	host    string
@@ -150,6 +142,12 @@ func setupFullNodesEx(
 	numAccounts := len(acctStake)
 	wallets := make([]string, numAccounts)
 	nodeInfos := make([]nodeInfo, numAccounts)
+
+	defaultConfig := config.GetDefaultLocal()
+	defaultConfig.Archival = false
+	defaultConfig.GossipFanout = 4
+	defaultConfig.NetAddress = ""
+	defaultConfig.BaseLoggerDebugLevel = 1
 
 	for i := range wallets {
 		rootDirectory := t.TempDir()
@@ -240,11 +238,11 @@ func setupFullNodesEx(
 		}
 
 		cfg, err := config.LoadConfigFromDisk(rootDirectory)
+		require.NoError(t, err)
 		phonebook := phonebookHook(nodeInfos, i)
-		require.NoError(t, err)
 		node, err := MakeFull(logging.Base().With("net", fmt.Sprintf("node%d", i)), rootDirectory, cfg, phonebook, g)
-		nodes[i] = node
 		require.NoError(t, err)
+		nodes[i] = node
 	}
 
 	return nodes, wallets

--- a/test/e2e-go/cli/algoh/expect/algohTimeoutTest.exp
+++ b/test/e2e-go/cli/algoh/expect/algohTimeoutTest.exp
@@ -17,7 +17,7 @@ if { [catch {
     if {[regexp "arm64" $archType]} {
        set timeout 60
     } else {
-       set timeout 5
+       set timeout 10
     }
     puts "set timeout to $timeout"
 


### PR DESCRIPTION
## Summary

Currently all config files are subject to migration: for each field, if it has a default value, it updated to a new default.
There is a problem with this approach because two `Local` instances are compared and it is impossible to say either a value came from a file or it is just a default value.

This PR allow to treat explicitly set values in a config file not to be migrated if both conditions are met:
1. Version field not set or set to 0 or 11-latest. 
2. Config file itself has any field to set to non-default value corresponding to its version (or some version).

In other words, if a config file is not a dump of all default values at some version, its fields are processed as explicitly set.

#### Note on exception of the logic above

Historically we had `config-vX.json` files manually created before versioned `Local` introduction so that `config-v0.json` - `config-v10.json` miss some fields and it is impossible to determine if these versions are exact copies of `Local` at their version so version 1-10 are excluded from the new logic. It is quite common to have config files to contain few non-default field without a version so these files must be processed as explicit so version=0 is included into a new logic.
This is why the `matchDefaultVsMap` function has `version >= 1 && version <= 10` exception, and it is there is to primarily satisfy the `TestLocal_ConfigMigrateFromDisk` test. 

## Test Plan

Added unit tests