### PR TITLE
pingpong: fix regression when making app calls

### DIFF
--- a/shared/pingpong/pingpong.go
+++ b/shared/pingpong/pingpong.go
@@ -1205,6 +1205,7 @@ func (pps *WorkerState) constructAppTxn(from string, fee uint64, client *libgoal
 	}
 
 	appOptIns := pps.cinfo.OptIns[aidx]
+	sender = from
 	if len(appOptIns) > 0 {
 		indices := rand.Perm(len(appOptIns))
 		limit := 5
@@ -1219,6 +1220,7 @@ func (pps *WorkerState) constructAppTxn(from string, fee uint64, client *libgoal
 		if pps.cinfo.AppParams[aidx].Creator != from &&
 			!slices.Contains(appOptIns, from) {
 			from = accounts[0]
+			sender = from
 		}
 		accounts = accounts[1:]
 	}


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #6286 where `constructAppTxn` in the `pingpong` perf testing tool's code was refactored to use the new `RefBundle` structure for txn.Access, but forgot to set the `sender` output arg. This caused `constructAppTxn` to always return an empty string, leading to "no acct" errors for all app calls in pingpong and 0 TPS for `stateful_teal_*` performance tests.

The fix adds the missing sender assignments:
- Initialize sender = from at the beginning of the opt-in logic
- Update sender = from when the from address is changed to use an already opted-in account

## Test Plan

Tested manually, "no acct" error no longer appears.