### PR TITLE
tests: network flaky tests fixes

### DIFF
--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -1250,7 +1250,7 @@ func TestP2PwsStreamHandlerDedup(t *testing.T) {
 	defer netB.Stop()
 
 	require.Eventually(t, func() bool {
-		return networkPeerIdentityDisconnect.GetUint64Value() == networkPeerIdentityDisconnectInitial+1
+		return networkPeerIdentityDisconnect.GetUint64Value() > networkPeerIdentityDisconnectInitial
 	}, 2*time.Second, 50*time.Millisecond)
 
 	// now allow the peer made outgoing connection to handle conn closing initiated by the other side

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -337,7 +337,7 @@ func setupWebsocketNetworkABwithLogger(t *testing.T, countTarget int, log loggin
 	counter := newMessageCounter(t, countTarget)
 	netB.RegisterHandlers([]TaggedMessageHandler{{Tag: protocol.TxnTag, MessageHandler: counter}})
 
-	readyTimeout := time.NewTimer(2 * time.Second)
+	readyTimeout := time.NewTimer(5 * time.Second)
 	waitReady(t, netA, readyTimeout.C)
 	t.Log("a ready")
 	waitReady(t, netB, readyTimeout.C)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -952,10 +952,18 @@ func TestNodeHybridTopology(t *testing.T) {
 	startAndConnectNodes(nodes, 10*time.Second)
 
 	// ensure the initial connectivity topology
+	repeatCounter := 0
 	require.Eventually(t, func() bool {
+		repeatCounter++
 		node0Conn := len(nodes[0].net.GetPeers(network.PeersConnectedIn)) > 0                             // has connection from 1
 		node1Conn := len(nodes[1].net.GetPeers(network.PeersConnectedOut, network.PeersConnectedIn)) == 2 // connected to 0 and 2
 		node2Conn := len(nodes[2].net.GetPeers(network.PeersConnectedOut, network.PeersConnectedIn)) >= 1 // connected to 1
+		if repeatCounter > 100 && !(node0Conn && node1Conn && node2Conn) {
+			t.Logf("IN/OUT connection stats:\nNode0 %d/%d, Node1 %d/%d, Node2 %d/%d",
+				len(nodes[0].net.GetPeers(network.PeersConnectedIn)), len(nodes[0].net.GetPeers(network.PeersConnectedOut)),
+				len(nodes[1].net.GetPeers(network.PeersConnectedIn)), len(nodes[1].net.GetPeers(network.PeersConnectedOut)),
+				len(nodes[2].net.GetPeers(network.PeersConnectedIn)), len(nodes[2].net.GetPeers(network.PeersConnectedOut)))
+		}
 		return node0Conn && node1Conn && node2Conn
 	}, 60*time.Second, 500*time.Millisecond)
 


### PR DESCRIPTION
## Summary

wsNetwork tests: increase wait ready timeout to 5s
TestP2PwsStreamHandlerDedup: relax wait condition to handle occasional disconnects
TestNodeHybridTopology: add debug output 

## Test Plan

These are test fixes