### PR TITLE
CICD: fix uploading testdata in nightlies

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -301,7 +301,7 @@ jobs:
     env:
       E2E_TEST_FILTER: SCRIPTS
       CI_PLATFORM: ${{ matrix.platform }}
-      CI_KEEP_TEMP_PLATFORM: amd64
+      CI_KEEP_TEMP_PLATFORM: "ubuntu-24.04"
     steps:
       - name: Download workspace archive
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -302,7 +302,7 @@ jobs:
     env:
       E2E_TEST_FILTER: SCRIPTS
       CI_PLATFORM: ${{ matrix.platform }}
-      CI_KEEP_TEMP_PLATFORM: amd64
+      CI_KEEP_TEMP_PLATFORM: ""
       SHORT_TEST_FLAG: "-short"
     steps:
       - name: Download workspace archive

--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -170,8 +170,10 @@ if [ -z "$E2E_TEST_FILTER" ] || [ "$E2E_TEST_FILTER" == "SCRIPTS" ]; then
 
     KEEP_TEMPS_CMD_STR=""
 
-    # If the platform is arm64, we want to pass "--keep-temps" into e2e_client_runner.py
+    # For one platform, we want to pass "--keep-temps" into e2e_client_runner.py
     # so that we can keep the temporary test artifact for use in the indexer e2e tests.
+    # This is done in the CI environment, where the CI_KEEP_TEMP_PLATFORM variable is set to the platform
+    # that should keep the temporary test artifact.
     # The file is located at ${TEMPDIR}/net_done.tar.bz2
     if [ -n "$CI_KEEP_TEMP_PLATFORM" ] && [ "$CI_KEEP_TEMP_PLATFORM" == "$CI_PLATFORM" ]; then
       echo "Setting --keep-temps so that an e2e artifact can be saved."


### PR DESCRIPTION
## Summary

Test data gets uploaded nightly for other integration testing. This PR fixes the condition for this upload.

## Test Plan

After merging, verify the nightly build will upload testdata.

