### PR TITLE
goal: Update 'goal app call' help text and change flag type

### DIFF
--- a/cmd/goal/application.go
+++ b/cmd/goal/application.go
@@ -111,8 +111,8 @@ func init() {
 	appCmd.PersistentFlags().StringSliceVar(&foreignAssets, "foreign-asset", nil, "Indexes of assets whose parameters are read in this transaction")
 	appCmd.PersistentFlags().StringArrayVar(&appStrBoxes, "box", nil, "A Box that may be accessed by this transaction. Use the same form as app-arg to name the box, preceded by an optional app-id and comma. Zero or omitted app-id indicates the box is accessible by the app being called.")
 	appCmd.PersistentFlags().StringSliceVar(&appStrAccounts, "app-account", nil, "Accounts that may be accessed from application logic")
-	appCmd.PersistentFlags().StringSliceVar(&appStrHoldings, "holding", nil, "A Holding that may be accessed from application logic. An asset-id followed by a comma and an address")
-	appCmd.PersistentFlags().StringSliceVar(&appStrLocals, "local", nil, "A Local State that may be accessed from application logic. An optional app-id and comma, followed by an address. Zero or omitted app-id indicates the local state for app being called.")
+	appCmd.PersistentFlags().StringArrayVar(&appStrHoldings, "holding", nil, "A Holding that may be accessed from application logic. An asset-id followed by a plus sign and an address")
+	appCmd.PersistentFlags().StringArrayVar(&appStrLocals, "local", nil, "A Local State that may be accessed from application logic. An optional app-id and a plus sign, followed by an address. Zero or omitted app-id indicates the local state for app being called.")
 	appCmd.PersistentFlags().BoolVar(&appUseAccess, "access", false, "Put references into the transaction's access list, instead of foreign arrays.")
 	appCmd.PersistentFlags().StringVarP(&appInputFilename, "app-input", "i", "", "JSON file containing encoded arguments and inputs (mutually exclusive with app-arg, app-account, foreign-app, foreign-asset, local, holding, and box)")
 


### PR DESCRIPTION
The help text was saying to use a comma to separate `--local` and `--holding` asset/app and address values. Which isn't entirely unexpected since `--box` already does that. However because they were being parsed as `StringSliceVar`, a comma would end up making two separate local refs that resulted in an invalid transaction.

Before change, and incorrectly using a comma:
```sh
% goal app call --app-id 1001 --from ALICE7Y2JOFGG2VGUC64VINB75PI56O6M2XW233KG2I3AIYJFUD4QMYTJM --local 1002,ALICE7Y2JOFGG2VGUC64VINB75PI56O6M2XW233KG2I3AIYJFUD4QMYTJM --access -o - | goal clerk inspect -
-[0]
{
  "txn": {
    "al": [
      {
        "p": 1002
      },
      {
        "l": {
          "p": 1
        }
      },
      {
        "d": "ALICE7Y2JOFGG2VGUC64VINB75PI56O6M2XW233KG2I3AIYJFUD4QMYTJM"
      },
      {
        "l": {
          "d": 3
        }
      }
    ],
    "apid": 1001,
    "fee": 1000,
    "fv": 3889,
    "gh": "rqKunm1Z2wiIQvKqBvNR9F3rxD4cHI869HLel9CPhxk=",
    "lv": 4889,
    "note": "dde3l0RJxWE=",
    "snd": "ALICE7Y2JOFGG2VGUC64VINB75PI56O6M2XW233KG2I3AIYJFUD4QMYTJM",
    "type": "appl"
  }
}

# or without inspecting the output...

Couldn't broadcast tx with algod: ... cut ... invalid : locals App reference 0 outside tx.Access
```

With changes, and incorrectly using comma:
```sh
% goal app call --app-id 1001 --from ALICE7Y2JOFGG2VGUC64VINB75PI56O6M2XW233KG2I3AIYJFUD4QMYTJM --local 1002,ALICE7Y2JOFGG2VGUC64VINB75PI56O6M2XW233KG2I3AIYJFUD4QMYTJM --access
failed to decode address 1002,ALICE7Y2JOFGG2VGUC64VINB75PI56O6M2XW233KG2I3AIYJFUD4QMYTJM from base 32
```