### PR TITLE
Syntax: Use "type X" syntax instead of "type ( .... )"

### DIFF
--- a/data/bookkeeping/block.go
+++ b/data/bookkeeping/block.go
@@ -29,245 +29,244 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 )
 
-type (
-	// BlockHash represents the hash of a block
-	BlockHash crypto.Digest
+// BlockHash represents the hash of a block
+type BlockHash crypto.Digest
 
-	// A BlockHeader represents the metadata and commitments to the state of a Block.
-	// The Algorand Ledger may be defined minimally as a cryptographically authenticated series of BlockHeader objects.
-	BlockHeader struct {
-		_struct struct{} `codec:",omitempty,omitemptyarray"`
+// A BlockHeader represents the metadata and commitments to the state of a Block.
+// The Algorand Ledger may be defined minimally as a cryptographically authenticated series of BlockHeader objects.
+type BlockHeader struct {
+	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-		Round basics.Round `codec:"rnd"`
+	Round basics.Round `codec:"rnd"`
 
-		// The hash of the previous block
-		Branch BlockHash `codec:"prev"`
+	// The hash of the previous block
+	Branch BlockHash `codec:"prev"`
 
-		// The hash of the previous block, using SHA-512
-		Branch512 crypto.Sha512Digest `codec:"prev512"`
+	// The hash of the previous block, using SHA-512
+	Branch512 crypto.Sha512Digest `codec:"prev512"`
 
-		// Sortition seed
-		Seed committee.Seed `codec:"seed"`
+	// Sortition seed
+	Seed committee.Seed `codec:"seed"`
 
-		// TxnCommitments authenticates the set of transactions appearing in the block.
-		TxnCommitments
+	// TxnCommitments authenticates the set of transactions appearing in the block.
+	TxnCommitments
 
-		// TimeStamp in seconds since epoch
-		TimeStamp int64 `codec:"ts"`
+	// TimeStamp in seconds since epoch
+	TimeStamp int64 `codec:"ts"`
 
-		// Genesis ID to which this block belongs.
-		GenesisID string `codec:"gen,allocbound=bounds.MaxGenesisIDLen"`
+	// Genesis ID to which this block belongs.
+	GenesisID string `codec:"gen,allocbound=bounds.MaxGenesisIDLen"`
 
-		// Genesis hash to which this block belongs.
-		GenesisHash crypto.Digest `codec:"gh"`
+	// Genesis hash to which this block belongs.
+	GenesisHash crypto.Digest `codec:"gh"`
 
-		// Proposer is the proposer of this block. Like the Seed, agreement adds
-		// this after the block is assembled by the transaction pool, so that the same block can be prepared
-		// for multiple participating accounts in the same node. Therefore, it can not be used
-		// to influence block evaluation. Populated if proto.Payouts.Enabled
-		Proposer basics.Address `codec:"prp"`
+	// Proposer is the proposer of this block. Like the Seed, agreement adds
+	// this after the block is assembled by the transaction pool, so that the same block can be prepared
+	// for multiple participating accounts in the same node. Therefore, it can not be used
+	// to influence block evaluation. Populated if proto.Payouts.Enabled
+	Proposer basics.Address `codec:"prp"`
 
-		// FeesCollected is the sum of all fees paid by transactions in this
-		// block. Populated if proto.Payouts.Enabled
-		FeesCollected basics.MicroAlgos `codec:"fc"`
+	// FeesCollected is the sum of all fees paid by transactions in this
+	// block. Populated if proto.Payouts.Enabled
+	FeesCollected basics.MicroAlgos `codec:"fc"`
 
-		// Bonus is the bonus incentive to be paid for proposing this block.  It
-		// begins as a consensus parameter value, and decays periodically.
-		Bonus basics.MicroAlgos `codec:"bi"`
+	// Bonus is the bonus incentive to be paid for proposing this block.  It
+	// begins as a consensus parameter value, and decays periodically.
+	Bonus basics.MicroAlgos `codec:"bi"`
 
-		// ProposerPayout is the amount that is moved from the FeeSink to
-		// the Proposer in this block.  It is basically the
-		// bonus + the payouts percent of FeesCollected, but may be zero'd by
-		// proposer ineligibility.
-		ProposerPayout basics.MicroAlgos `codec:"pp"`
+	// ProposerPayout is the amount that is moved from the FeeSink to
+	// the Proposer in this block.  It is basically the
+	// bonus + the payouts percent of FeesCollected, but may be zero'd by
+	// proposer ineligibility.
+	ProposerPayout basics.MicroAlgos `codec:"pp"`
 
-		// Rewards.
-		//
-		// When a block is applied, some amount of rewards are accrued to
-		// every account with AccountData.Status=/=NotParticipating.  The
-		// amount is (thisBlock.RewardsLevel-prevBlock.RewardsLevel) of
-		// MicroAlgos for every whole config.Protocol.RewardUnit of MicroAlgos in
-		// that account's AccountData.MicroAlgos.
-		//
-		// Rewards are not compounded (i.e., not added to AccountData.MicroAlgos)
-		// until some other transaction is executed on that account.
-		//
-		// Not compounding rewards allows us to precisely know how many algos
-		// of rewards will be distributed without having to examine every
-		// account to determine if it should get one more algo of rewards
-		// because compounding formed another whole config.Protocol.RewardUnit
-		// of algos.
-		RewardsState
+	// Rewards.
+	//
+	// When a block is applied, some amount of rewards are accrued to
+	// every account with AccountData.Status=/=NotParticipating.  The
+	// amount is (thisBlock.RewardsLevel-prevBlock.RewardsLevel) of
+	// MicroAlgos for every whole config.Protocol.RewardUnit of MicroAlgos in
+	// that account's AccountData.MicroAlgos.
+	//
+	// Rewards are not compounded (i.e., not added to AccountData.MicroAlgos)
+	// until some other transaction is executed on that account.
+	//
+	// Not compounding rewards allows us to precisely know how many algos
+	// of rewards will be distributed without having to examine every
+	// account to determine if it should get one more algo of rewards
+	// because compounding formed another whole config.Protocol.RewardUnit
+	// of algos.
+	RewardsState
 
-		// Consensus protocol versioning.
-		//
-		// Each block is associated with a version of the consensus protocol,
-		// stored under UpgradeState.CurrentProtocol.  The protocol version
-		// for a block can be determined without having to first decode the
-		// block and its CurrentProtocol field, and this field is present for
-		// convenience and explicitness.  Block.Valid() checks that this field
-		// correctly matches the expected protocol version.
-		//
-		// Each block is associated with at most one active upgrade proposal
-		// (a new version of the protocol).  An upgrade proposal can be made
-		// by a block proposer, as long as no other upgrade proposal is active.
-		// The upgrade proposal lasts for many rounds (UpgradeVoteRounds), and
-		// in each round, that round's block proposer votes to support (or not)
-		// the proposed upgrade.
-		//
-		// If enough votes are collected, the proposal is approved, and will
-		// definitely take effect.  The proposal lingers for some number of
-		// rounds to give clients a chance to notify users about an approved
-		// upgrade, if the client doesn't support it, so the user has a chance
-		// to download updated client software.
-		//
-		// Block proposers influence this upgrade machinery through two fields
-		// in UpgradeVote: UpgradePropose, which proposes an upgrade to a new
-		// protocol, and UpgradeApprove, which signals approval of the current
-		// proposal.
-		//
-		// Once a block proposer determines its UpgradeVote, then UpdateState
-		// is updated deterministically based on the previous UpdateState and
-		// the new block's UpgradeVote.
-		UpgradeState
-		UpgradeVote
+	// Consensus protocol versioning.
+	//
+	// Each block is associated with a version of the consensus protocol,
+	// stored under UpgradeState.CurrentProtocol.  The protocol version
+	// for a block can be determined without having to first decode the
+	// block and its CurrentProtocol field, and this field is present for
+	// convenience and explicitness.  Block.Valid() checks that this field
+	// correctly matches the expected protocol version.
+	//
+	// Each block is associated with at most one active upgrade proposal
+	// (a new version of the protocol).  An upgrade proposal can be made
+	// by a block proposer, as long as no other upgrade proposal is active.
+	// The upgrade proposal lasts for many rounds (UpgradeVoteRounds), and
+	// in each round, that round's block proposer votes to support (or not)
+	// the proposed upgrade.
+	//
+	// If enough votes are collected, the proposal is approved, and will
+	// definitely take effect.  The proposal lingers for some number of
+	// rounds to give clients a chance to notify users about an approved
+	// upgrade, if the client doesn't support it, so the user has a chance
+	// to download updated client software.
+	//
+	// Block proposers influence this upgrade machinery through two fields
+	// in UpgradeVote: UpgradePropose, which proposes an upgrade to a new
+	// protocol, and UpgradeApprove, which signals approval of the current
+	// proposal.
+	//
+	// Once a block proposer determines its UpgradeVote, then UpdateState
+	// is updated deterministically based on the previous UpdateState and
+	// the new block's UpgradeVote.
+	UpgradeState
+	UpgradeVote
 
-		// TxnCounter is the number of the next transaction that will be
-		// committed after this block.  Genesis blocks can start at either
-		// 0 or 1000, depending on a consensus parameter (AppForbidLowResources).
-		TxnCounter uint64 `codec:"tc"`
+	// TxnCounter is the number of the next transaction that will be
+	// committed after this block.  Genesis blocks can start at either
+	// 0 or 1000, depending on a consensus parameter (AppForbidLowResources).
+	TxnCounter uint64 `codec:"tc"`
 
-		// StateProofTracking tracks the status of the state proofs, potentially
-		// for multiple types of ASPs (Algorand's State Proofs).
-		//msgp:sort protocol.StateProofType protocol.SortStateProofType
-		StateProofTracking map[protocol.StateProofType]StateProofTrackingData `codec:"spt,allocbound=protocol.NumStateProofTypes"`
+	// StateProofTracking tracks the status of the state proofs, potentially
+	// for multiple types of ASPs (Algorand's State Proofs).
+	//msgp:sort protocol.StateProofType protocol.SortStateProofType
+	StateProofTracking map[protocol.StateProofType]StateProofTrackingData `codec:"spt,allocbound=protocol.NumStateProofTypes"`
 
-		// ParticipationUpdates contains the information needed to mark
-		// certain accounts offline because their participation keys expired
-		ParticipationUpdates
-	}
+	// ParticipationUpdates contains the information needed to mark
+	// certain accounts offline because their participation keys expired
+	ParticipationUpdates
+}
 
-	// TxnCommitments represents the commitments computed from the transactions in the block.
-	// It contains multiple commitments based on different algorithms and hash functions, to support different use cases.
-	TxnCommitments struct {
-		_struct struct{} `codec:",omitempty,omitemptyarray"`
-		// Root of transaction Merkle tree using the SHA-512/256 hash function.
-		// This commitment is computed based on the PaysetCommit type specified in the block's consensus protocol.
-		NativeSha512_256Commitment crypto.Digest `codec:"txn"`
+// TxnCommitments represents the commitments computed from the transactions in the block.
+// It contains multiple commitments based on different algorithms and hash functions, to support different use cases.
+type TxnCommitments struct {
+	_struct struct{} `codec:",omitempty,omitemptyarray"`
+	// Root of transaction Merkle tree using the SHA-512/256 hash function.
+	// This commitment is computed based on the PaysetCommit type specified in the block's consensus protocol.
+	NativeSha512_256Commitment crypto.Digest `codec:"txn"`
 
-		// Root of transaction vector commitment Merkle tree using the SHA-256 hash function.
-		Sha256Commitment crypto.Digest `codec:"txn256"`
+	// Root of transaction vector commitment Merkle tree using the SHA-256 hash function.
+	Sha256Commitment crypto.Digest `codec:"txn256"`
 
-		// Root of transaction vector commitment Merkle tree using the SHA-512 hash function.
-		Sha512Commitment crypto.Sha512Digest `codec:"txn512"`
-	}
+	// Root of transaction vector commitment Merkle tree using the SHA-512 hash function.
+	Sha512Commitment crypto.Sha512Digest `codec:"txn512"`
+}
 
-	// ParticipationUpdates represents participation account data that
-	// needs to be checked/acted on by the network
-	ParticipationUpdates struct {
-		_struct struct{} `codec:",omitempty,omitemptyarray"`
+// ParticipationUpdates represents participation account data that
+// needs to be checked/acted on by the network
+type ParticipationUpdates struct {
+	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-		// ExpiredParticipationAccounts contains a list of online accounts
-		// that needs to be converted to offline since their
-		// participation key expired.
-		ExpiredParticipationAccounts []basics.Address `codec:"partupdrmv,allocbound=bounds.MaxProposedExpiredOnlineAccounts"`
+	// ExpiredParticipationAccounts contains a list of online accounts
+	// that needs to be converted to offline since their
+	// participation key expired.
+	ExpiredParticipationAccounts []basics.Address `codec:"partupdrmv,allocbound=bounds.MaxProposedExpiredOnlineAccounts"`
 
-		// AbsentParticipationAccounts contains a list of online accounts that
-		// needs to be converted to offline since they are not proposing.
-		AbsentParticipationAccounts []basics.Address `codec:"partupdabs,allocbound=bounds.MaxMarkAbsent"`
-	}
+	// AbsentParticipationAccounts contains a list of online accounts that
+	// needs to be converted to offline since they are not proposing.
+	AbsentParticipationAccounts []basics.Address `codec:"partupdabs,allocbound=bounds.MaxMarkAbsent"`
+}
 
-	// RewardsState represents the global parameters controlling the rate
-	// at which accounts accrue rewards.
-	RewardsState struct {
-		_struct struct{} `codec:",omitempty,omitemptyarray"`
+// RewardsState represents the global parameters controlling the rate
+// at which accounts accrue rewards.
+type RewardsState struct {
+	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-		// The FeeSink accepts transaction fees. It can only spend to
-		// the incentive pool.
-		FeeSink basics.Address `codec:"fees"`
+	// The FeeSink accepts transaction fees. It can only spend to
+	// the incentive pool.
+	FeeSink basics.Address `codec:"fees"`
 
-		// The RewardsPool accepts periodic injections from the
-		// FeeSink and continually redistributes them to addresses as
-		// rewards.
-		RewardsPool basics.Address `codec:"rwd"`
+	// The RewardsPool accepts periodic injections from the
+	// FeeSink and continually redistributes them to addresses as
+	// rewards.
+	RewardsPool basics.Address `codec:"rwd"`
 
-		// RewardsLevel specifies how many rewards, in MicroAlgos,
-		// have been distributed to each config.Protocol.RewardUnit
-		// of MicroAlgos since genesis.
-		RewardsLevel uint64 `codec:"earn"`
+	// RewardsLevel specifies how many rewards, in MicroAlgos,
+	// have been distributed to each config.Protocol.RewardUnit
+	// of MicroAlgos since genesis.
+	RewardsLevel uint64 `codec:"earn"`
 
-		// The number of new MicroAlgos added to the participation stake from rewards at the next round.
-		RewardsRate uint64 `codec:"rate"`
+	// The number of new MicroAlgos added to the participation stake from rewards at the next round.
+	RewardsRate uint64 `codec:"rate"`
 
-		// The number of leftover MicroAlgos after the distribution of RewardsRate/rewardUnits
-		// MicroAlgos for every reward unit in the next round.
-		RewardsResidue uint64 `codec:"frac"`
+	// The number of leftover MicroAlgos after the distribution of RewardsRate/rewardUnits
+	// MicroAlgos for every reward unit in the next round.
+	RewardsResidue uint64 `codec:"frac"`
 
-		// The round at which the RewardsRate will be recalculated.
-		RewardsRecalculationRound basics.Round `codec:"rwcalr"`
-	}
+	// The round at which the RewardsRate will be recalculated.
+	RewardsRecalculationRound basics.Round `codec:"rwcalr"`
+}
 
-	// UpgradeVote represents the vote of the block proposer with
-	// respect to protocol upgrades.
-	UpgradeVote struct {
-		_struct struct{} `codec:",omitempty,omitemptyarray"`
+// UpgradeVote represents the vote of the block proposer with
+// respect to protocol upgrades.
+type UpgradeVote struct {
+	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-		// UpgradePropose indicates a proposed upgrade
-		UpgradePropose protocol.ConsensusVersion `codec:"upgradeprop"`
+	// UpgradePropose indicates a proposed upgrade
+	UpgradePropose protocol.ConsensusVersion `codec:"upgradeprop"`
 
-		// UpgradeDelay indicates the time between acceptance and execution
-		UpgradeDelay basics.Round `codec:"upgradedelay"`
+	// UpgradeDelay indicates the time between acceptance and execution
+	UpgradeDelay basics.Round `codec:"upgradedelay"`
 
-		// UpgradeApprove indicates a yes vote for the current proposal
-		UpgradeApprove bool `codec:"upgradeyes"`
-	}
+	// UpgradeApprove indicates a yes vote for the current proposal
+	UpgradeApprove bool `codec:"upgradeyes"`
+}
 
-	// UpgradeState tracks the protocol upgrade state machine.  It is,
-	// strictly speaking, computable from the history of all UpgradeVotes
-	// but we keep it in the block for explicitness and convenience
-	// (instead of materializing it separately, like balances).
-	//msgp:ignore UpgradeState
-	UpgradeState struct {
-		CurrentProtocol protocol.ConsensusVersion `codec:"proto"`
-		NextProtocol    protocol.ConsensusVersion `codec:"nextproto"`
-		// NextProtocolApprovals is the number of approvals for the next protocol proposal. It is expressed in basics.Round because it is a count of rounds.
-		NextProtocolApprovals basics.Round `codec:"nextyes"`
-		// NextProtocolVoteBefore specify the last voting round for the next protocol proposal. If there is no voting for
-		// an upgrade taking place, this would be zero.
-		NextProtocolVoteBefore basics.Round `codec:"nextbefore"`
-		// NextProtocolSwitchOn specify the round number at which the next protocol would be adopted. If there is no upgrade taking place,
-		// nor a wait for the next protocol, this would be zero.
-		NextProtocolSwitchOn basics.Round `codec:"nextswitch"`
-	}
+// UpgradeState tracks the protocol upgrade state machine.  It is,
+// strictly speaking, computable from the history of all UpgradeVotes
+// but we keep it in the block for explicitness and convenience
+// (instead of materializing it separately, like balances).
+//
+//msgp:ignore UpgradeState
+type UpgradeState struct {
+	CurrentProtocol protocol.ConsensusVersion `codec:"proto"`
+	NextProtocol    protocol.ConsensusVersion `codec:"nextproto"`
+	// NextProtocolApprovals is the number of approvals for the next protocol proposal. It is expressed in basics.Round because it is a count of rounds.
+	NextProtocolApprovals basics.Round `codec:"nextyes"`
+	// NextProtocolVoteBefore specify the last voting round for the next protocol proposal. If there is no voting for
+	// an upgrade taking place, this would be zero.
+	NextProtocolVoteBefore basics.Round `codec:"nextbefore"`
+	// NextProtocolSwitchOn specify the round number at which the next protocol would be adopted. If there is no upgrade taking place,
+	// nor a wait for the next protocol, this would be zero.
+	NextProtocolSwitchOn basics.Round `codec:"nextswitch"`
+}
 
-	// StateProofTrackingData tracks the status of state proofs.
-	StateProofTrackingData struct {
-		_struct struct{} `codec:",omitempty,omitemptyarray"`
+// StateProofTrackingData tracks the status of state proofs.
+type StateProofTrackingData struct {
+	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-		// StateProofVotersCommitment is the root of a vector commitment containing the
-		// online accounts that will help sign a state proof.  The
-		// VC root, and the state proof, happen on blocks that
-		// are a multiple of ConsensusParams.StateProofRounds.  For blocks
-		// that are not a multiple of ConsensusParams.StateProofRounds,
-		// this value is zero.
-		StateProofVotersCommitment crypto.GenericDigest `codec:"v"`
+	// StateProofVotersCommitment is the root of a vector commitment containing the
+	// online accounts that will help sign a state proof.  The
+	// VC root, and the state proof, happen on blocks that
+	// are a multiple of ConsensusParams.StateProofRounds.  For blocks
+	// that are not a multiple of ConsensusParams.StateProofRounds,
+	// this value is zero.
+	StateProofVotersCommitment crypto.GenericDigest `codec:"v"`
 
-		// StateProofOnlineTotalWeight is the total number of microalgos held by the online accounts
-		// during the StateProof round (or zero, if the merkle root is zero - no commitment for StateProof voters).
-		// This is intended for computing the threshold of votes to expect from StateProofVotersCommitment.
-		StateProofOnlineTotalWeight basics.MicroAlgos `codec:"t"`
+	// StateProofOnlineTotalWeight is the total number of microalgos held by the online accounts
+	// during the StateProof round (or zero, if the merkle root is zero - no commitment for StateProof voters).
+	// This is intended for computing the threshold of votes to expect from StateProofVotersCommitment.
+	StateProofOnlineTotalWeight basics.MicroAlgos `codec:"t"`
 
-		// StateProofNextRound is the next round for which we will accept
-		// a StateProof transaction.
-		StateProofNextRound basics.Round `codec:"n"`
-	}
+	// StateProofNextRound is the next round for which we will accept
+	// a StateProof transaction.
+	StateProofNextRound basics.Round `codec:"n"`
+}
 
-	// A Block contains the Payset and metadata corresponding to a given Round.
-	Block struct {
-		BlockHeader
-		Payset transactions.Payset `codec:"txns,maxtotalbytes=bounds.MaxTxnBytesPerBlock"`
-	}
-)
+// A Block contains the Payset and metadata corresponding to a given Round.
+type Block struct {
+	BlockHeader
+	Payset transactions.Payset `codec:"txns,maxtotalbytes=bounds.MaxTxnBytesPerBlock"`
+}
 
 // TxnDeadError defines an error type which indicates a transaction is outside of the
 // round validity window.

--- a/data/transactions/payset.go
+++ b/data/transactions/payset.go
@@ -21,11 +21,10 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 )
 
-type (
-	// A Payset represents a common, unforgeable, consistent, ordered set of SignedTxn objects.
-	//msgp:allocbound Payset 100000
-	Payset []SignedTxnInBlock
-)
+// Payset represents a common, unforgeable, consistent, ordered set of SignedTxn objects.
+//
+//msgp:allocbound Payset 100000
+type Payset []SignedTxnInBlock
 
 // CommitFlat returns a commitment to the Payset, as a flat array.
 func (payset Payset) CommitFlat() crypto.Digest {

--- a/scripts/export_sdk_types.py
+++ b/scripts/export_sdk_types.py
@@ -88,8 +88,8 @@ SDK="../go-algorand-sdk/"
 
 def sdkize(input):
     # allocbounds are not used by the SDK. It's confusing to leave them in.
-    input = re.sub(",allocbound=.*\"", '"', input)
-    input = re.sub("^//msgp:allocbound.*\n", '', input, flags=re.MULTILINE)
+    input = re.sub(",(allocbound|maxtotalbytes)=.*\"", '"', input)
+    input = re.sub("^\\s*//msgp:(allocbound|sort|ignore).*\n", '', input, flags=re.MULTILINE)
 
     # protocol.ConsensusVersion and protocolConsensusVxx constants are
     # the only things that stays in the protocol package. So we "hide"
@@ -98,9 +98,7 @@ def sdkize(input):
     input = input.replace("protocol.ConsensusFuture", "protocolConsensusFuture")
 
     # All types are in the same package in the SDK
-    input = input.replace("basics.", "")
-    input = input.replace("crypto.", "")
-    input = re.sub(r'protocol\.\b', r'', input)
+    input = re.sub(r'(basics|crypto|committee|transactions|protocol)\.\b', r'', input)
 
     # and go back...
     input = input.replace("protocolConsensusV", "protocol.ConsensusV")
@@ -184,6 +182,24 @@ if __name__ == "__main__":
     #   apps
     export_type("ApplicationCallTxnFields", "data/transactions/application.go", "applications")
     export_type("AppIndex", "data/basics/userBalance.go", "applications")
+
+    # Block
+    export_type("BlockHeader", "data/bookkeeping/block.go", "block")
+    export_type("TxnCommitments", "data/bookkeeping/block.go", "block")
+    export_type("ParticipationUpdates", "data/bookkeeping/block.go", "block")
+    export_type("RewardsState", "data/bookkeeping/block.go", "block")
+    export_type("UpgradeVote", "data/bookkeeping/block.go", "block")
+    export_type("UpgradeState", "data/bookkeeping/block.go", "block")
+    export_type("StateProofTrackingData", "data/bookkeeping/block.go", "block")
+    export_type("Block", "data/bookkeeping/block.go", "block")
+    export_type("Payset", "data/transactions/payset.go", "block")
+    export_type("SignedTxnInBlock", "data/transactions/signedtxn.go", "block")
+    export_type("SignedTxnWithAD", "data/transactions/signedtxn.go", "block")
+    export_type("ApplyData", "data/transactions/transaction.go", "block")
+    export_type("EvalDelta", "data/transactions/teal.go", "block")
+    export_type("StateDelta", "data/basics/teal.go", "block")
+    export_type("ValueDelta", "data/basics/teal.go", "block")
+    export_type("DeltaAction", "data/basics/teal.go", "block")
 
     # StateDelta.  Eventually need to deal with all types from ledgercore.StateDelta down
     export_type("AppParams", "data/basics/userBalance.go", "statedelta")


### PR DESCRIPTION
We export types to the Go SDK using a simple script that searches for types textually, and can't see types of the form:

```
type (
  X ...
}
```

It always wants "type <name>".

This is only a syntax change, so existing tests are fine.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
