### PR TITLE
goal: minor text fix

### DIFF
--- a/cmd/goal/multisig.go
+++ b/cmd/goal/multisig.go
@@ -142,7 +142,7 @@ var addSigCmd = &cobra.Command{
 }
 
 var signProgramCmd = &cobra.Command{
-	Use:   "signprogram -t [transaction file] -a [address]",
+	Use:   "signprogram -a [address]",
 	Short: "Add a signature to a multisig LogicSig",
 	Long:  `Start a multisig LogicSig, or add a signature to an existing multisig, for a given program.`,
 	Args:  validateNoPosArgsFn,


### PR DESCRIPTION
`-t` doesn't exist for `goal clerk multisig signprogram` and the text was probably copied from addSigCmd