### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/cmd/algofix/typecheck.go
+++ b/cmd/algofix/typecheck.go
@@ -9,6 +9,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -258,10 +259,7 @@ func typecheck(cfg *TypeConfig, f *ast.File) (typeof map[interface{}]string, ass
 					if !copied {
 						copied = true
 						// Copy map lazily: it's time.
-						cfg1.Type = make(map[string]*Type)
-						for k, v := range cfg.Type {
-							cfg1.Type[k] = v
-						}
+						cfg1.Type = maps.Clone(cfg.Type)
 					}
 					t := &Type{Field: map[string]string{}}
 					cfg1.Type[s.Name.Name] = t


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
