### PR TITLE
eval: call WellFormed from eval.transaction

### DIFF
--- a/ledger/acctonline_expired_test.go
+++ b/ledger/acctonline_expired_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/crypto/merklesignature"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/txntest"
@@ -320,6 +321,7 @@ func (m *doubleLedgerAcctModel) goOnline(addr basics.Address, firstvalid, lastva
 		// meaningless non-zero voting data
 		VotePK:          crypto.OneTimeSignatureVerifier(addr),
 		SelectionPK:     crypto.VRFVerifier(addr),
+		StateProofPK:    merklesignature.Commitment{1},
 		VoteKeyDilution: 1024,
 	})
 	m.accts[addr] = m.ops.Sub(m.accts[addr], basics.MicroAlgos{Raw: minFee})

--- a/ledger/apptxn_test.go
+++ b/ledger/apptxn_test.go
@@ -1823,8 +1823,9 @@ func TestSelfCheckHoldingNewApp(t *testing.T) {
 			ForeignAssets: []basics.AssetIndex{assetID},
 		}
 		selfcheck.ApplicationID = dl.txn(&selfcheck).ApplicationID
-		selfcheck.ApprovalProgram = []byte{}
-		selfcheck.ClearStateProgram = []byte{}
+		// remove programs to just call the app
+		selfcheck.ApprovalProgram = nil
+		selfcheck.ClearStateProgram = nil
 
 		dl.txn(&selfcheck)
 

--- a/ledger/apptxn_test.go
+++ b/ledger/apptxn_test.go
@@ -1875,8 +1875,9 @@ func TestCheckHoldingNewApp(t *testing.T) {
 			ForeignAssets: []basics.AssetIndex{assetID},
 		}
 		check.ApplicationID = dl.txn(&check).ApplyData.ApplicationID
-		check.ApprovalProgram = []byte{}
-		check.ClearStateProgram = []byte{}
+		// remove the programs to just call the app
+		check.ApprovalProgram = nil
+		check.ClearStateProgram = nil
 
 		create := txntest.Txn{
 			Type:          "appl",

--- a/ledger/double_test.go
+++ b/ledger/double_test.go
@@ -72,6 +72,10 @@ func (dl *DoubleLedger) beginBlock() *eval.BlockEvaluator {
 	return dl.eval
 }
 
+// txn will add a transaction to the current block. If no block is
+// currently being built, it will start one, and end it after the
+// transaction is added. If a problem is specified, it will be
+// expected to fail, and the block will not be ended.
 func (dl *DoubleLedger) txn(tx *txntest.Txn, problem ...string) (stib *transactions.SignedTxnInBlock) {
 	dl.t.Helper()
 	if dl.eval == nil {

--- a/ledger/eval/eval.go
+++ b/ledger/eval/eval.go
@@ -1184,6 +1184,12 @@ func (eval *BlockEvaluator) transaction(txn transactions.SignedTxn, evalParams *
 			return err
 		}
 
+		err = txn.Txn.WellFormed(eval.specials, eval.proto)
+		if err != nil {
+			txnErr := ledgercore.TxnNotWellFormedError(fmt.Sprintf("transaction %v: malformed: %v", txn.ID(), err))
+			return &txnErr
+		}
+
 		// Transaction already in the ledger?
 		err = cow.checkDup(txn.Txn.FirstValid, txn.Txn.LastValid, txid, ledgercore.Txlease{Sender: txn.Txn.Sender, Lease: txn.Txn.Lease})
 		if err != nil {

--- a/ledger/eval/eval_test.go
+++ b/ledger/eval/eval_test.go
@@ -1410,6 +1410,7 @@ func TestAbsenteeChecks(t *testing.T) {
 			Header: transactions.Header{
 				Sender:      addrs[i],
 				Fee:         minFee,
+				FirstValid:  blkEval.Round().SubSaturate(1000),
 				LastValid:   blkEval.Round(),
 				GenesisHash: l.GenesisHash(),
 			},

--- a/ledger/simple_test.go
+++ b/ledger/simple_test.go
@@ -117,7 +117,9 @@ func fillDefaults(t testing.TB, ledger *Ledger, eval *eval.BlockEvaluator, txn *
 	if txn.FirstValid == 0 {
 		txn.FirstValid = eval.Round()
 	}
-	if txn.Type == protocol.KeyRegistrationTx && txn.VoteFirst == 0 {
+	if txn.Type == protocol.KeyRegistrationTx && txn.VoteFirst == 0 &&
+		// check this is not an offline txn
+		(!txn.VotePK.IsEmpty() || !txn.SelectionPK.IsEmpty()) {
 		txn.VoteFirst = eval.Round()
 	}
 

--- a/ledger/testing/testGenesis.go
+++ b/ledger/testing/testGenesis.go
@@ -28,6 +28,7 @@ import (
 // GenesisCfg provides a configuration object for NewTestGenesis.
 type GenesisCfg struct {
 	rewardsPoolAmount basics.MicroAlgos
+	feeSinkAmount     basics.MicroAlgos
 	OnlineCount       int
 }
 
@@ -37,6 +38,14 @@ type TestGenesisOption func(*GenesisCfg)
 // TurnOffRewards turns off the rewards pool for tests that are sensitive to
 // "surprise" balance changes.
 var TurnOffRewards = func(cfg *GenesisCfg) { cfg.rewardsPoolAmount = basics.MicroAlgos{Raw: 100_000} }
+
+// InitialFeeSinkBalance sets the initial balance of the fee sink to a specific value.
+// This is useful for tests that need precise control over the fee sink balance.
+func InitialFeeSinkBalance(microAlgos uint64) TestGenesisOption {
+	return func(cfg *GenesisCfg) {
+		cfg.feeSinkAmount = basics.MicroAlgos{Raw: microAlgos}
+	}
+}
 
 // NewTestGenesis creates a bunch of accounts, splits up 10B algos
 // between them and the rewardspool and feesink, and gives out the
@@ -88,8 +97,12 @@ func NewTestGenesis(opts ...TestGenesisOption) (bookkeeping.GenesisBalances, []b
 		accts[addrs[i]] = adata
 	}
 
+	feeSinkBal := basics.MicroAlgos{Raw: amount}
+	if cfg.feeSinkAmount.Raw > 0 {
+		feeSinkBal = cfg.feeSinkAmount
+	}
 	accts[sink] = basics.AccountData{
-		MicroAlgos: basics.MicroAlgos{Raw: amount},
+		MicroAlgos: feeSinkBal,
 		Status:     basics.NotParticipating,
 	}
 


### PR DESCRIPTION
## Summary

This adds an extra call to WellFormed to transaction evaluation (already run as part of txn validation & signature checking).

## Test Plan

Fixed broken tests that were making transactions that failed the WellFormed check.