### PR TITLE
tests: add retries to TestCatchpointTrackerWaitNotBlocking

### DIFF
--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -1092,25 +1092,19 @@ func TestCatchpointTrackerWaitNotBlocking(t *testing.T) {
 	}
 
 	// switch context one more time to give the blockqueue syncer to run
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	// ensure Ledger.Wait() is non-blocked for all rounds except the last one (due to possible races)
-	attempts := 0
 	for rnd := startRound; rnd < endRound; rnd++ {
 		done := ledger.Wait(rnd)
-	checkAgain:
-		select {
-		case <-done:
-			attempts = 0
-		default:
-			if attempts >= 3 {
-				require.FailNow(t, fmt.Sprintf("Wait(%d) is blocked", rnd))
-			} else {
-				time.Sleep(1 * time.Millisecond)
-				attempts++
-				goto checkAgain
+		require.Eventually(t, func() bool {
+			select {
+			case <-done:
+				return true
+			default:
+				return false
 			}
-		}
+		}, 15*time.Millisecond, 1*time.Millisecond, "Wait(%d) is blocked", rnd)
 	}
 }
 


### PR DESCRIPTION
## Summary

TestCatchpointTrackerWaitNotBlocking started failing after migration to GH Actions. Failure example: https://github.com/algorand/go-algorand/actions/runs/18669344175/job/53227121869?pr=6469
Fixed by adding retries into assertion loop in order to give block syncer goroutine to finish flushing blocks.

## Test Plan

This is a test change