### PR TITLE
tests: increase wait timeout in TestTotalWeightChanges

### DIFF
--- a/test/e2e-go/features/stateproofs/stateproofs_test.go
+++ b/test/e2e-go/features/stateproofs/stateproofs_test.go
@@ -847,7 +847,7 @@ func TestTotalWeightChanges(t *testing.T) {
 		if testing.Short() {
 			a.NoError(fixture.WaitForRound(rnd, 30*time.Second))
 		} else {
-			a.NoError(fixture.WaitForRound(rnd, 60*time.Second))
+			a.NoError(fixture.WaitForRound(rnd, 120*time.Second))
 		}
 		blk, err := libgoal.BookkeepingBlock(rnd)
 		a.NoErrorf(err, "failed to retrieve block from algod on round %d", rnd)


### PR DESCRIPTION
## Summary

`TestTotalWeightChanges` creates a large network. It is known if multi-node network startup is delayed consensus struggles to agree on the first round because at some point better proposal emerges but can't make it way in time.
Increases timeout from 60 to 120 seconds to give the network more chances to succeed.

## Test Plan

This is a test fix