### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/util/metrics/counter_test.go
+++ b/util/metrics/counter_test.go
@@ -66,7 +66,7 @@ func TestMetricCounter(t *testing.T) {
 
 	test.Lock()
 	defer test.Unlock()
-	// the the loop above we've created a single metric name with five different labels set ( host0, host1 .. host 4)
+	// the loop above we've created a single metric name with five different labels set ( host0, host1 .. host 4)
 	// let's see if we received all the 5 different labels.
 	require.Equal(t, 5, len(test.metrics), "Missing metric counts were reported: %+v", test.metrics)
 
@@ -113,7 +113,7 @@ func TestMetricCounterFastInts(t *testing.T) {
 
 	test.Lock()
 	defer test.Unlock()
-	// the the loop above we've created a single metric name with five different labels set ( host0, host1 .. host 4)
+	// the loop above we've created a single metric name with five different labels set ( host0, host1 .. host 4)
 	// let's see if we received all the 5 different labels.
 	require.Equal(t, 1, len(test.metrics), "Missing metric counts were reported: %+v", test.metrics)
 
@@ -162,7 +162,7 @@ func TestMetricCounterMixed(t *testing.T) {
 
 	test.Lock()
 	defer test.Unlock()
-	// the the loop above we've created a single metric name with five different labels set ( host0, host1 .. host 4)
+	// the loop above we've created a single metric name with five different labels set ( host0, host1 .. host 4)
 	// let's see if we received all the 5 different labels.
 	require.Equal(t, 1, len(test.metrics), "Missing metric counts were reported: %+v", test.metrics)
 

--- a/util/metrics/gauge_test.go
+++ b/util/metrics/gauge_test.go
@@ -68,7 +68,7 @@ func TestMetricGauge(t *testing.T) {
 
 	test.Lock()
 	defer test.Unlock()
-	// the the loop above we've created 3 separate gauges
+	// the loop above we've created 3 separate gauges
 	// let's see if we received all 3 metrics
 	require.Equal(t, 3, len(test.metrics), "Missing metric counts were reported: %+v", test.metrics)
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

remove redundant word in comment

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
