### PR TITLE
test: fix logging after TestP2PHTTPHandler finishes

### DIFF
--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -398,8 +398,8 @@ func TestP2PNetworkAddress(t *testing.T) {
 	cfg := config.GetDefaultLocal()
 	log := logging.TestingLog(t)
 	netA, err := NewP2PNetwork(log, cfg, "", nil, GenesisInfo{genesisID, config.Devtestnet}, &nopeNodeInfo{}, nil, nil)
-	defer netA.Stop()
 	require.NoError(t, err)
+	defer netA.Stop()
 	addrInfo := netA.service.AddrInfo()
 	// close the real service since we will substitute a mock one
 	netA.service.Close()
@@ -801,7 +801,7 @@ func TestP2PHTTPHandler(t *testing.T) {
 	// zero clients allowed, rate limiting window (10s) is greater than queue deadline (1s)
 	netB, err := NewP2PNetwork(log, cfg, "", nil, GenesisInfo{genesisID, config.Devtestnet}, &nopeNodeInfo{}, nil, nil)
 	require.NoError(t, err)
-	defer netB.Stop() // even though netB.Start is not called, NewP2PNetwork creates goroutines that need to be stopped
+	defer netB.Stop() // even though netB.Start is not called, NewP2PNetwork creates goroutines to stop
 
 	pstore, err := peerstore.MakePhonebook(0, 10*time.Second)
 	require.NoError(t, err)
@@ -1428,6 +1428,7 @@ func TestP2PTxTopicValidator_NoWsPeer(t *testing.T) {
 
 	net, err := NewP2PNetwork(log, cfg, "", nil, GenesisInfo{genesisID, config.Devtestnet}, &nopeNodeInfo{}, nil, nil)
 	require.NoError(t, err)
+	defer net.Stop()
 
 	peerID := peer.ID("12345678") // must be 8+ in size
 	msg := pubsub.Message{Message: &pb.Message{}, ID: string(peerID)}
@@ -1457,6 +1458,7 @@ func TestGetPeersFiltersSelf(t *testing.T) {
 
 	net, err := NewP2PNetwork(log, cfg, t.TempDir(), []string{}, GenesisInfo{"test-genesis", "test-network"}, &nopeNodeInfo{}, nil, nil)
 	require.NoError(t, err)
+	defer net.Stop()
 	selfID := net.service.ID()
 
 	// Create and add self


### PR DESCRIPTION
## Summary

Occasionally `TestP2PHTTPHandler` causes the logger to be called after it finishes. The logging occurs inside a goroutine started by go-libp2p-kad-dht which is created when `NewP2PNetwork` calls `p2p.MakeCapabilitiesDiscovery` which calls `MakeDHT`. Calling `P2PNetwork.Stop()` calls `dht.Close()` and should shut down these goroutines.

```
=== FAIL: network  (0.00s)
PASS
panic: Log in goroutine after TestP2PHTTPHandler has completed: time="2025-10-20T18:00:54.980905 +0000" level=warning msg="failed when refreshing routing table2 errors occurred:\n\t* failed to query for self, err=failed to find any peer in table\n\t* failed to refresh cpl=0, err=failed to find any peer in table\n\n" file=rt_refresh_manager.go function="github.com/libp2p/go-libp2p-kad-dht/rtrefresh.(*RtRefreshManager).loop" libp2p=dht/RtRefreshManager line=187

goroutine 10525 [running]:
testing.(*common).log(0xc002740a80, {0xc00272fba0, 0x190})
	/opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1030 +0x1df
testing.(*common).Log(0xc002740a80, {0xc0030151e0, 0x1, 0x1})
	/opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1180 +0x77
github.com/algorand/go-algorand/logging.TestLogWriter.Write({{0x2e25150?, 0xc002740a80?}}, {0xc003052280, 0x190, 0x4966c9?})
	/home/runner/work/go-algorand/go-algorand/logging/testingLogger.go:40 +0x104
github.com/sirupsen/logrus.(*Entry).write(0xc0007461c0)
	/home/runner/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:286 +0x262
github.com/sirupsen/logrus.(*Entry).log(0xc000746150, 0x3, {0xc003270b40, 0xbb})
	/home/runner/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:251 +0x976
github.com/sirupsen/logrus.(*Entry).Log(0xc000746150, 0x3, {0xc002ff3ae8, 0x1, 0x1})
	/home/runner/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:293 +0x8c
github.com/algorand/go-algorand/network/p2p.(*loggingCore).Write(0xc0016bec80, {0x1, {0xc235bc15ba76b315, 0x18a1265d3, 0x3c46720}, {0x27f0bcb, 0x14}, {0xc003270a80, 0xbb}, {0x1, ...}, ...}, ...)
	/home/runner/work/go-algorand/go-algorand/network/p2p/logger.go:136 +0x6ba
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc002fd1380, {0x0, 0x0, 0x0})
	/home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/entry.go:253 +0x1ed
go.uber.org/zap.(*SugaredLogger).log(0xc0006e14a0, 0x1, {0x0, 0x0}, {0xc002ff3f28, 0x2, 0x2}, {0x0, 0x0, 0x0})
	/home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/sugar.go:355 +0x12d
go.uber.org/zap.(*SugaredLogger).Warn(...)
	/home/runner/go/pkg/mod/go.uber.org/zap@v1.27.0/sugar.go:161
github.com/libp2p/go-libp2p-kad-dht/rtrefresh.(*RtRefreshManager).loop(0xc0000ff680)
	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-kad-dht@v0.28.0/rtrefresh/rt_refresh_manager.go:187 +0x1f4
created by github.com/libp2p/go-libp2p-kad-dht/rtrefresh.(*RtRefreshManager).Start in goroutine 4610
	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-kad-dht@v0.28.0/rtrefresh/rt_refresh_manager.go:93 +0xa5
FAIL	github.com/algorand/go-algorand/network	6.671s

DONE 14328 tests, 2328 skipped, 1 failure in 253.834s
```

## Test Plan

Test should stop having this rare flakiness.