### PR TITLE
refactor: use reflect.TypeFor

### DIFF
--- a/cmd/algofix/fix.go
+++ b/cmd/algofix/fix.go
@@ -750,7 +750,7 @@ func expr(s string) ast.Expr {
 	return x
 }
 
-var posType = reflect.TypeOf(token.Pos(0))
+var posType = reflect.TypeFor[token.Pos]()
 
 func killPos(v reflect.Value) {
 	switch v.Kind() {

--- a/logging/telemetryspec/metric_test.go
+++ b/logging/telemetryspec/metric_test.go
@@ -68,7 +68,7 @@ func TestAssembleBlockStatsString(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	var abs AssembleBlockStats
-	localType := reflect.TypeOf(abs)
+	localType := reflect.TypeFor[AssembleBlockStats]()
 
 	// Empty StateProofStats will not be reported. Set a filed to check it printed
 	abs.StateProofStats.ProvenWeight = 1

--- a/protocol/codec_tester.go
+++ b/protocol/codec_tester.go
@@ -42,7 +42,7 @@ type msgpMarshalUnmarshal interface {
 	msgp.Unmarshaler
 }
 
-var rawMsgpType = reflect.TypeOf(msgp.Raw{})
+var rawMsgpType = reflect.TypeFor[msgp.Raw]()
 var errSkipRawMsgpTesting = fmt.Errorf("skipping msgp.Raw serializing, since it won't be the same across go-codec and msgp")
 
 func oneOf(n int) bool {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

Try to use better api reflect.TypeFor instead of reflect.TypeOf when we have known the type.
More info https://github.com/golang/go/issues/60088

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
