### PR TITLE
node: fallback to ws or p2p on hybrid misconfiguration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -168,11 +168,6 @@ func enrichNetworkingConfig(source Local) (Local, error) {
 			source.GossipFanout = defaultRelayGossipFanout
 		}
 	}
-	// In hybrid mode we want to prevent connections from the same node over both P2P and WS.
-	// The only way it is supported at the moment is to use net identity challenge that is based on PublicAddress.
-	if (source.NetAddress != "" || source.P2PHybridNetAddress != "") && source.EnableP2PHybridMode && source.PublicAddress == "" {
-		return source, errors.New("PublicAddress must be specified when EnableP2PHybridMode is set")
-	}
 	source.PublicAddress = strings.ToLower(source.PublicAddress)
 	return source, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -773,7 +773,7 @@ func TestLocal_ValidateP2PHybridConfig(t *testing.T) {
 				PublicAddress:       test.publicAddress,
 			}
 			err := c.ValidateP2PHybridConfig()
-			require.Equal(t, test.err, err != nil, fmt.Sprintf("%s: %v => %v", name, test, err))
+			require.Equal(t, test.err, err != nil, "%s: %v => %v", name, test, err)
 		})
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -147,20 +147,6 @@ func TestLocal_EnrichNetworkingConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	c1 = Local{
-		NetAddress:          "test1",
-		EnableP2PHybridMode: true,
-	}
-	c2, err = enrichNetworkingConfig(c1)
-	require.ErrorContains(t, err, "PublicAddress must be specified when EnableP2PHybridMode is set")
-
-	c1 = Local{
-		P2PHybridNetAddress: "test1",
-		EnableP2PHybridMode: true,
-	}
-	c2, err = enrichNetworkingConfig(c1)
-	require.ErrorContains(t, err, "PublicAddress must be specified when EnableP2PHybridMode is set")
-
-	c1 = Local{
 		EnableP2PHybridMode: true,
 		PublicAddress:       "test2",
 	}
@@ -759,16 +745,20 @@ func TestLocal_ValidateP2PHybridConfig(t *testing.T) {
 		enableP2PHybridMode bool
 		p2pHybridNetAddress string
 		netAddress          string
+		publicAddress       string
 		err                 bool
 	}{
-		{false, "", "", false},
-		{false, ":0", "", false},
-		{false, "", ":0", false},
-		{false, ":0", ":0", false},
-		{true, "", "", false},
-		{true, ":0", "", true},
-		{true, "", ":0", true},
-		{true, ":0", ":0", false},
+		{false, "", "", "", false},
+		{false, ":0", "", "", false},
+		{false, "", ":0", "", false},
+		{false, ":0", ":0", "", false},
+		{true, "", "", "", false},
+		{true, ":0", "", "", true},
+		{true, ":0", "", "pub", true},
+		{true, "", ":0", "", true},
+		{true, "", ":0", "pub", true},
+		{true, ":0", ":0", "", true},
+		{true, ":0", ":0", "pub", false},
 	}
 
 	for i, test := range tests {
@@ -780,9 +770,10 @@ func TestLocal_ValidateP2PHybridConfig(t *testing.T) {
 				EnableP2PHybridMode: test.enableP2PHybridMode,
 				P2PHybridNetAddress: test.p2pHybridNetAddress,
 				NetAddress:          test.netAddress,
+				PublicAddress:       test.publicAddress,
 			}
 			err := c.ValidateP2PHybridConfig()
-			require.Equal(t, test.err, err != nil, name)
+			require.Equal(t, test.err, err != nil, fmt.Sprintf("%s: %v => %v", name, test, err))
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/karalabe/hid v1.0.1-0.20240919124526-821c38d2678e
 	github.com/klauspost/cpuid/v2 v2.2.8
 	github.com/labstack/echo/v4 v4.13.3
+	github.com/labstack/gommon v0.4.2
 	github.com/libp2p/go-libp2p v0.37.0
 	github.com/libp2p/go-libp2p-kad-dht v0.28.0
 	github.com/libp2p/go-libp2p-kbucket v0.6.4
@@ -115,7 +116,6 @@ require (
 	github.com/koron/go-ssdp v0.0.4 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/libp2p/go-cidranger v1.1.0 // indirect
 	github.com/libp2p/go-flow-metrics v0.2.0 // indirect

--- a/node/node.go
+++ b/node/node.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/algorand/go-deadlock"
+	"github.com/labstack/gommon/log"
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/agreement/gossip"
@@ -152,6 +153,9 @@ type AlgorandFullNode struct {
 	oldKeyDeletionNotify        chan struct{}
 	monitoringRoutinesWaitGroup sync.WaitGroup
 
+	hybridError                 string // whether the MakeFull switched to non-hybrid mode due to a P2PHybridConfigError and needs to be logged periodically
+	hybridErrorRoutineWaitGroup sync.WaitGroup
+
 	tracer messagetracer.MessageTracer
 
 	stateProofWorker *stateproof.Worker
@@ -202,11 +206,22 @@ func MakeFull(log logging.Logger, rootDir string, cfg config.Local, phonebookAdd
 
 	// tie network, block fetcher, and agreement services together
 	var p2pNode network.GossipNode
+recreateNetwork:
 	if cfg.EnableP2PHybridMode {
 		p2pNode, err = network.NewHybridP2PNetwork(node.log, node.config, rootDir, phonebookAddresses, genesis.ID(), genesis.Network, node)
 		if err != nil {
-			log.Errorf("could not create hybrid p2p node: %v", err)
-			return nil, err
+			if !errors.As(err, &config.P2PHybridConfigError{}) {
+				log.Errorf("could not create hybrid p2p node: %v", err)
+				return nil, err
+			}
+			// it was P2PHybridConfigError error so fallback to non-hybrid mode (either P2P or WS)
+			cfg.EnableP2PHybridMode = false
+
+			// indicate we need to start logging the error into the log periodically
+			node.hybridError = fmt.Sprintf("could not create hybrid p2p node: %v", err)
+			log.Error(node.hybridError)
+
+			goto recreateNetwork
 		}
 	} else if cfg.EnableP2P {
 		p2pNode, err = network.NewP2PNetwork(node.log, node.config, rootDir, phonebookAddresses, genesis.ID(), genesis.Network, node, nil)
@@ -372,6 +387,24 @@ func (node *AlgorandFullNode) Start() error {
 		return nil
 	}
 
+	if node.hybridError != "" {
+		node.hybridErrorRoutineWaitGroup.Add(1)
+		go func() {
+			defer node.hybridErrorRoutineWaitGroup.Done()
+			ticker := time.NewTicker(6 * time.Hour)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-node.ctx.Done():
+					return
+				case <-ticker.C:
+					// continue logging the error periodically
+					log.Errorf(node.hybridError)
+				}
+			}
+		}()
+	}
+
 	if node.catchpointCatchupService != nil {
 		startNetwork()
 		node.catchpointCatchupService.Start(node.ctx)
@@ -447,6 +480,7 @@ func (node *AlgorandFullNode) Stop() {
 	defer func() {
 		node.mu.Unlock()
 		node.waitMonitoringRoutines()
+		node.hybridErrorRoutineWaitGroup.Wait()
 
 		// oldKeyDeletionThread uses accountManager registry so must be stopped before accountManager is closed
 		node.accountManager.Registry().Close()

--- a/node/node.go
+++ b/node/node.go
@@ -210,7 +210,7 @@ recreateNetwork:
 	if cfg.EnableP2PHybridMode {
 		p2pNode, err = network.NewHybridP2PNetwork(node.log, node.config, rootDir, phonebookAddresses, genesis.ID(), genesis.Network, node)
 		if err != nil {
-			if !errors.As(err, &config.P2PHybridConfigError{}) {
+			if _, ok := err.(config.P2PHybridConfigError); !ok {
 				log.Errorf("could not create hybrid p2p node: %v", err)
 				return nil, err
 			}
@@ -218,7 +218,11 @@ recreateNetwork:
 			cfg.EnableP2PHybridMode = false
 
 			// indicate we need to start logging the error into the log periodically
-			node.hybridError = fmt.Sprintf("could not create hybrid p2p node: %v", err)
+			fallbackNetName := "WS"
+			if cfg.EnableP2P {
+				fallbackNetName = "P2P"
+			}
+			node.hybridError = fmt.Sprintf("could not create hybrid p2p node: %v. Falling back to %s network", err, fallbackNetName)
 			log.Error(node.hybridError)
 
 			goto recreateNetwork

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1381,5 +1381,7 @@ func TestNodeMakeFullHybrid(t *testing.T) {
 	require.IsType(t, &network.WebsocketNetwork{}, node.net)
 
 	node.Stop()
-	require.Contains(t, buf.String(), "P2PHybridMode requires both NetAddress")
+	messages := buf.String()
+	require.Contains(t, messages, "could not create hybrid p2p node: P2PHybridMode requires both NetAddress")
+	require.Contains(t, messages, "Falling back to WS network")
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -17,6 +17,7 @@
 package node
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
 	"os"
@@ -1350,4 +1351,35 @@ func TestNodeP2P_NetProtoVersions(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestNodeMakeFullHybrid(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	testDirectory := t.TempDir()
+
+	genesis := bookkeeping.Genesis{
+		SchemaID:    "go-test-node-genesis",
+		Proto:       protocol.ConsensusCurrentVersion,
+		Network:     config.Devtestnet,
+		FeeSink:     sinkAddr.String(),
+		RewardsPool: poolAddr.String(),
+	}
+
+	var buf bytes.Buffer
+	log := logging.NewLogger()
+	log.SetOutput(&buf)
+
+	cfg := config.GetDefaultLocal()
+	cfg.EnableP2PHybridMode = true
+	cfg.NetAddress = ":0"
+
+	node, err := MakeFull(log, testDirectory, cfg, []string{}, genesis)
+	require.NoError(t, err)
+	err = node.Start()
+	require.NoError(t, err)
+	require.IsType(t, &network.WebsocketNetwork{}, node.net)
+
+	node.Stop()
+	require.Contains(t, buf.String(), "P2PHybridMode requires both NetAddress")
 }


### PR DESCRIPTION
## Summary

As a first step to enabling p2p and hybrid mode make sure having `EnableP2PHybridMode=true` does not abort node starting but logs error message instead periodically.

## Test Plan

Added a unit test to make sure the new log message appears in a log.