### PR TITLE
CI: use GOTOOLCHAIN=auto when running modernize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ fix: build
 	$(GOBIN)/algofix */
 
 modernize:
-	go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -category minmax,slicescontains,sortslice,stringscutprefix,mapsloop -fix -test ./...
+	GOTOOLCHAIN=auto go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -category minmax,slicescontains,sortslice,stringscutprefix,mapsloop -fix -test ./...
 
 lint: deps
 	$(GOBIN)/golangci-lint run -c .golangci.yml


### PR DESCRIPTION
Quick fix for environments where GOTOOLCHAIN might be set for other reasons.