### PR TITLE
tests: log TestSimulate to debug the shutdown deadlock

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -119,6 +119,14 @@ jobs:
           job-type: "Test"
           build-type: "Nightly Build"
           details: "• Partition: `${{ matrix.partition_id }}` of ${{ env.PARTITION_TOTAL }}\n• Failed Step: `${{ steps.run_tests.name }}`"
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs-${{ matrix.platform }}-${{ github.run_id }}-${{ matrix.partition_id }}
+          path: |
+            **/*.log
+          retention-days: 30
       - name: Upload test artifacts to GitHub
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -64,6 +64,14 @@ jobs:
           job-type: "Test"
           build-type: "PR Build"
           details: "• Partition: `${{ matrix.partition_id }}` of ${{ env.PARTITION_TOTAL }}\n• Failed Step: `${{ steps.run_tests.name }}`"
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs-${{ matrix.platform }}-${{ github.run_id }}-${{ matrix.partition_id }}
+          path: |
+            **/*.log
+          retention-days: 30
       - name: Upload test artifacts to GitHub
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

The agreementtest package's `TestSimulate` very rarely deadlocks, with a recent example [here](https://github.com/algorand/go-algorand/actions/runs/17536514906). The stack trace in that failure shows the test goroutine blocked in `instant.shutdown()` waiting on channel `<-i.Z1`. `instant` is a test-only clock implementation used by the simulation.

This fetches the test logs on failure to help us better understand this failure.