### PR TITLE
tests: fix wait timeout in TestApplicationsUpgradeOverREST

### DIFF
--- a/test/e2e-go/upgrades/application_support_test.go
+++ b/test/e2e-go/upgrades/application_support_test.go
@@ -242,10 +242,10 @@ int 1
 	a.NoError(err)
 	round, err = client.CurrentRound()
 	a.NoError(err)
-	_, err = client.BroadcastTransaction(signedTxn)
+	txid, err := client.BroadcastTransaction(signedTxn)
 	a.NoError(err)
 
-	client.WaitForRound(round + 2)
+	client.WaitForConfirmedTxn(round+10, txid)
 
 	// check creator's balance record for the app entry and the state changes
 	ad, err = client.AccountData(creator)


### PR DESCRIPTION
## Summary

Fix TestApplicationsUpgradeOverREST failure seen in https://github.com/algorand/go-algorand/actions/runs/16784825266/job/47532941575

## Test Plan

This is a test fix