### PR TITLE
tests: remove "Fail" part from test test names

### DIFF
--- a/agreement/cryptoVerifier_test.go
+++ b/agreement/cryptoVerifier_test.go
@@ -388,9 +388,9 @@ func BenchmarkCryptoVerifierBundleVertification(b *testing.B) {
 	}
 }
 
-// TestCryptoVerifierVerificationFailures tests to see that the cryptoVerifier.VerifyVote returns an error in the vote response
+// TestCryptoVerifierVerificationErrs tests to see that the cryptoVerifier.VerifyVote returns an error in the vote response
 // when being unable to enqueue a vote.
-func TestCryptoVerifierVerificationFailures(t *testing.T) {
+func TestCryptoVerifierVerificationErrs(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	mainPool := execpool.MakePool(t)

--- a/agreement/persistence_test.go
+++ b/agreement/persistence_test.go
@@ -278,7 +278,7 @@ func TestEmptyMapDeserialization(t *testing.T) {
 	require.NotNil(t, v1.Equivocators)
 }
 
-func TestDecodeFailures(t *testing.T) {
+func TestDecodeErrs(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	clock := timers.MakeMonotonicClock[TimeoutType](time.Date(2015, 1, 2, 5, 6, 7, 8, time.UTC))
 	ce := clock.Encode()

--- a/agreement/pseudonode_test.go
+++ b/agreement/pseudonode_test.go
@@ -458,12 +458,12 @@ func TestPseudonodeLoadingOfParticipationKeys(t *testing.T) {
 
 type substrServiceLogger struct {
 	logging.Logger
-	looupStrings   []string
+	lookupStrings  []string
 	instancesFound []int
 }
 
 func (ssl *substrServiceLogger) Infof(s string, args ...interface{}) {
-	for i, str := range ssl.looupStrings {
+	for i, str := range ssl.lookupStrings {
 		if strings.Contains(s, str) {
 			ssl.instancesFound[i]++
 			return
@@ -471,9 +471,9 @@ func (ssl *substrServiceLogger) Infof(s string, args ...interface{}) {
 	}
 }
 
-// TestPseudonodeFailedEnqueuedTasks test to see that in the case where we cannot enqueue the verification task to the backlog, we won't be waiting forever - instead,
+// TestPseudonodeNonEnqueuedTasks test to see that in the case where we cannot enqueue the verification task to the backlog, we won't be waiting forever - instead,
 // we would generate a warning message and keep going.
-func TestPseudonodeFailedEnqueuedTasks(t *testing.T) {
+func TestPseudonodeNonEnqueuedTasks(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	t.Parallel()
@@ -485,7 +485,7 @@ func TestPseudonodeFailedEnqueuedTasks(t *testing.T) {
 
 	subStrLogger := &substrServiceLogger{
 		Logger:         logging.TestingLog(t),
-		looupStrings:   []string{"pseudonode.makeVotes: failed to enqueue vote verification for", "pseudonode.makeProposals: failed to enqueue vote verification"},
+		lookupStrings:  []string{"pseudonode.makeVotes: failed to enqueue vote verification for", "pseudonode.makeProposals: failed to enqueue vote verification"},
 		instancesFound: []int{0, 0},
 	}
 	sLogger := serviceLogger{

--- a/catchup/peerSelector_test.go
+++ b/catchup/peerSelector_test.go
@@ -325,7 +325,7 @@ func peerSelectorTestRandVal(t *testing.T, seed int) float64 {
 	randVal = randVal + 1
 	return randVal
 }
-func TestPeerSelector_PeersDownloadFailed(t *testing.T) {
+func TestPeerSelector_PeersDownloadError(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -915,7 +915,7 @@ func TestEnsureAndResolveGenesisDirs_migrate(t *testing.T) {
 	require.FileExists(t, filepath.Join(hotDir, "stateproof.sqlite-wal"))
 }
 
-func TestEnsureAndResolveGenesisDirs_migrateCrashFail(t *testing.T) {
+func TestEnsureAndResolveGenesisDirs_migrateCrashErr(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	cfg := GetDefaultLocal()
@@ -947,7 +947,7 @@ func TestEnsureAndResolveGenesisDirs_migrateCrashFail(t *testing.T) {
 	require.NoFileExists(t, filepath.Join(hotDir, "crash.sqlite-shm"))
 }
 
-func TestEnsureAndResolveGenesisDirs_migrateSPFail(t *testing.T) {
+func TestEnsureAndResolveGenesisDirs_migrateSPErr(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	cfg := GetDefaultLocal()

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -1285,7 +1285,7 @@ int 1`,
 	}
 }
 
-func TestSimulateTransactionVerificationFailure(t *testing.T) {
+func TestSimulateTransactionVerificationErr(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 

--- a/data/bookkeeping/block_test.go
+++ b/data/bookkeeping/block_test.go
@@ -562,7 +562,7 @@ func TestInitialRewardsRateCalculation(t *testing.T) {
 		return true
 	}
 
-	// test expected failuire
+	// test expected failure
 	consensusParams.InitialRewardsRateCalculation = false
 	require.False(t, runTest())
 
@@ -658,7 +658,7 @@ func TestNextRewardsRateWithFix(t *testing.T) {
 	}
 }
 
-func TestNextRewardsRateFailsWithoutFix(t *testing.T) {
+func TestNextRewardsRateErrsWithoutFix(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 

--- a/data/transactions/logic/evalAppTxn_test.go
+++ b/data/transactions/logic/evalAppTxn_test.go
@@ -1379,7 +1379,7 @@ int 1
 	})
 }
 
-func TestCreateOldAppFails(t *testing.T) {
+func TestCreateOldAppErrs(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -4590,7 +4590,7 @@ func TestLinearOpcodes(t *testing.T) {
 	}
 }
 
-func TestRekeyFailsOnOldVersion(t *testing.T) {
+func TestRekeyErrsOnOldVersion(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -932,9 +932,9 @@ func TestTxnHeartbeat(t *testing.T) {
 	verifyGroup(t, txnGroups, &blkHdr, breakHbProofFunc, restoreHbProofFunc, crypto.ErrBatchHasFailedSigs.Error())
 }
 
-// TestTxnGroupCacheUpdateFailLogic test makes sure that a payment transaction contains a logic (and no signature)
+// TestTxnGroupCacheUpdateRejLogic test makes sure that a payment transaction contains a logic (and no signature)
 // is valid (and added to the cache) only if logic passes
-func TestTxnGroupCacheUpdateFailLogic(t *testing.T) {
+func TestTxnGroupCacheUpdateRejLogic(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	_, signedTxn, _, _ := generateTestObjects(100, 20, 0, 50)

--- a/ledger/apply/challenge_test.go
+++ b/ledger/apply/challenge_test.go
@@ -51,7 +51,7 @@ func TestBitsMatch(t *testing.T) {
 	require.False(t, bitsMatch([]byte{0x1, 0xff}, []byte{0x1, 00}, 9))
 }
 
-func TestFailsChallenge(t *testing.T) {
+func TestUnsuccessfulChallenge(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 	a := assert.New(t)

--- a/ledger/apptxn_test.go
+++ b/ledger/apptxn_test.go
@@ -1718,7 +1718,7 @@ assert
 	})
 }
 
-func TestAbortWhenInnerAppCallFails(t *testing.T) {
+func TestAbortWhenInnerAppCallErrs(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 

--- a/ledger/eval/eval_test.go
+++ b/ledger/eval/eval_test.go
@@ -1247,8 +1247,8 @@ func (p *failRoundCowParent) lookup(basics.Address) (ledgercore.AccountData, err
 	return ledgercore.AccountData{}, fmt.Errorf("disk I/O fail (on purpose)")
 }
 
-// TestExpiredAccountGenerationWithDiskFailure tests edge cases where disk failures can lead to ledger look up failures
-func TestExpiredAccountGenerationWithDiskFailure(t *testing.T) {
+// TestExpiredAccountGenerationWithDiskErr tests edge cases where disk failures can lead to ledger look up failures
+func TestExpiredAccountGenerationWithDiskErr(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 

--- a/ledger/simulation/simulation_eval_test.go
+++ b/ledger/simulation/simulation_eval_test.go
@@ -2647,7 +2647,7 @@ byte "hello"; log; int 1`,
 	})
 }
 
-func TestFailingLogicSigPCandStack(t *testing.T) {
+func TestInvalidLogicSigPCandStack(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
@@ -2768,7 +2768,7 @@ byte "hello"; log; int 1`,
 	})
 }
 
-func TestFailingApp(t *testing.T) {
+func TestInvalidApp(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
@@ -4448,7 +4448,7 @@ app_local_put
 	}
 }
 
-func TestGlobalStateTypeChangeFailure(t *testing.T) {
+func TestGlobalStateTypeChangeErr(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
@@ -6561,7 +6561,7 @@ func makeProgramToCallInner(t *testing.T, program string) string {
 	return wrapCodeWithVersionAndReturn(itxnSubmitCode)
 }
 
-func TestAppCallInnerTxnApplyDataOnFail(t *testing.T) {
+func TestAppCallInnerTxnApplyDataOnErr(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
@@ -6671,7 +6671,7 @@ byte "finished asset create"
 log
 `
 
-func TestNonAppCallInnerTxnApplyDataOnFail(t *testing.T) {
+func TestNonAppCallInnerTxnApplyDataOnErr(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
@@ -6769,7 +6769,7 @@ byte "finished asset config"
 log
 `
 
-func TestInnerTxnNonAppCallFailure(t *testing.T) {
+func TestInnerTxnNonAppCallErr(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 	simulationTest(t, func(env simulationtesting.Environment) simulationTestCase {
@@ -8952,7 +8952,7 @@ func TestFixSigners(t *testing.T) {
 		innerProgram := fmt.Sprintf(`#pragma version 9
 		txn ApplicationID
 		bz end
-		
+
 		// Rekey to the the innerRekeyAddr
 		itxn_begin
 		int pay
@@ -8962,7 +8962,7 @@ func TestFixSigners(t *testing.T) {
 		addr %s
 		itxn_field RekeyTo
 		itxn_submit
-		
+
 		end:
 		int 1
 		`, innerRekeyAddr)

--- a/network/p2p/dnsaddr/resolve_test.go
+++ b/network/p2p/dnsaddr/resolve_test.go
@@ -85,7 +85,7 @@ func (f *failureResolver) LookupTXT(context.Context, string) ([]string, error) {
 	return nil, fmt.Errorf("always errors")
 }
 
-func TestMultiaddrsFromResolverDnsFailure(t *testing.T) {
+func TestMultiaddrsFromResolverDnsErr(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -511,7 +511,7 @@ func TestP2PBootstrapFunc(t *testing.T) {
 	require.GreaterOrEqual(t, len(addr.Addrs), 1)
 }
 
-func TestP2PdnsLookupBootstrapPeersFailure(t *testing.T) {
+func TestP2PdnsLookupBootstrapPeersErr(t *testing.T) {
 	t.Parallel()
 	partitiontest.PartitionTest(t)
 

--- a/test/e2e-go/cli/goal/account_test.go
+++ b/test/e2e-go/cli/goal/account_test.go
@@ -56,7 +56,7 @@ func TestAccountNew(t *testing.T) {
 	a.True(matched, "Account list should contain the account we just created")
 }
 
-func TestAccountNewDuplicateFails(t *testing.T) {
+func TestAccountNewDuplicateErrs(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	defer fixtures.ShutdownSynchronizedTest(t)

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -285,7 +285,7 @@ func getFixture(consensusParams *config.ConsensusParams) *fixtures.RestClientFix
 	return &fixture
 }
 
-func TestCatchpointCatchupFailure(t *testing.T) {
+func TestCatchpointCatchupErr(t *testing.T) {
 	// Overview of this test:
 	// Start a two-node network (primary has 100%, using has 0%)
 	// create a web proxy, have the using node use it as a peer, blocking all requests for round #2. ( and allowing everything else )

--- a/test/e2e-go/kmd/e2e_kmd_server_client_test.go
+++ b/test/e2e-go/kmd/e2e_kmd_server_client_test.go
@@ -45,7 +45,7 @@ func TestServerStartsStopsSuccessfully(t *testing.T) {
 	a.NoError(err)
 }
 
-func TestBadAuthFails(t *testing.T) {
+func TestBadAuthErrs(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	defer fixtures.ShutdownSynchronizedTest(t)
 

--- a/test/e2e-go/kmd/e2e_kmd_sqlite_test.go
+++ b/test/e2e-go/kmd/e2e_kmd_sqlite_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
-func TestNonAbsSQLiteWalletConfigFails(t *testing.T) {
+func TestNonAbsSQLiteWalletConfigErrs(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	defer fixtures.ShutdownSynchronizedTest(t)
 

--- a/test/e2e-go/restAPI/other/misc_test.go
+++ b/test/e2e-go/restAPI/other/misc_test.go
@@ -81,7 +81,7 @@ func TestDisabledAPIConfig(t *testing.T) {
 	assert.Contains(t, err.Error(), "Invalid API Token")
 }
 
-func TestSendingNotClosingAccountFails(t *testing.T) {
+func TestSendingNotClosingAccountErrs(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	defer fixtures.ShutdownSynchronizedTest(t)
 

--- a/test/e2e-go/restAPI/restClient_test.go
+++ b/test/e2e-go/restAPI/restClient_test.go
@@ -445,7 +445,7 @@ func TestClientCanGetGoRoutines(t *testing.T) {
 	a.True(strings.Contains(goRoutines, "goroutine profile:"))
 }
 
-func TestSendingTooMuchFails(t *testing.T) {
+func TestSendingTooMuchErrs(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	defer fixtures.ShutdownSynchronizedTest(t)
 
@@ -487,7 +487,7 @@ func TestSendingTooMuchFails(t *testing.T) {
 	a.Error(err)
 }
 
-func TestSendingFromEmptyAccountFails(t *testing.T) {
+func TestSendingFromEmptyAccountErrs(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	defer fixtures.ShutdownSynchronizedTest(t)
 
@@ -527,7 +527,7 @@ func TestSendingFromEmptyAccountFails(t *testing.T) {
 	a.Error(err)
 }
 
-func TestSendingTooLittleToEmptyAccountFails(t *testing.T) {
+func TestSendingTooLittleToEmptyAccountErrs(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	defer fixtures.ShutdownSynchronizedTest(t)
 
@@ -560,7 +560,7 @@ func TestSendingTooLittleToEmptyAccountFails(t *testing.T) {
 	a.Error(err)
 }
 
-func TestSendingLowFeeFails(t *testing.T) {
+func TestSendingLowFeeErrs(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	defer fixtures.ShutdownSynchronizedTest(t)
 

--- a/tools/network/dnssec/trustedchain_test.go
+++ b/tools/network/dnssec/trustedchain_test.go
@@ -274,7 +274,7 @@ func TestEnsureTrustChain(t *testing.T) {
 	a.Contains(err.Error(), "failed to verify test. KSK against digest in parent DS")
 }
 
-func TestEnsureTrustChainFailures(t *testing.T) {
+func TestEnsureTrustChainError(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	a := require.New(t)


### PR DESCRIPTION
## Summary

Remove 'Fail*' part from go test name so that 'Fail' is quickly searchable in test results.

## Test Plan

This is test files change