### PR TITLE
tests: disable flaky TestSimpleUpgrade on macos CI builder

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -404,9 +404,8 @@ func TestSimpleUpgrade(t *testing.T) {
 		t.Skip("Test takes ~50 seconds.")
 	}
 
-	if (runtime.GOARCH == "arm" || runtime.GOARCH == "arm64" && runtime.GOOS != "darwin") &&
-		strings.ToUpper(os.Getenv("CIRCLECI")) == "TRUE" {
-		t.Skip("Test is too heavy for amd64 builder running in parallel with other packages")
+	if runtime.GOOS == "darwin" && strings.ToUpper(os.Getenv("GITHUB_ACTIONS")) == "TRUE" {
+		t.Skip("Test is too heavy for macOS builder running in parallel with other packages")
 	}
 
 	// ConsensusTest0 is a version of ConsensusV0 used for testing


### PR DESCRIPTION
## Summary

Disable `TestSimpleUpgrade` on macOS GH Action builders similar to what we had for CircleCI.
Failure example: https://github.com/algorand/go-algorand/actions/runs/18975816182/job/54195826821
GH Actions env vars docs: https://docs.github.com/en/actions/reference/workflows-and-actions/variables

## Test Plan

This is a test fix.