### PR TITLE
tests: fix testCatchpointAfterStakeLookupTxns

### DIFF
--- a/ledger/catchpointfilewriter_test.go
+++ b/ledger/catchpointfilewriter_test.go
@@ -1199,6 +1199,12 @@ assert
 		require.Empty(t, vb.Block().AbsentParticipationAccounts)
 	}
 
+	require.Eventually(t, func() bool {
+		gr, _ := dl.generator.LatestCommitted()
+		vr, _ := dl.validator.LatestCommitted()
+		return gr == vr
+	}, 1*time.Second, 50*time.Millisecond)
+
 	// wait for tracker to flush
 	testCatchpointFlushRound(dl.generator)
 	testCatchpointFlushRound(dl.validator)


### PR DESCRIPTION
## Summary

`testCatchpointAfterStakeLookupTxns` uses double ledger after adding lots of blocks, and then checks accounts are persisted on the same round. But sometimes it checks too early so validator has not persisted the latest block yet so flushing with `testCatchpointFlushRound` does flush but sometimes on a previous round.
Fixed by ensuring both ledgers have the latest block persisted.

## Test Plan

This is a unit test fix