### PR TITLE
node: print repeating error to the node log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/karalabe/hid v1.0.1-0.20240919124526-821c38d2678e
 	github.com/klauspost/cpuid/v2 v2.2.8
 	github.com/labstack/echo/v4 v4.13.3
-	github.com/labstack/gommon v0.4.2
 	github.com/libp2p/go-libp2p v0.37.0
 	github.com/libp2p/go-libp2p-kad-dht v0.28.0
 	github.com/libp2p/go-libp2p-kbucket v0.6.4
@@ -116,6 +115,7 @@ require (
 	github.com/koron/go-ssdp v0.0.4 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/libp2p/go-cidranger v1.1.0 // indirect
 	github.com/libp2p/go-flow-metrics v0.2.0 // indirect

--- a/node/node.go
+++ b/node/node.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/algorand/go-deadlock"
-	"github.com/labstack/gommon/log"
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/agreement/gossip"
@@ -407,7 +406,7 @@ func (node *AlgorandFullNode) Start() error {
 					return
 				case <-ticker.C:
 					// continue logging the error periodically
-					log.Errorf(node.hybridError)
+					node.log.Error(node.hybridError)
 				}
 			}
 		}()


### PR DESCRIPTION
Original comment in: #6376

> I was looking through the PR and noticed this is the only use of the newly imported package above (`"github.com/labstack/gommon/log"` on [line 32](https://github.com/algorand/go-algorand/pull/6376/files#diff-375d57e386f20eaa5f09f02bb9d28bfc48ac3dca18d0325f59492208219e5618R32)). I'm just wondering if this was intentional?

## Summary

It looked like an error was being sent to the wrong place. I test it and couldn't see the error message, but this PR places it into the log file.

## Test Plan

I reduced the ticker to `2 * time.Second` and misconfigured a local node. It correctly repeated the error message.
```
nullun@local demonet % tail -f rootdir/node1/node.log | grep P2PHybridMode
{"file":"node.go","function":"github.com/algorand/go-algorand/node.(*AlgorandFullNode).Start.func2","level":"error","line":409,"msg":"could not create hybrid p2p node: P2PHybridMode requires both NetAddress and P2PHybridNetAddress to be set or unset. Falling back to P2P network","name":":4004","time":"2025-08-04T15:11:27.424437+01:00"}
{"file":"node.go","function":"github.com/algorand/go-algorand/node.(*AlgorandFullNode).Start.func2","level":"error","line":409,"msg":"could not create hybrid p2p node: P2PHybridMode requires both NetAddress and P2PHybridNetAddress to be set or unset. Falling back to P2P network","name":":4004","time":"2025-08-04T15:11:29.424504+01:00"}
{"file":"node.go","function":"github.com/algorand/go-algorand/node.(*AlgorandFullNode).Start.func2","level":"error","line":409,"msg":"could not create hybrid p2p node: P2PHybridMode requires both NetAddress and P2PHybridNetAddress to be set or unset. Falling back to P2P network","name":":4004","time":"2025-08-04T15:11:31.424506+01:00"}
{"file":"node.go","function":"github.com/algorand/go-algorand/node.(*AlgorandFullNode).Start.func2","level":"error","line":409,"msg":"could not create hybrid p2p node: P2PHybridMode requires both NetAddress and P2PHybridNetAddress to be set or unset. Falling back to P2P network","name":":4004","time":"2025-08-04T15:11:33.424467+01:00"}
```