### PR TITLE
Test: Use NearZeros to make simple Equal() tests

### DIFF
--- a/data/transactions/teal.go
+++ b/data/transactions/teal.go
@@ -58,17 +58,18 @@ func (ed EvalDelta) Equal(o EvalDelta) bool {
 		return false
 	}
 
-	// GlobalDeltas must be equal
 	if !ed.GlobalDelta.Equal(o.GlobalDelta) {
 		return false
 	}
 
-	// Logs must be equal
+	if !slices.Equal(ed.SharedAccts, o.SharedAccts) {
+		return false
+	}
+
 	if !slices.Equal(ed.Logs, o.Logs) {
 		return false
 	}
 
-	// InnerTxns must be equal
 	if len(ed.InnerTxns) != len(o.InnerTxns) {
 		return false
 	}

--- a/data/transactions/transaction_test.go
+++ b/data/transactions/transaction_test.go
@@ -19,11 +19,13 @@ package transactions
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
+	basics_testing "github.com/algorand/go-algorand/data/basics/testing"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
@@ -76,6 +78,7 @@ func TestTransactionHash(t *testing.T) {
 
 func TestTransactionIDChanges(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	txn := Transaction{
 		Type: "pay",
@@ -114,4 +117,28 @@ func TestTransactionIDChanges(t *testing.T) {
 	if txn2.ID() == txn.ID() {
 		t.Errorf("txid does not depend on lastvalid")
 	}
+}
+
+func TestApplyDataEquality(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	var empty ApplyData
+	for _, nz := range basics_testing.NearZeros(t, ApplyData{}) {
+		ad := nz.(ApplyData)
+		assert.False(t, ad.Equal(empty), "Equal() seems to be disregarding something %+v", ad)
+	}
+
+}
+
+func TestEvalDataEquality(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	var empty EvalDelta
+	for _, nz := range basics_testing.NearZeros(t, EvalDelta{}) {
+		ed := nz.(EvalDelta)
+		assert.False(t, ed.Equal(empty), "Equal() seems to be disregarding something %+v", ed)
+	}
+
 }


### PR DESCRIPTION
NeasrZeros had to be improved to avoid looping on recursive types. But it's now easy to write easy Equal() tests that will fail if you add a field to a type and forget to modify Equal().  Caught a bug in EvalDelta.Equal().

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
