### PR TITLE
Fix panic when checking macro names containing non-ASCII runes

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -2207,7 +2207,7 @@ func checkMacroName(macroName string, version uint64, labels map[string]int) err
 		} else if count == 1 {
 			secondRune = r
 		}
-		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && !otherAllowedChars[r] {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && (int(r) >= len(otherAllowedChars) || !otherAllowedChars[r]) {
 			return fmt.Errorf("%s character not allowed in macro name", string(r))
 		}
 		count++

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -3559,6 +3559,7 @@ add:
 		AssemblerMaxVersion,
 		exp(3, "Cannot create label with same name as macro: coolLabel"),
 	)
+	testProg(t, `#define 👩 123`, AssemblerMaxVersion, exp(1, "👩 character not allowed in macro name"))
 	// These two tests are just for coverage, they really really can't happen
 	ops := newOpStream(AssemblerMaxVersion)
 	err := define(&ops, []token{{str: "not#define"}})


### PR DESCRIPTION
## Summary

Fixes a panic when assembling TEAL code containing macros with non-ASCII runes, e.g.:
```teal
#define 👩 123
```

## Test Plan

Added a new test case to verify that the macro name validation correctly rejects names containing disallowed characters.