### PR TITLE
Prepare for falcon_verify in v12

### DIFF
--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -432,11 +432,15 @@ online_stake
 voter_params_get VoterIncentiveEligible
 `
 
-const stateProofNonsense = `
-pushbytes 0x0123456789abcd
-sumhash512
+const fvNonsense = `
+pushbytes 0xabcd
 dup; dup
 falcon_verify
+`
+
+const sumhashNonsense = `
+pushbytes 0x0123
+sumhash512
 `
 
 const mimcNonsense = `
@@ -457,7 +461,9 @@ const v10Nonsense = v9Nonsense + pairingNonsense + spliceNonsence
 
 const v11Nonsense = v10Nonsense + incentiveNonsense + mimcNonsense
 
-const v12Nonsense = v11Nonsense + stateProofNonsense
+const v12Nonsense = v11Nonsense + fvNonsense
+
+const v13Nonsense = v12Nonsense + sumhashNonsense
 
 const v6Compiled = "2004010002b7a60c26050242420c68656c6c6f20776f726c6421070123456789abcd208dae2087fbba51304eb02b91f656948397a7946390e8cb70fc9ea4d95f92251d047465737400320032013202320380021234292929292b0431003101310231043105310731083109310a310b310c310d310e310f3111311231133114311533000033000133000233000433000533000733000833000933000a33000b33000c33000d33000e33000f3300113300123300133300143300152d2e01022581f8acd19181cf959a1281f8acd19181cf951a81f8acd19181cf1581f8acd191810f082209240a220b230c240d250e230f2310231123122313231418191a1b1c28171615400003290349483403350222231d4a484848482b50512a632223524100034200004322602261222704634848222862482864286548482228246628226723286828692322700048482371004848361c0037001a0031183119311b311d311e311f312023221e312131223123312431253126312731283129312a312b312c312d312e312f447825225314225427042455220824564c4d4b0222382124391c0081e80780046a6f686e2281d00f23241f880003420001892224902291922494249593a0a1a2a3a4a5a6a7a8a9aaabacadae24af3a00003b003c003d816472064e014f012a57000823810858235b235a2359b03139330039b1b200b322c01a23c1001a2323c21a23c3233e233f8120af06002a494905002a49490700b400b53a03b6b7043cb8033a0c2349c42a9631007300810881088120978101c53a8101c6003a"
 
@@ -480,12 +486,14 @@ const spliceCompiled = "d2d3"
 const v10Compiled = v9Compiled + pairingCompiled + spliceCompiled
 
 const incentiveCompiled = "757401"
-
-const stateProofCompiled = "80070123456789abcd86494985"
 const mimcCompiled = "802011223344556677889900aabbccddeeff11223344556677889900aabbccddeeffe601"
-
 const v11Compiled = v10Compiled + incentiveCompiled + mimcCompiled
-const v12Compiled = v11Compiled + stateProofCompiled
+
+const fvCompiled = "8002abcd494985"
+const v12Compiled = v11Compiled + fvCompiled
+
+const sumhashCompiled = "8002012386"
+const v13Compiled = v12Compiled + sumhashCompiled
 
 var nonsense = map[uint64]string{
 	1:  v1Nonsense,
@@ -500,6 +508,7 @@ var nonsense = map[uint64]string{
 	10: v10Nonsense,
 	11: v11Nonsense,
 	12: v12Nonsense,
+	13: v13Nonsense,
 }
 
 var compiled = map[uint64]string{
@@ -515,6 +524,7 @@ var compiled = map[uint64]string{
 	10: "0a" + v10Compiled,
 	11: "0b" + v11Compiled,
 	12: "0c" + v12Compiled,
+	13: "0d" + v13Compiled,
 }
 
 func pseudoOp(opcode string) bool {
@@ -568,7 +578,7 @@ func TestAssemble(t *testing.T) {
 	}
 }
 
-var experiments = []uint64{spOpcodesVersion}
+var experiments = []uint64{sumhashVersion}
 
 // TestExperimental forces a conscious choice to promote "experimental" opcode
 // groups. This will fail when we increment vFuture's LogicSigVersion. If we had

--- a/data/transactions/logic/crypto_test.go
+++ b/data/transactions/logic/crypto_test.go
@@ -76,7 +76,7 @@ func TestSumhash(t *testing.T) {
 	}
 
 	for _, v := range testVectors {
-		testAccepts(t, fmt.Sprintf(`byte "%s"; sumhash512; byte 0x%s; ==`, v.in, v.out), 12)
+		testAccepts(t, fmt.Sprintf(`byte "%s"; sumhash512; byte 0x%s; ==`, v.in, v.out), 13)
 	}
 }
 

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -1271,6 +1271,9 @@ global PayoutsMaxBalance; int 6; ==; assert
 const globalV12TestProgram = globalV11TestProgram + `
 `
 
+const globalV13TestProgram = globalV12TestProgram + `
+`
+
 func TestAllGlobals(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
@@ -1294,6 +1297,7 @@ func TestAllGlobals(t *testing.T) {
 		10: {GenesisHash, globalV10TestProgram},
 		11: {PayoutsMaxBalance, globalV11TestProgram},
 		12: {PayoutsMaxBalance, globalV12TestProgram},
+		13: {PayoutsMaxBalance, globalV12TestProgram},
 	}
 	// tests keys are versions so they must be in a range 1..AssemblerMaxVersion plus zero version
 	require.LessOrEqual(t, len(tests), AssemblerMaxVersion+1)
@@ -1925,6 +1929,7 @@ func TestTxn(t *testing.T) {
 		10: testTxnProgramTextV10,
 		11: testTxnProgramTextV11,
 		12: testTxnProgramTextV12,
+		13: testTxnProgramTextV12, // nothing new yet
 	}
 
 	for i, txnField := range TxnFieldNames {

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -28,7 +28,7 @@ import (
 )
 
 // LogicVersion defines default assembler and max eval versions
-const LogicVersion = 12
+const LogicVersion = 13
 
 // rekeyingEnabledVersion is the version of TEAL where RekeyTo functionality
 // was enabled. This is important to remember so that old TEAL accounts cannot
@@ -81,7 +81,7 @@ const mimcVersion = 11
 // EXPERIMENTAL. These should be revisited whenever a new LogicSigVersion is
 // moved from vFuture to a new consensus version. If they remain unready, bump
 // their version, and fixup TestAssemble() in assembler_test.go.
-const spOpcodesVersion = 12 // falcon_verify, sumhash512
+const sumhashVersion = 13
 
 // Unlimited Global Storage opcodes
 const boxVersion = 8 // box_*
@@ -655,8 +655,8 @@ var OpSpecs = []OpSpec{
 	{0x83, "pushints", opPushInts, proto(":", "", "[N items]").stackExplain(opPushIntsStackChange), 8, constants(asmPushInts, checkIntImmArgs, "uint ...", immInts).typed(typePushInts).trust()},
 
 	{0x84, "ed25519verify_bare", opEd25519VerifyBare, proto("bb{64}b{32}:T"), 7, costly(1900)},
-	{0x85, "falcon_verify", opFalconVerify, proto("bb{1232}b{1793}:T"), spOpcodesVersion, costly(1700)}, // dynamic for internal hash?
-	{0x86, "sumhash512", opSumhash512, proto("b:b{64}"), spOpcodesVersion, costByLength(150, 7, 4, 0)},
+	{0x85, "falcon_verify", opFalconVerify, proto("bb{1232}b{1793}:T"), 12, costly(1700)}, // dynamic for internal hash?
+	{0x86, "sumhash512", opSumhash512, proto("b:b{64}"), sumhashVersion, costByLength(150, 7, 4, 0)},
 
 	// "Function oriented"
 	{0x88, "callsub", opCallSub, proto(":"), 4, detBranch()},


### PR DESCRIPTION
sumhash is staying experimental until a use case is shown

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
