### PR TITLE
lint: run modernize fmtappendf

### DIFF
--- a/agreement/fuzzer/ledger_test.go
+++ b/agreement/fuzzer/ledger_test.go
@@ -42,7 +42,7 @@ var readOnlyParticipationVotes = []*crypto.OneTimeSignatureSecrets{}
 func init() {
 	rand.Seed(randseed)
 	for i := 0; i < 64; i++ {
-		prngSeed := []byte(fmt.Sprintf("Fuzzer-OTSS-PRNG-%d", i))
+		prngSeed := fmt.Appendf(nil, "Fuzzer-OTSS-PRNG-%d", i)
 		rng := crypto.MakePRNG(prngSeed)
 		readOnlyParticipationVotes = append(readOnlyParticipationVotes, crypto.GenerateOneTimeSignatureSecretsRNG(0, 1000, rng))
 	}

--- a/cmd/opdoc/opdoc.go
+++ b/cmd/opdoc/opdoc.go
@@ -256,7 +256,7 @@ func opToMarkdown(out io.Writer, op *logic.OpSpec, groupDocWritten map[string]bo
 }
 
 func opsToMarkdown(out io.Writer, version uint64) error {
-	_, err := out.Write([]byte(fmt.Sprintf("# v%d Opcodes\n\nOps have a 'cost' of 1 unless otherwise specified.\n\n", version)))
+	_, err := out.Write(fmt.Appendf(nil, "# v%d Opcodes\n\nOps have a 'cost' of 1 unless otherwise specified.\n\n", version))
 	if err != nil {
 		return err
 	}

--- a/config/defaultsGenerator/defaultsGenerator.go
+++ b/config/defaultsGenerator/defaultsGenerator.go
@@ -65,7 +65,7 @@ func main() {
 	localDefaultsBytes = append(localDefaultsBytes, []byte(autoGenHeader)...)
 
 	// add the package name:
-	localDefaultsBytes = append(localDefaultsBytes, []byte(fmt.Sprintf("\npackage %s\n\n", *packageName))...)
+	localDefaultsBytes = append(localDefaultsBytes, fmt.Appendf(nil, "\npackage %s\n\n", *packageName)...)
 
 	autoDefaultsBytes := []byte(prettyPrint(config.AutogenLocal, "go"))
 

--- a/daemon/algod/server.go
+++ b/daemon/algod/server.go
@@ -399,12 +399,12 @@ func (s *Server) Start() {
 	// quit earlier than these service files get created
 	s.pidFile = filepath.Join(s.RootPath, "algod.pid")
 	s.netFile = filepath.Join(s.RootPath, "algod.net")
-	err = os.WriteFile(s.pidFile, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0644)
+	err = os.WriteFile(s.pidFile, fmt.Appendf(nil, "%d\n", os.Getpid()), 0644)
 	if err != nil {
 		fmt.Printf("pidfile error: %v\n", err)
 		os.Exit(1)
 	}
-	err = os.WriteFile(s.netFile, []byte(fmt.Sprintf("%s\n", addr)), 0644)
+	err = os.WriteFile(s.netFile, fmt.Appendf(nil, "%s\n", addr), 0644)
 	if err != nil {
 		fmt.Printf("netfile error: %v\n", err)
 		os.Exit(1)
@@ -413,7 +413,7 @@ func (s *Server) Start() {
 	listenAddr, listening := s.node.ListeningAddress()
 	if listening {
 		s.netListenFile = filepath.Join(s.RootPath, "algod-listen.net")
-		err = os.WriteFile(s.netListenFile, []byte(fmt.Sprintf("%s\n", listenAddr)), 0644)
+		err = os.WriteFile(s.netListenFile, fmt.Appendf(nil, "%s\n", listenAddr), 0644)
 		if err != nil {
 			fmt.Printf("netlistenfile error: %v\n", err)
 			os.Exit(1)

--- a/daemon/kmd/server/server.go
+++ b/daemon/kmd/server/server.go
@@ -147,7 +147,7 @@ func (ws *WalletServer) writeStateFiles(netAddr string) (err error) {
 		return
 	}
 	// pidPath file contains current process ID
-	err = os.WriteFile(ws.pidPath, []byte(fmt.Sprintf("%d", os.Getpid())), 0640)
+	err = os.WriteFile(ws.pidPath, fmt.Appendf(nil, "%d", os.Getpid()), 0640)
 	return
 }
 

--- a/daemon/kmd/session/auth.go
+++ b/daemon/kmd/session/auth.go
@@ -91,8 +91,8 @@ func generateHandleIDAndSecret() ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 
-	hexID := []byte(fmt.Sprintf("%x", handleID))
-	hexSecret := []byte(fmt.Sprintf("%x", handleSecret))
+	hexID := fmt.Appendf(nil, "%x", handleID)
+	hexSecret := fmt.Appendf(nil, "%x", handleSecret)
 	return hexID, hexSecret, nil
 }
 
@@ -149,7 +149,7 @@ func (sm *Manager) InitWalletHandle(w wallet.Wallet, pw []byte) ([]byte, error) 
 	sm.mux.Lock()
 	defer sm.mux.Unlock()
 	sm.walletHandles[string(handleID)] = handle
-	handleToken := []byte(fmt.Sprintf("%s%s%s", handleID, wHandleTokenSplitChar, handleSecret))
+	handleToken := fmt.Appendf(nil, "%s%s%s", handleID, wHandleTokenSplitChar, handleSecret)
 
 	return handleToken, nil
 }

--- a/daemon/kmd/wallet/driver/sqlite_crypto.go
+++ b/daemon/kmd/wallet/driver/sqlite_crypto.go
@@ -233,7 +233,7 @@ func decryptBlobWithPassword(blob []byte, ptType plaintextType, password []byte)
 // specifies the key to be derived
 func extractKeyWithIndex(derivationKey []byte, index uint64) (pk crypto.PublicKey, sk crypto.PrivateKey, err error) {
 	// The info tag is just the the utf-8 string representation of the index
-	info := []byte(fmt.Sprintf(hkdfInfoFormat, index))
+	info := fmt.Appendf(nil, hkdfInfoFormat, index)
 
 	// We can skip hkdf.Extract since our key is long and uniformly random
 	// Use the master derivation key and the index to generate a keystream

--- a/daemon/kmd/wallet/wallet.go
+++ b/daemon/kmd/wallet/wallet.go
@@ -78,5 +78,5 @@ func GenerateWalletID() ([]byte, error) {
 	if err != nil {
 		return []byte(""), err
 	}
-	return []byte(fmt.Sprintf("%x", bytes)), nil
+	return fmt.Appendf(nil, "%x", bytes), nil
 }

--- a/ledger/acctdeltas_test.go
+++ b/ledger/acctdeltas_test.go
@@ -2033,7 +2033,7 @@ func BenchmarkLRUResources(b *testing.B) {
 	for i := 0; i < 850; i++ {
 		data.Data.ApprovalProgram = make([]byte, 8096*4)
 		data.Aidx = basics.CreatableIndex(1)
-		addrBytes := ([]byte(fmt.Sprintf("%d", i)))[:32]
+		addrBytes := (fmt.Appendf(nil, "%d", i))[:32]
 		var addr basics.Address
 		for i, b := range addrBytes {
 			addr[i] = b
@@ -2120,7 +2120,7 @@ func BenchmarkBoxDatabaseRead(b *testing.B) {
 					var pv trackerdb.PersistedKVData
 					boxName := boxNames[i%totalBoxes]
 					b.StartTimer()
-					err = lookupStmt.QueryRow([]byte(fmt.Sprintf("%d", boxName))).Scan(&pv.Round, &v)
+					err = lookupStmt.QueryRow(fmt.Appendf(nil, "%d", boxName)).Scan(&pv.Round, &v)
 					b.StopTimer()
 					require.NoError(b, err)
 					require.True(b, v.Valid)
@@ -2150,7 +2150,7 @@ func BenchmarkBoxDatabaseRead(b *testing.B) {
 				for i := 0; i < b.N+lookback; i++ {
 					var pv trackerdb.PersistedKVData
 					boxName := boxNames[i%totalBoxes]
-					err = lookupStmt.QueryRow([]byte(fmt.Sprintf("%d", boxName))).Scan(&pv.Round, &v)
+					err = lookupStmt.QueryRow(fmt.Appendf(nil, "%d", boxName)).Scan(&pv.Round, &v)
 					require.NoError(b, err)
 					require.True(b, v.Valid)
 
@@ -2158,7 +2158,7 @@ func BenchmarkBoxDatabaseRead(b *testing.B) {
 					if i >= lookback {
 						boxName = boxNames[(i-lookback)%totalBoxes]
 						b.StartTimer()
-						err = lookupStmt.QueryRow([]byte(fmt.Sprintf("%d", boxName))).Scan(&pv.Round, &v)
+						err = lookupStmt.QueryRow(fmt.Appendf(nil, "%d", boxName)).Scan(&pv.Round, &v)
 						b.StopTimer()
 						require.NoError(b, err)
 						require.True(b, v.Valid)

--- a/ledger/acctupdates_test.go
+++ b/ledger/acctupdates_test.go
@@ -1082,7 +1082,7 @@ func TestKVCache(t *testing.T) {
 
 	kvMap := make(map[string][]byte)
 	for i := 0; i < kvCnt; i++ {
-		kvMap[fmt.Sprintf("%d", i)] = []byte(fmt.Sprintf("value%d", i))
+		kvMap[fmt.Sprintf("%d", i)] = fmt.Appendf(nil, "value%d", i)
 	}
 
 	// add kvsPerBlock KVs on each iteration. The first kvCnt/kvsPerBlock
@@ -2620,7 +2620,7 @@ func TestAcctUpdatesLookupStateDelta(t *testing.T) {
 	var currentRound basics.Round
 	kvMap := make(map[string][]byte)
 	for i := 0; i < kvCnt; i++ {
-		kvMap[fmt.Sprintf("%d", i)] = []byte(fmt.Sprintf("value%d", i))
+		kvMap[fmt.Sprintf("%d", i)] = fmt.Appendf(nil, "value%d", i)
 	}
 
 	// Iterate through rounds 1..9, creating KvDeltas and modifying some accounts/assets

--- a/ledger/ledger_perf_test.go
+++ b/ledger/ledger_perf_test.go
@@ -249,7 +249,7 @@ func benchmarkFullBlocks(params testParams, b *testing.B) {
 			// add 1.
 			for k := uint64(0); k < numApps; k++ {
 				tx.Sender = creator
-				tx.Note = []byte(fmt.Sprintf("%d,%d,%d", i, j, k))
+				tx.Note = fmt.Appendf(nil, "%d,%d,%d", i, j, k)
 				tx.GenesisHash = crypto.Digest{1}
 
 				// add tx to block
@@ -279,7 +279,7 @@ func benchmarkFullBlocks(params testParams, b *testing.B) {
 					tx = makeUnsignedASATx(createdAppIdx, basics.Address{}, i)
 					tx.OnCompletion = transactions.OptInOC
 					tx.Sender = acct
-					tx.Note = []byte(fmt.Sprintf("%d,%d,%d", i, j, k))
+					tx.Note = fmt.Appendf(nil, "%d,%d,%d", i, j, k)
 					tx.GenesisHash = crypto.Digest{1}
 					k++
 

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -135,7 +135,7 @@ func TestP2PSubmitTX(t *testing.T) {
 
 	// send messages from B and confirm that they get received by C (via A)
 	for i := 0; i < 10; i++ {
-		err = netB.Broadcast(context.Background(), protocol.TxnTag, []byte(fmt.Sprintf("hello %d", i)), false, nil)
+		err = netB.Broadcast(context.Background(), protocol.TxnTag, fmt.Appendf(nil, "hello %d", i), false, nil)
 		require.NoError(t, err)
 	}
 
@@ -224,7 +224,7 @@ func TestP2PSubmitTXNoGossip(t *testing.T) {
 	netB.RegisterValidatorHandlers(passThroughHandler)
 	netC.RegisterValidatorHandlers(passThroughHandler)
 	for i := 0; i < 10; i++ {
-		err = netA.Broadcast(context.Background(), protocol.TxnTag, []byte(fmt.Sprintf("test %d", i)), false, nil)
+		err = netA.Broadcast(context.Background(), protocol.TxnTag, fmt.Appendf(nil, "test %d", i), false, nil)
 		require.NoError(t, err)
 	}
 
@@ -309,7 +309,7 @@ func TestP2PSubmitWS(t *testing.T) {
 
 	// send messages from B and confirm that they get received by C (via A)
 	for i := 0; i < 10; i++ {
-		err = netB.Broadcast(context.Background(), testTag, []byte(fmt.Sprintf("hello %d", i)), false, nil)
+		err = netB.Broadcast(context.Background(), testTag, fmt.Appendf(nil, "hello %d", i), false, nil)
 		require.NoError(t, err)
 	}
 
@@ -1333,9 +1333,9 @@ func TestP2PEnableGossipService_NodeDisable(t *testing.T) {
 
 			// send messages from both nodes to each other and confirm they are received.
 			for i := 0; i < 10; i++ {
-				err = netA.Broadcast(context.Background(), testTag, []byte(fmt.Sprintf("hello from A %d", i)), false, nil)
+				err = netA.Broadcast(context.Background(), testTag, fmt.Appendf(nil, "hello from A %d", i), false, nil)
 				require.NoError(t, err)
-				err = netB.Broadcast(context.Background(), testTag, []byte(fmt.Sprintf("hello from B %d", i)), false, nil)
+				err = netB.Broadcast(context.Background(), testTag, fmt.Appendf(nil, "hello from B %d", i), false, nil)
 				require.NoError(t, err)
 			}
 

--- a/network/requestTracker.go
+++ b/network/requestTracker.go
@@ -323,8 +323,8 @@ func (rt *RequestTracker) sendBlockedConnectionResponse(conn net.Conn, requestTi
 	// http handler can handle, or getting requests that fails before the header retrieval is complete.
 	// in this case, we want to send our response right away and disconnect. If the client is currently still sending it's request, it might not know how to handle
 	// this correctly. This use case is similar to the issue handled by the go-server in the same manner. ( see "431 Request Header Fields Too Large" in the server.go )
-	_, err = conn.Write([]byte(
-		fmt.Sprintf("HTTP/1.1 %d %s\r\nContent-Type: text/plain; charset=utf-8\r\nConnection: close\r\n%s: %d\r\n\r\n", http.StatusTooManyRequests, http.StatusText(http.StatusTooManyRequests), TooManyRequestsRetryAfterHeader, rt.config.ConnectionsRateLimitingWindowSeconds)))
+	_, err = conn.Write(
+		fmt.Appendf(nil, "HTTP/1.1 %d %s\r\nContent-Type: text/plain; charset=utf-8\r\nConnection: close\r\n%s: %d\r\n\r\n", http.StatusTooManyRequests, http.StatusText(http.StatusTooManyRequests), TooManyRequestsRetryAfterHeader, rt.config.ConnectionsRateLimitingWindowSeconds))
 	if err != nil {
 		rt.log.With("connection", "tcp").Debugf("Failed to write response to a blocked connection response: %v", err)
 		return

--- a/protocol/codec_tester.go
+++ b/protocol/codec_tester.go
@@ -424,7 +424,7 @@ func EncodingTest(template msgpMarshalUnmarshal) error {
 	}
 
 	if debugCodecTester {
-		err = os.WriteFile("/tmp/v0", []byte(fmt.Sprintf("%#v", v0)), 0666)
+		err = os.WriteFile("/tmp/v0", fmt.Appendf(nil, "%#v", v0), 0666)
 		if err != nil {
 			return err
 		}
@@ -464,11 +464,11 @@ func EncodingTest(template msgpMarshalUnmarshal) error {
 	}
 
 	if debugCodecTester {
-		err = os.WriteFile("/tmp/v1", []byte(fmt.Sprintf("%#v", v1)), 0666)
+		err = os.WriteFile("/tmp/v1", fmt.Appendf(nil, "%#v", v1), 0666)
 		if err != nil {
 			return err
 		}
-		err = os.WriteFile("/tmp/v2", []byte(fmt.Sprintf("%#v", v2)), 0666)
+		err = os.WriteFile("/tmp/v2", fmt.Appendf(nil, "%#v", v2), 0666)
 		if err != nil {
 			return err
 		}

--- a/rpcs/ledgerService.go
+++ b/rpcs/ledgerService.go
@@ -126,7 +126,7 @@ func (ls *LedgerService) ServeHTTP(response http.ResponseWriter, request *http.R
 		if versionStr != "1" {
 			logging.Base().Debugf("LedgerService.ServeHTTP: bad version '%s'", versionStr)
 			response.WriteHeader(http.StatusBadRequest)
-			response.Write([]byte(fmt.Sprintf("unsupported version '%s'", versionStr)))
+			response.Write(fmt.Appendf(nil, "unsupported version '%s'", versionStr))
 			return
 		}
 	}
@@ -134,7 +134,7 @@ func (ls *LedgerService) ServeHTTP(response http.ResponseWriter, request *http.R
 		if ls.genesisID != genesisID {
 			logging.Base().Debugf("LedgerService.ServeHTTP: bad genesisID mine=%#v theirs=%#v", ls.genesisID, genesisID)
 			response.WriteHeader(http.StatusBadRequest)
-			response.Write([]byte(fmt.Sprintf("mismatching genesisID '%s'", genesisID)))
+			response.Write(fmt.Appendf(nil, "mismatching genesisID '%s'", genesisID))
 			return
 		}
 	} else {
@@ -150,7 +150,7 @@ func (ls *LedgerService) ServeHTTP(response http.ResponseWriter, request *http.R
 		if err != nil {
 			logging.Base().Debugf("LedgerService.ServeHTTP: parse form err : %v", err)
 			response.WriteHeader(http.StatusBadRequest)
-			response.Write([]byte(fmt.Sprintf("unable to parse form body : %v", err)))
+			response.Write(fmt.Appendf(nil, "unable to parse form body : %v", err))
 			return
 		}
 		roundStrs, ok := request.Form["r"]
@@ -167,13 +167,13 @@ func (ls *LedgerService) ServeHTTP(response http.ResponseWriter, request *http.R
 				if versionStrs[0] != "1" {
 					logging.Base().Debugf("LedgerService.ServeHTTP: bad version '%s'", versionStr)
 					response.WriteHeader(http.StatusBadRequest)
-					response.Write([]byte(fmt.Sprintf("unsupported version specified '%s'", versionStrs[0])))
+					response.Write(fmt.Appendf(nil, "unsupported version specified '%s'", versionStrs[0]))
 					return
 				}
 			} else {
 				logging.Base().Debugf("LedgerService.ServeHTTP: wrong number of v=%d args", len(versionStrs))
 				response.WriteHeader(http.StatusBadRequest)
-				response.Write([]byte(fmt.Sprintf("invalid number of version specified %d", len(versionStrs))))
+				response.Write(fmt.Appendf(nil, "invalid number of version specified %d", len(versionStrs)))
 				return
 			}
 		}
@@ -182,7 +182,7 @@ func (ls *LedgerService) ServeHTTP(response http.ResponseWriter, request *http.R
 	if err != nil {
 		logging.Base().Debugf("LedgerService.ServeHTTP: round parse fail ('%s'): %v", roundStr, err)
 		response.WriteHeader(http.StatusBadRequest)
-		response.Write([]byte(fmt.Sprintf("specified round number could not be parsed using base 36 : %v", err)))
+		response.Write(fmt.Appendf(nil, "specified round number could not be parsed using base 36 : %v", err))
 		return
 	}
 	logging.Base().Infof("LedgerService.ServeHTTP: serving catchpoint round %d", round)
@@ -193,13 +193,13 @@ func (ls *LedgerService) ServeHTTP(response http.ResponseWriter, request *http.R
 		case ledgercore.ErrNoEntry:
 			// entry cound not be found.
 			response.WriteHeader(http.StatusNotFound)
-			response.Write([]byte(fmt.Sprintf("catchpoint file for round %d is not available", round)))
+			response.Write(fmt.Appendf(nil, "catchpoint file for round %d is not available", round))
 			return
 		default:
 			// unexpected error.
 			logging.Base().Warnf("LedgerService.ServeHTTP : failed to retrieve catchpoint %d %v", round, err)
 			response.WriteHeader(http.StatusInternalServerError)
-			response.Write([]byte(fmt.Sprintf("catchpoint file for round %d could not be retrieved due to internal error : %v", round, err)))
+			response.Write(fmt.Appendf(nil, "catchpoint file for round %d could not be retrieved due to internal error : %v", round, err))
 			return
 		}
 	}
@@ -237,7 +237,7 @@ func (ls *LedgerService) ServeHTTP(response http.ResponseWriter, request *http.R
 	if err != nil {
 		logging.Base().Warnf("LedgerService.ServeHTTP : failed to decompress catchpoint %d %v", round, err)
 		response.WriteHeader(http.StatusInternalServerError)
-		response.Write([]byte(fmt.Sprintf("catchpoint file for round %d could not be decompressed due to internal error : %v", round, err)))
+		response.Write(fmt.Appendf(nil, "catchpoint file for round %d could not be decompressed due to internal error : %v", round, err))
 		return
 	}
 	defer decompressedGzip.Close()

--- a/test/commandandcontrol/cc_agent/component/agent.go
+++ b/test/commandandcontrol/cc_agent/component/agent.go
@@ -138,7 +138,7 @@ func (status CommandStatus) String() string {
 // ProcessRequest processes the command received via the CC Service
 func (agent *Agent) ProcessRequest(managementServiceRequest lib.CCServiceRequest) (err error) {
 	log.Infof("received command for %s\n", managementServiceRequest.Component)
-	err = agent.ServiceConnection.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("received request %+v ", managementServiceRequest)))
+	err = agent.ServiceConnection.WriteMessage(websocket.TextMessage, fmt.Appendf(nil, "received request %+v ", managementServiceRequest))
 	if err != nil {
 		log.Errorf("problem sending ack to client , %v", err)
 	}
@@ -225,7 +225,7 @@ func (agent *Agent) processPingPongComponentRequest(managementServiceRequest lib
 		err := componentInstance.Process(componentCommand)
 		if err != nil {
 			log.Errorf("error processing ping pong component request %v", err)
-			err = agent.ServiceConnection.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("error processing request %+v with err: %v", managementServiceRequest, err)))
+			err = agent.ServiceConnection.WriteMessage(websocket.TextMessage, fmt.Appendf(nil, "error processing request %+v with err: %v", managementServiceRequest, err))
 			if err != nil {
 				log.Errorf("error sending message to service %v", err)
 			}

--- a/test/commandandcontrol/cc_agent/main.go
+++ b/test/commandandcontrol/cc_agent/main.go
@@ -153,7 +153,7 @@ func main() {
 				log.Errorf("error processRequest: %v\n", err)
 				return
 			}
-			serverChannel <- []byte(fmt.Sprintf("agent %s is processing request %+v", component.GetHostAgent().Host.Name, managementServiceRequest))
+			serverChannel <- fmt.Appendf(nil, "agent %s is processing request %+v", component.GetHostAgent().Host.Name, managementServiceRequest)
 		}
 	}()
 
@@ -166,7 +166,7 @@ func main() {
 		case <-done:
 			return
 		case t := <-ticker.C:
-			err := serverWs.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("heartbeat from agent %s with time %s", component.GetHostAgent().Host.Name, t.String())))
+			err := serverWs.WriteMessage(websocket.TextMessage, fmt.Appendf(nil, "heartbeat from agent %s with time %s", component.GetHostAgent().Host.Name, t.String()))
 			if err != nil {
 				log.Error("write:", err)
 				return

--- a/test/e2e-go/cli/goal/expect/catchpointCatchupWebProxy/webproxy.go
+++ b/test/e2e-go/cli/goal/expect/catchpointCatchupWebProxy/webproxy.go
@@ -63,7 +63,7 @@ func main() {
 		}
 		if *webProxyLogFile != "" {
 			f, _ := os.OpenFile(*webProxyLogFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-			f.Write([]byte(fmt.Sprintf("proxy saw request for %s\n", request.URL.String())))
+			f.Write(fmt.Appendf(nil, "proxy saw request for %s\n", request.URL.String()))
 			f.Close()
 		}
 

--- a/test/e2e-go/features/catchup/catchpointCatchup_test.go
+++ b/test/e2e-go/features/catchup/catchpointCatchup_test.go
@@ -90,7 +90,7 @@ func denyRoundRequestsWebProxy(a *require.Assertions, listeningAddress string, r
 		// prevent requests for the given block to go through.
 		if request.URL.String() == fmt.Sprintf("/v1/test-v1/block/%d", round) {
 			response.WriteHeader(http.StatusBadRequest)
-			response.Write([]byte(fmt.Sprintf("webProxy prevents block %d from serving", round)))
+			response.Write(fmt.Appendf(nil, "webProxy prevents block %d from serving", round))
 			return
 		}
 		next(response, request)


### PR DESCRIPTION
## Summary

This runs the official golang tool [modernize](https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize) with the `fmtappendf` fix.

## Test Plan

Existing tests should pass