### PR TITLE
AVM: Allow 0 as app in LocalRef, specifying current app

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -539,11 +539,6 @@ type ConsensusParams struct {
 	// EnableBoxRefNameError specifies that box ref names should be validated early
 	EnableBoxRefNameError bool
 
-	// EnableUnnamedBoxAccessInNewApps allows newly created (in this group) apps to
-	// create boxes that were not named in a box ref. Each empty box ref in the
-	// group allows one such creation.
-	EnableUnnamedBoxAccessInNewApps bool
-
 	// ExcludeExpiredCirculation excludes expired stake from the total online stake
 	// used by agreement for Circulation, and updates the calculation of StateProofOnlineTotalWeight used
 	// by state proofs to use the same method (rather than excluding stake from the top N stakeholders as before).
@@ -572,17 +567,16 @@ type ConsensusParams struct {
 	// EnableSha512BlockHash adds an additional SHA-512 hash to the block header.
 	EnableSha512BlockHash bool
 
-	// EnableInnerClawbackWithoutSenderHolding allows an inner clawback (axfer
-	// w/ AssetSender) even if the Sender holding of the asset is not
-	// available. This parameters can be removed and assumed true after the
-	// first consensus release in which it is set true.
-	EnableInnerClawbackWithoutSenderHolding bool
-
 	// AppSizeUpdates allows application update transactions to change
 	// the extra-program-pages and global schema sizes. Since it enables newly
 	// legal transactions, this parameter can be removed and assumed true after
 	// the first consensus release in which it is set true.
 	AppSizeUpdates bool
+
+	// AllowZeroLocalAppRef allows for a 0 in a LocalRef of the access list to
+	// specify the current app. This parameter can be removed and assumed true
+	// after the first consensus release in which it is set true.
+	AllowZeroLocalAppRef bool
 }
 
 // ProposerPayoutRules puts several related consensus parameters in one place. The same
@@ -1444,13 +1438,10 @@ func initConsensusProtocols() {
 	v41.EnableAppVersioning = true
 	v41.EnableSha512BlockHash = true
 
-	v41.EnableUnnamedBoxAccessInNewApps = true
-
 	// txn.Access work
 	v41.MaxAppTxnAccounts = 8       // Accounts are no worse than others, they should be the same
 	v41.MaxAppAccess = 16           // Twice as many, though cross products are explicit
 	v41.BytesPerBoxReference = 2048 // Count is more important that bytes, loosen up
-	v41.EnableInnerClawbackWithoutSenderHolding = true
 	v41.LogicSigMsig = false
 	v41.LogicSigLMsig = true
 
@@ -1469,6 +1460,7 @@ func initConsensusProtocols() {
 	vFuture.LogicSigVersion = 13 // When moving this to a release, put a new higher LogicSigVersion here
 
 	vFuture.AppSizeUpdates = true
+	vFuture.AllowZeroLocalAppRef = true
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -1318,7 +1318,7 @@ func (v2 *Handlers) SimulateTransaction(ctx echo.Context, params model.SimulateT
 		}
 	}
 
-	response := convertSimulationResult(simulationResult, proto.EnableUnnamedBoxAccessInNewApps)
+	response := convertSimulationResult(simulationResult)
 
 	handle, contentType, err := getCodecHandle((*string)(params.Format))
 	if err != nil {

--- a/data/transactions/application.go
+++ b/data/transactions/application.go
@@ -210,7 +210,7 @@ func (rr ResourceRef) Empty() bool {
 // wellFormed checks that a ResourceRef is a proper member of `access. `rr` is
 // either empty a single kind of resource. Any internal indices point to proper
 // locations inside `access`.
-func (rr ResourceRef) wellFormed(access []ResourceRef, proto config.ConsensusParams) error {
+func (rr ResourceRef) wellFormed(access []ResourceRef, inCreate bool, proto config.ConsensusParams) error {
 	// Count the number of non-empty fields
 	count := 0
 	// The "basic" resources are inherently wellFormed
@@ -231,7 +231,13 @@ func (rr ResourceRef) wellFormed(access []ResourceRef, proto config.ConsensusPar
 		count++
 	}
 	if !rr.Locals.Empty() {
-		if _, _, err := rr.Locals.Resolve(access, basics.Address{}); err != nil {
+		if !proto.AllowZeroLocalAppRef && rr.Locals.App == 0 {
+			return errors.New("0 App in LocalsRef is not supported")
+		}
+		if inCreate && rr.Locals.App == 0 {
+			return errors.New("0 App in LocalsRef during app create is not allowed or necessary")
+		}
+		if _, _, err := rr.Locals.Resolve(access, basics.Address{}, 0); err != nil {
 			return err
 		}
 		count++
@@ -309,9 +315,9 @@ func (lr LocalsRef) Empty() bool {
 	return lr == LocalsRef{}
 }
 
-// Resolve looks up the referenced address and app in the access list. 0 is
-// returned if the App index is 0, meaning "current app".
-func (lr LocalsRef) Resolve(access []ResourceRef, sender basics.Address) (basics.Address, basics.AppIndex, error) {
+// Resolve looks up the referenced address and app in the access list. Zero
+// values are translated to the supplied sender or current app.
+func (lr LocalsRef) Resolve(access []ResourceRef, sender basics.Address, current basics.AppIndex) (basics.Address, basics.AppIndex, error) {
 	address := sender // Returned when lr.Address == 0
 	if lr.Address != 0 {
 		if lr.Address > uint64(len(access)) { // recall that Access is 1-based
@@ -322,12 +328,15 @@ func (lr LocalsRef) Resolve(access []ResourceRef, sender basics.Address) (basics
 			return basics.Address{}, 0, fmt.Errorf("locals Address reference %d is not an Address", lr.Address)
 		}
 	}
-	if lr.App == 0 || lr.App > uint64(len(access)) { // 1-based
-		return basics.Address{}, 0, fmt.Errorf("locals App reference %d outside tx.Access", lr.App)
-	}
-	app := access[lr.App-1].App
-	if app == 0 {
-		return basics.Address{}, 0, fmt.Errorf("locals App reference %d is not an App", lr.App)
+	app := current // Returned when lr.App == 0
+	if lr.App != 0 {
+		if lr.App > uint64(len(access)) { // 1-based
+			return basics.Address{}, 0, fmt.Errorf("locals App reference %d outside tx.Access", lr.App)
+		}
+		app = access[lr.App-1].App
+		if app == 0 {
+			return basics.Address{}, 0, fmt.Errorf("locals App reference %d is not an App", lr.App)
+		}
 	}
 	return address, app, nil
 }
@@ -512,7 +521,7 @@ func (ac ApplicationCallTxnFields) wellFormed(proto config.ConsensusParams) erro
 		}
 
 		for _, rr := range ac.Access {
-			if err := rr.wellFormed(ac.Access, proto); err != nil {
+			if err := rr.wellFormed(ac.Access, ac.ApplicationID == 0, proto); err != nil {
 				return err
 			}
 		}

--- a/data/transactions/application_test.go
+++ b/data/transactions/application_test.go
@@ -203,9 +203,32 @@ func TestAppCallAccessWellFormed(t *testing.T) {
 			},
 		},
 		{
-			expectedError: "locals App reference 0 outside tx.Access",
+			// eliminate this test after AllowZeroAppInLocalsRef is removed
+			expectedError: "0 App in LocalsRef is not supported",
 			ac: ApplicationCallTxnFields{
 				ApplicationID: 1,
+				Access: []ResourceRef{
+					{Address: basics.Address{0xaa}},
+					{Locals: LocalsRef{Address: 1}},
+				},
+			},
+			cv: protocol.ConsensusV41,
+		},
+		{
+			ac: ApplicationCallTxnFields{
+				ApplicationID: 1,
+				Access: []ResourceRef{
+					{Address: basics.Address{0xaa}},
+					{Locals: LocalsRef{Address: 1}},
+				},
+			},
+		},
+		{
+			expectedError: "0 App in LocalsRef during app create is not allowed or necessary",
+			ac: ApplicationCallTxnFields{
+				ApplicationID:     0,
+				ApprovalProgram:   []byte{0x05},
+				ClearStateProgram: []byte{0x05},
 				Access: []ResourceRef{
 					{Address: basics.Address{0xaa}},
 					{Locals: LocalsRef{Address: 1}},

--- a/data/transactions/logic/box.go
+++ b/data/transactions/logic/box.go
@@ -52,7 +52,7 @@ func (cx *EvalContext) availableBox(name string, operation BoxOperation, createS
 	// we don't have to go to the disk. but we only allow one such access for
 	// each spare (empty) box ref. that way, we can't end up needing to write
 	// many separate newly created boxes.
-	if !ok && cx.Proto.EnableUnnamedBoxAccessInNewApps {
+	if !ok {
 		if _, newAppAccess = cx.available.createdApps[cx.appID]; newAppAccess {
 			if cx.available.unnamedAccess > 0 {
 				ok = true                    // allow it

--- a/ledger/apptxn_test.go
+++ b/ledger/apptxn_test.go
@@ -3765,6 +3765,7 @@ func TestUnfundedSenders(t *testing.T) {
 // no min balance.
 func TestAppCallAppDuringInit(t *testing.T) {
 	partitiontest.PartitionTest(t)
+	t.Parallel()
 
 	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
 	ledgertesting.TestConsensusRange(t, 31, 0, func(t *testing.T, ver int, cv protocol.ConsensusVersion, cfg config.Local) {
@@ -3808,5 +3809,170 @@ func TestAppCallAppDuringInit(t *testing.T) {
 			problem = "balance 0 below min"
 		}
 		dl.txn(&callInInit, problem)
+	})
+}
+
+// TestZeroAppLocalsAccess confirms that a 0, used as the app in a LocalRef indicates the current app.
+func TestZeroAppLocalsAccess(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
+	ledgertesting.TestConsensusRange(t, accessVersion, 0, func(t *testing.T, ver int, cv protocol.ConsensusVersion, cfg config.Local) {
+		dl := NewDoubleLedger(t, genBalances, cv, cfg)
+		defer dl.Close()
+
+		// readFromArg0 tries to read the local named in Arg0 from the
+		// address given in Arg1. This allows testing of various ways to provide
+		// access to locals.
+		readFromArg0 := txntest.Txn{
+			Type:   "appl",
+			Sender: addrs[0],
+			ApprovalProgram: main(`
+txn ApplicationArgs 0			// An address
+byte "XXX"
+app_local_get
+`),
+		}
+
+		appID := dl.txn(&readFromArg0).ApplicationID
+
+		dl.txn(&txntest.Txn{
+			Type:            "appl",
+			Sender:          addrs[1],
+			ApplicationID:   appID,
+			ApplicationArgs: [][]byte{addrs[2][:]},
+		}, "unavailable Account "+addrs[2].String())
+
+		// The old way: foreign account, with the implied access the cross product with current app
+		dl.txn(&txntest.Txn{
+			Type:            "appl",
+			Sender:          addrs[1],
+			ApplicationID:   appID,
+			ApplicationArgs: [][]byte{addrs[2][:]},
+			Accounts:        []basics.Address{addrs[2]},
+		}, addrs[2].String()+" has not opted in") // shows that it's available now
+
+		// The long way with Access: specify the called app as a resource ref,
+		// then have the localref point to it.
+		dl.txn(&txntest.Txn{
+			Type:            "appl",
+			Sender:          addrs[1], // opt-in
+			ApplicationID:   appID,
+			ApplicationArgs: [][]byte{addrs[2][:]},
+			Access: []transactions.ResourceRef{{
+				Address: addrs[2],
+			}, {
+				App: appID,
+			}, {
+				Locals: transactions.LocalsRef{
+					Address: 1, App: 2,
+				},
+			}},
+		}, addrs[2].String()+" has not opted in") // shows that it's available now
+
+		// The short way with Access: use 0 to mean the called app
+		problem := "0 App in LocalsRef is not supported"
+		if ver >= 42 { // 0 app is allowed now.  (Remove this after consensus change)
+			problem = addrs[2].String() + " has not opted in"
+		}
+
+		dl.txn(&txntest.Txn{
+			Type:            "appl",
+			Sender:          addrs[1], // opt-in
+			ApplicationID:   appID,
+			ApplicationArgs: [][]byte{addrs[2][:]},
+			Access: []transactions.ResourceRef{{
+				Address: addrs[2],
+			}, {
+				Locals: transactions.LocalsRef{
+					Address: 1, App: 0,
+				},
+			}},
+		}, problem)
+
+	})
+
+}
+
+// TestLocalAccessInNewApps shows that in a group that creates a new app, that
+// app can access any available account's locals for that app. Of course,
+// although the locals may be available, it's quite hard to construct examples
+// in which an account is opted-in to the new app.
+func TestLocalAccessInNewApps(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	genBalances, addrs, _ := ledgertesting.NewTestGenesis()
+	ledgertesting.TestConsensusRange(t, accessVersion, 0, func(t *testing.T, ver int, cv protocol.ConsensusVersion, cfg config.Local) {
+		dl := NewDoubleLedger(t, genBalances, cv, cfg)
+		defer dl.Close()
+
+		// callArg0WithArg1 is an app that simply calls the appID provided in
+		// the 0th argument.  It supplies its own 1st arg as the callee's
+		// 0th. It is intended to be called by a top-level app in a group where
+		// a previous transactions has created a new app.  The caller of this
+		// app determines the id of that newly created app and provides it to
+		// `readFromArg0`. The goal is to re-invoke the newly created app and
+		// show it can access locals for an available account even though the
+		// Locals do not explcitly appear in an access list.
+
+		callArg0WithArg1 := txntest.Txn{
+			Type:   "appl",
+			Sender: addrs[0],
+			ApprovalProgram: main(`
+itxn_begin
+int appl;                     itxn_field TypeEnum
+txn ApplicationArgs 0; btoi;  itxn_field ApplicationID
+txn ApplicationArgs 1;        itxn_field ApplicationArgs
+itxn_submit
+int 1
+`),
+		}
+
+		callID := dl.txn(&callArg0WithArg1).ApplicationID
+
+		// readFromArg0 tries to read the local named in Arg0 from the
+		// address given in Arg1. This allows testing of various ways to provide
+		// access to locals.
+		readFromArg0 := txntest.Txn{
+			Type:   "appl",
+			Sender: addrs[0],
+			ApprovalProgram: main(`
+txn ApplicationArgs 0			// An address
+byte "XXX"
+app_local_get
+`),
+		}
+
+		callFirst := txntest.Txn{
+			Type:   "appl",
+			Sender: addrs[0],
+			ApprovalProgram: `	// Don't use main(), so this runs at creation time
+itxn_begin
+int appl; itxn_field TypeEnum
+gtxn 0 CreatedApplicationID		// get the app ID created in first txn
+itob
+itxn_field ApplicationArgs
+txn ApplicationArgs 0; itxn_field ApplicationArgs
+int ` + strconv.FormatUint(uint64(callID), 10) + `
+itxn_field ApplicationID
+itxn_submit
+`,
+			Access: []transactions.ResourceRef{{
+				App: callID,
+			}},
+			Fee: 1_000_000, // Oversize fee, so that newly created app can make inner call
+		}
+
+		dl.txgroup("unavailable Account "+addrs[2].String(), &readFromArg0, callFirst.Args(string(addrs[2][:])))
+
+		callWithAcctAccess := callFirst
+		callWithAcctAccess.Access = append(callWithAcctAccess.Access, transactions.ResourceRef{Address: addrs[2]})
+		// The "not opted in" error shows that the local ref has become
+		// available because addr[2] because available, this demonstrates that
+		// the LocalRef is not needed because the app in question was made
+		// earlier in the same group.
+		dl.txgroup(addrs[2].String()+" has not opted in", &readFromArg0, callWithAcctAccess.Args(string(addrs[2][:])))
 	})
 }


### PR DESCRIPTION
A localref inside of tx.Access ought to be able to use 0 for "current app". It was an oversight to prohibit it.  This PR allows it, but is consensus gated.

Also removes two consensus flags that can be assumed true now because they are strictly more lenient.

Add, indeed _this_ consensus flag can be removed once it has gone into effect.

Addresses #6449 

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
