### PR TITLE
CI: add make modernize target & add to codegen verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,9 @@ fmt:
 fix: build
 	$(GOBIN)/algofix */
 
+modernize:
+	go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -category minmax,slicescontains,sortslice,stringscutprefix,mapsloop -fix -test ./...
+
 lint: deps
 	$(GOBIN)/golangci-lint run -c .golangci.yml
 
@@ -129,7 +132,7 @@ tidy: check_go_version
 check_shell:
 	find . -type f -name "*.sh" -exec shellcheck {} +
 
-sanity: fix lint fmt tidy
+sanity: fix lint fmt tidy modernize
 
 cover:
 	go test $(GOTAGS) -coverprofile=cover.out $(UNIT_TEST_SOURCES)
@@ -412,7 +415,7 @@ dump: $(addprefix gen/,$(addsuffix /genesis.dump, $(NETWORKS)))
 install: build
 	scripts/dev_install.sh -p $(GOBIN)
 
-.PHONY: default fmt lint check_shell sanity cover prof deps build build-race build-e2e test fulltest shorttest clean cleango deploy node_exporter install %gen gen NONGO_BIN check-go-version rebuild_kmd_swagger universal libsodium
+.PHONY: default fmt lint check_shell sanity cover prof deps build build-race build-e2e test fulltest shorttest clean cleango deploy node_exporter install %gen gen NONGO_BIN check-go-version rebuild_kmd_swagger universal libsodium modernize
 
 ###### TARGETS FOR CICD PROCESS ######
 include ./scripts/release/mule/Makefile.mule

--- a/scripts/travis/codegen_verification.sh
+++ b/scripts/travis/codegen_verification.sh
@@ -36,6 +36,9 @@ make generate
 echo "Running fixcheck"
 "$GOPATH"/bin/algofix -error */
 
+echo "Running modernize checks"
+make modernize
+
 echo "Running expect linter"
 make expectlint
 


### PR DESCRIPTION
## Summary

This adds to CI the enforcement of the code suggestions from gopls's [`modernize`](https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize) tool for the categories from these merged PRs:
- #6431
- #6433
- #6434 

## Test Plan

New codegen_verification step should pass