### PR TITLE
logging: log configuration migration messages

### DIFF
--- a/cmd/algod/main.go
+++ b/cmd/algod/main.go
@@ -175,7 +175,7 @@ func run() int {
 	checkAndDeleteIndexerFile("indexer.sqlite-shm")
 	checkAndDeleteIndexerFile("indexer.sqlite-wal")
 
-	cfg, err := config.LoadConfigFromDisk(absolutePath)
+	cfg, migrationResults, err := config.LoadConfigFromDiskWithMigrations(absolutePath)
 	if err != nil && !os.IsNotExist(err) {
 		// log is not setup yet, this will log to stderr
 		log.Fatalf("Cannot load config: %v", err)
@@ -371,7 +371,7 @@ func run() int {
 		cfg.LogSizeLimit = 0
 	}
 
-	err = s.Initialize(cfg, phonebookAddresses, string(genesisText))
+	err = s.Initialize(cfg, phonebookAddresses, string(genesisText), migrationResults)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		log.Error(err)

--- a/config/config.go
+++ b/config/config.go
@@ -107,10 +107,16 @@ const PlaceholderPublicAddress = "PLEASE_SET_ME"
 // cannot be loaded, the default config is returned (with the error from loading the
 // custom file).
 func LoadConfigFromDisk(custom string) (c Local, err error) {
+	c, _, err = loadConfigFromFile(filepath.Join(custom, ConfigFilename))
+	return
+}
+
+// LoadConfigFromDiskWithMigrations is like LoadConfigFromDisk but also returns migration results
+func LoadConfigFromDiskWithMigrations(custom string) (c Local, migrations []MigrationResult, err error) {
 	return loadConfigFromFile(filepath.Join(custom, ConfigFilename))
 }
 
-func loadConfigFromFile(configFile string) (c Local, err error) {
+func loadConfigFromFile(configFile string) (c Local, migrations []MigrationResult, err error) {
 	c = defaultLocal
 	c.Version = 0 // Reset to 0 so we get the version from the loaded file.
 	c, err = mergeConfigFromFile(configFile, c)
@@ -121,7 +127,7 @@ func loadConfigFromFile(configFile string) (c Local, err error) {
 	// Migrate in case defaults were changed
 	// If a config file does not have version, it is assumed to be zero.
 	// All fields listed in migrate() might be changed if an actual value matches to default value from a previous version.
-	c, err = migrate(c)
+	c, migrations, err = migrate(c)
 	return
 }
 

--- a/config/migrate.go
+++ b/config/migrate.go
@@ -153,7 +153,6 @@ func migrate(cfg Local) (newCfg Local, migrations []MigrationResult, err error) 
 				panic(fmt.Sprintf("unsupported data type (%s) encountered when reflecting on config.Local datatype %s", reflect.ValueOf(&defaultCurrentConfig).Elem().FieldByName(field.Name).Kind(), field.Name))
 			}
 		}
-		newCfg.Version = nextVersion
 	}
 
 	// Only return migrations where the value actually changed

--- a/config/migrate.go
+++ b/config/migrate.go
@@ -156,8 +156,11 @@ func migrate(cfg Local) (newCfg Local, migrations []MigrationResult, err error) 
 		newCfg.Version = nextVersion
 	}
 
+	// Only return migrations where the value actually changed
 	for _, migration := range migratedFields {
-		migrations = append(migrations, migration)
+		if migration.OldValue != migration.NewValue {
+			migrations = append(migrations, migration)
+		}
 	}
 
 	return

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -78,7 +78,7 @@ type Server struct {
 }
 
 // Initialize creates a Node instance with applicable network services
-func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string, genesisText string) error {
+func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string, genesisText string, migrationResults []config.MigrationResult) error {
 	// set up node
 	s.log = logging.Base()
 
@@ -233,6 +233,11 @@ func (s *Server) Initialize(cfg config.Local, phonebookAddresses []string, genes
 		s.log.Infoln("Telemetry Disabled")
 	}
 	s.log.Infoln("++++++++++++++++++++++++++++++++++++++++")
+
+	for _, m := range migrationResults {
+		s.log.Infof("Upgraded default config value for %s from %v (version %d) to %v (version %d)",
+			m.FieldName, m.OldValue, m.OldVersion, m.NewValue, m.NewVersion)
+	}
 
 	metricLabels := map[string]string{}
 	if s.log.GetTelemetryEnabled() {


### PR DESCRIPTION
## Summary

Add info-level log messages to show when configuration defaults for old versions are upgraded to the default for the latest config version.

## Test Plan

Updated TestLocal_ConfigMigrateFromDisk show the new messages (with go test -v). Manually ran using goal/algod as well.