### PR TITLE
CICD: fix short test flag and up parallelism

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -89,7 +89,7 @@ jobs:
       PARTITION_ID: ${{ matrix.partition_id }}
       PARTITION_TOTAL: 4
       CIRCLECI: true
-      SHORT_TEST_FLAG: "-short"
+      SHORTTEST: "-short"
     steps:
       - name: Download workspace archive
         uses: actions/download-artifact@v4
@@ -119,7 +119,7 @@ jobs:
           gotestsum --format standard-verbose \
             --junitfile ~/test_results/${{ matrix.platform }}_test/${PARTITION_ID}/results.xml \
             --jsonfile ~/test_results/${{ matrix.platform }}_test/${PARTITION_ID}/testresults.json \
-            -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" $SHORT_TEST_FLAG \
+            -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" $SHORTTEST \
             -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 4 \
             $PACKAGE_NAMES
       - name: Notify Slack on failure
@@ -240,7 +240,7 @@ jobs:
       PARTITION_TOTAL: 4
       E2E_TEST_FILTER: EXPECT
       PARALLEL_FLAG: "-p 4"
-      SHORT_TEST_FLAG: "-short"
+      SHORTTEST: "-short"
     steps:
       - name: Download workspace archive
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -120,7 +120,7 @@ jobs:
             --junitfile ~/test_results/${{ matrix.platform }}_test/${PARTITION_ID}/results.xml \
             --jsonfile ~/test_results/${{ matrix.platform }}_test/${PARTITION_ID}/testresults.json \
             -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" $SHORT_TEST_FLAG \
-            -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 8 \
+            -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 2 \
             $PACKAGE_NAMES
       - name: Notify Slack on failure
         if: failure() && env.SLACK_WEBHOOK != ''
@@ -172,7 +172,7 @@ jobs:
       PARTITION_ID: ${{ matrix.partition_id }}
       PARTITION_TOTAL: 4
       E2E_TEST_FILTER: GO
-      PARALLEL_FLAG: "-p 8"
+      PARALLEL_FLAG: "-p 2"
       SHORT_TEST_FLAG: "-short"
     steps:
       - name: Download workspace archive
@@ -239,7 +239,7 @@ jobs:
       PARTITION_ID: ${{ matrix.partition_id }}
       PARTITION_TOTAL: 4
       E2E_TEST_FILTER: EXPECT
-      PARALLEL_FLAG: "-p 8"
+      PARALLEL_FLAG: "-p 2"
       SHORT_TEST_FLAG: "-short"
     steps:
       - name: Download workspace archive

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -120,7 +120,7 @@ jobs:
             --junitfile ~/test_results/${{ matrix.platform }}_test/${PARTITION_ID}/results.xml \
             --jsonfile ~/test_results/${{ matrix.platform }}_test/${PARTITION_ID}/testresults.json \
             -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" $SHORT_TEST_FLAG \
-            -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 2 \
+            -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 4 \
             $PACKAGE_NAMES
       - name: Notify Slack on failure
         if: failure() && env.SLACK_WEBHOOK != ''
@@ -172,8 +172,8 @@ jobs:
       PARTITION_ID: ${{ matrix.partition_id }}
       PARTITION_TOTAL: 4
       E2E_TEST_FILTER: GO
-      PARALLEL_FLAG: "-p 2"
-      SHORT_TEST_FLAG: "-short"
+      PARALLEL_FLAG: "-p 4"
+      SHORTTEST: "-short"
     steps:
       - name: Download workspace archive
         uses: actions/download-artifact@v4
@@ -239,7 +239,7 @@ jobs:
       PARTITION_ID: ${{ matrix.partition_id }}
       PARTITION_TOTAL: 4
       E2E_TEST_FILTER: EXPECT
-      PARALLEL_FLAG: "-p 2"
+      PARALLEL_FLAG: "-p 4"
       SHORT_TEST_FLAG: "-short"
     steps:
       - name: Download workspace archive

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -120,7 +120,7 @@ jobs:
             --junitfile ~/test_results/${{ matrix.platform }}_test/${PARTITION_ID}/results.xml \
             --jsonfile ~/test_results/${{ matrix.platform }}_test/${PARTITION_ID}/testresults.json \
             -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" $SHORT_TEST_FLAG \
-            -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 4 \
+            -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 8 \
             $PACKAGE_NAMES
       - name: Notify Slack on failure
         if: failure() && env.SLACK_WEBHOOK != ''
@@ -172,7 +172,7 @@ jobs:
       PARTITION_ID: ${{ matrix.partition_id }}
       PARTITION_TOTAL: 4
       E2E_TEST_FILTER: GO
-      PARALLEL_FLAG: "-p 4"
+      PARALLEL_FLAG: "-p 8"
       SHORT_TEST_FLAG: "-short"
     steps:
       - name: Download workspace archive
@@ -239,7 +239,7 @@ jobs:
       PARTITION_ID: ${{ matrix.partition_id }}
       PARTITION_TOTAL: 4
       E2E_TEST_FILTER: EXPECT
-      PARALLEL_FLAG: "-p 4"
+      PARALLEL_FLAG: "-p 8"
       SHORT_TEST_FLAG: "-short"
     steps:
       - name: Download workspace archive

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -232,12 +232,12 @@ jobs:
       fail-fast: false
       matrix:
         platform: ["ubuntu-24.04"]
-        partition_id: [0, 1, 2, 3] # set PARTITION_TOTAL below to match
+        partition_id: [0, 1, 2, 3, 4, 5, 6, 7] # set PARTITION_TOTAL below to match
     runs-on: ${{ matrix.platform }}
     env:
       CIRCLECI: true
       PARTITION_ID: ${{ matrix.partition_id }}
-      PARTITION_TOTAL: 4
+      PARTITION_TOTAL: 8
       E2E_TEST_FILTER: EXPECT
       PARALLEL_FLAG: "-p 4"
       SHORTTEST: "-short"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -120,7 +120,7 @@ jobs:
             --junitfile ~/test_results/${{ matrix.platform }}_test/${PARTITION_ID}/results.xml \
             --jsonfile ~/test_results/${{ matrix.platform }}_test/${PARTITION_ID}/testresults.json \
             -- --tags "sqlite_unlock_notify sqlite_omit_load_extension" $SHORT_TEST_FLAG \
-            -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 1 \
+            -race -timeout 1h -coverprofile=coverage.txt -covermode=atomic -p 4 \
             $PACKAGE_NAMES
       - name: Notify Slack on failure
         if: failure() && env.SLACK_WEBHOOK != ''
@@ -165,14 +165,14 @@ jobs:
       fail-fast: false
       matrix:
         platform: ["ubuntu-24.04"]
-        partition_id: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] # set PARTITION_TOTAL below to match
+        partition_id: [0, 1, 2, 3] # set PARTITION_TOTAL below to match
     runs-on: ${{ matrix.platform }}
     env:
       CIRCLECI: true
       PARTITION_ID: ${{ matrix.partition_id }}
-      PARTITION_TOTAL: 16
+      PARTITION_TOTAL: 4
       E2E_TEST_FILTER: GO
-      PARALLEL_FLAG: "-p 1"
+      PARALLEL_FLAG: "-p 4"
       SHORT_TEST_FLAG: "-short"
     steps:
       - name: Download workspace archive
@@ -239,7 +239,7 @@ jobs:
       PARTITION_ID: ${{ matrix.partition_id }}
       PARTITION_TOTAL: 4
       E2E_TEST_FILTER: EXPECT
-      PARALLEL_FLAG: "-p 1"
+      PARALLEL_FLAG: "-p 4"
       SHORT_TEST_FLAG: "-short"
     steps:
       - name: Download workspace archive


### PR DESCRIPTION
## Summary

The flags to run short tests were not correct in the GitHub Actions conversion of PR tests. This fixes that.

Additionally, parallelism was not enabled, and seems to have a pretty good effect at 4, so this was added.

These changes have the benefit of reducing PR checks in GitHub Actions to around 22 minutes.

## Test Plan

Ran through GitHub Actions PR Tests multiple times. Please verify these work correctly on this PR as well.
