### PR TITLE
tests: fix flaky e2e multisig tests

### DIFF
--- a/test/scripts/e2e_subs/e2e-teal-multisig.sh
+++ b/test/scripts/e2e_subs/e2e-teal-multisig.sh
@@ -77,7 +77,8 @@ ${gcmd} clerk send --amount 100000 --from ${ACCOUNT_MSIG} --to ${ACCOUNT_A} -L $
 echo "Auto-detection correctly used new mode on future consensus"
 
 # Verify auto-detection used new mode (LMsig field)
-if ! cat ${TEMPDIR}/auto2.lsig | msgpacktool -d | grep -q '"lmsig"'; then
+msgpacktool -d < ${TEMPDIR}/auto2.lsig > ${TEMPDIR}/auto2.json
+if ! grep -q '"lmsig"' ${TEMPDIR}/auto2.json; then
     echo "ERROR: Auto-detection did not use new mode (LMsig field not found)"
     exit 1
 fi

--- a/test/scripts/e2e_subs/v32/e2e-teal-multisig.sh
+++ b/test/scripts/e2e_subs/v32/e2e-teal-multisig.sh
@@ -65,7 +65,8 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 echo "Auto-detection correctly used legacy mode on v32"
-if ! cat ${TEMPDIR}/auto2.lsig | msgpacktool -d | grep -q '"msig"'; then
+msgpacktool -d < ${TEMPDIR}/auto2.lsig > ${TEMPDIR}/auto2.json
+if ! grep -q '"msig"' ${TEMPDIR}/auto2.json; then
     echo "ERROR: Auto-detection did not use legacy mode (Msig field not found)"
     exit 1
 fi


### PR DESCRIPTION
## Summary

In the multisig e2e tests, `msgpacktool -d | grep -q` runs under `set -o pipefail`, so when `grep -q` exits right after matching "lmsig"/"msig", msgpacktool might still be writing and encounter EPIPE, leading to a non-zero status reported and a failed test.

## Test Plan

Tests should be hopefully less flaky.