### PR TITLE
network: do not use telemetry id for p2p nets

### DIFF
--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -791,12 +791,12 @@ func (n *P2PNetwork) OnNetworkAdvance() {
 
 // TelemetryGUID returns the telemetry GUID of this node.
 func (n *P2PNetwork) TelemetryGUID() string {
-	return n.log.GetTelemetryGUID()
+	return ""
 }
 
 // InstanceName returns the instance name of this node.
 func (n *P2PNetwork) InstanceName() string {
-	return n.log.GetInstanceName()
+	return ""
 }
 
 // GenesisID returns the genesis ID of this node.


### PR DESCRIPTION
## Summary

Prevent p2p from exposing own telemetry ids.

## Test Plan

Existing tests