### PR TITLE
Txn: move/add asset txn validation into their own wellFormed methods

### DIFF
--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -337,9 +337,34 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 			return err
 		}
 
-	case protocol.AssetConfigTx, protocol.AssetTransferTx, protocol.AssetFreezeTx:
+	case protocol.AssetConfigTx:
 		if !proto.Asset {
 			return fmt.Errorf("asset transaction not supported")
+		}
+
+		err := tx.AssetConfigTxnFields.wellFormed(proto)
+		if err != nil {
+			return err
+		}
+
+	case protocol.AssetTransferTx:
+		if !proto.Asset {
+			return fmt.Errorf("asset transaction not supported")
+		}
+
+		err := tx.AssetTransferTxnFields.wellFormed()
+		if err != nil {
+			return err
+		}
+
+	case protocol.AssetFreezeTx:
+		if !proto.Asset {
+			return fmt.Errorf("asset transaction not supported")
+		}
+
+		err := tx.AssetFreezeTxnFields.wellFormed()
+		if err != nil {
+			return err
 		}
 
 	case protocol.ApplicationCallTx:
@@ -430,18 +455,6 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 	}
 	if len(tx.Note) > proto.MaxTxnNoteBytes {
 		return fmt.Errorf("transaction note too big: %d > %d", len(tx.Note), proto.MaxTxnNoteBytes)
-	}
-	if len(tx.AssetConfigTxnFields.AssetParams.AssetName) > proto.MaxAssetNameBytes {
-		return fmt.Errorf("transaction asset name too big: %d > %d", len(tx.AssetConfigTxnFields.AssetParams.AssetName), proto.MaxAssetNameBytes)
-	}
-	if len(tx.AssetConfigTxnFields.AssetParams.UnitName) > proto.MaxAssetUnitNameBytes {
-		return fmt.Errorf("transaction asset unit name too big: %d > %d", len(tx.AssetConfigTxnFields.AssetParams.UnitName), proto.MaxAssetUnitNameBytes)
-	}
-	if len(tx.AssetConfigTxnFields.AssetParams.URL) > proto.MaxAssetURLBytes {
-		return fmt.Errorf("transaction asset url too big: %d > %d", len(tx.AssetConfigTxnFields.AssetParams.URL), proto.MaxAssetURLBytes)
-	}
-	if tx.AssetConfigTxnFields.AssetParams.Decimals > proto.MaxAssetDecimals {
-		return fmt.Errorf("transaction asset decimals is too high (max is %d)", proto.MaxAssetDecimals)
 	}
 	if tx.Sender == spec.RewardsPool {
 		// this check is just to be safe, but reaching here seems impossible, since it requires computing a preimage of rwpool


### PR DESCRIPTION
Whilst going through the specs I've been doubling checking what's there and how go-algorand is doing it. For asset transactions it felt like there _should_ be more than we currently had. So I've created this PR to see if it's worth relocating the existing acfg checks and introducing some new axfer/afrz wellFormed checks which I feel make sense.

acfg - moved:
 + AssetName must not be longer than MaxAssetNameBytes. This was moved from `data/transactions/transaction.go:Transaction.WellFormed()`.
 + UnitName must not be longer than MaxAssetUnitNameBytes. This was moved from `data/transactions/transaction.go:Transaction.WellFormed()`.
 + URL must not be longer than MaxAssetURLBytes. This was moved from `data/transactions/transaction.go:Transaction.WellFormed()`.
 + Decimals must not be greater than MaxAssetDecimals. This was moved from `data/transactions/transaction.go:Transaction.WellFormed()`.

axfer - new:
 + XferAsset must not be zero (missing). This was previously caught by `ledger/apply/asset.go` as "asset 0 does not exist or has been deleted".
 + AssetSender and AssetCloseTo cannot both be set. This was previously caught by `ledger/apply/asset.go` as "cannot close asset by clawback".

afrz - new:
 + FreezeAsset must not be zero (missing). This was previously caught by `ledger/apply/asset.go` as "asset 0 does not exist or has been deleted".
 + FreezeAccount must not be zero (missing). This was previously caught by `ledger/apply/asset.go` as "asset not found in account".