### PR TITLE
tests: use more realistic BlockEvaluator in ledger/ledger_test.go

### DIFF
--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -213,7 +213,7 @@ return`
 	ledger, err := OpenLedger(logging.Base(), "TestAppAccountData", true, genesisInitState, cfg)
 	a.NoError(err)
 	defer ledger.Close()
-	l := ledgerTestHelper{ledger, t}
+	l := ledgerTestBlockBuilder{ledger, t}
 
 	txHeader := transactions.Header{
 		Sender:      creator,
@@ -439,7 +439,7 @@ return`
 	ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
 	defer ledger.Close()
-	l := ledgerTestHelper{ledger, t}
+	l := ledgerTestBlockBuilder{ledger, t}
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -607,7 +607,7 @@ return`
 	stx1 := sign(initKeys, appCall1)
 	stx2 := sign(initKeys, appCall2)
 
-	blk = makeNewEmptyBlock(t, l.Ledger, genesisID, genesisInitState.Accounts)
+	blk = l.makeNewEmptyBlock(genesisID, genesisInitState.Accounts)
 	ad1 := transactions.ApplyData{
 		EvalDelta: transactions.EvalDelta{
 			LocalDeltas: map[uint64]basics.StateDelta{0: {"lk1": basics.ValueDelta{
@@ -683,7 +683,7 @@ return`
 	ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
 	defer ledger.Close()
-	l := ledgerTestHelper{ledger, t}
+	l := ledgerTestBlockBuilder{ledger, t}
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -761,7 +761,7 @@ return`
 	stx1 := sign(initKeys, appCall)
 	stx2 := sign(initKeys, payment)
 
-	blk := makeNewEmptyBlock(t, l.Ledger, genesisID, genesisInitState.Accounts)
+	blk := l.makeNewEmptyBlock(genesisID, genesisInitState.Accounts)
 	txib1, err := blk.EncodeSignedTxn(stx1, transactions.ApplyData{})
 	a.NoError(err)
 	txib2, err := blk.EncodeSignedTxn(stx2, transactions.ApplyData{ClosingAmount: balance})
@@ -838,7 +838,7 @@ return`
 	ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
 	defer ledger.Close()
-	l := ledgerTestHelper{ledger, t}
+	l := ledgerTestBlockBuilder{ledger, t}
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -895,7 +895,7 @@ return`
 	stx1 := sign(initKeys, appCall)
 	stx2 := sign(initKeys, payment)
 
-	blk := makeNewEmptyBlock(t, l.Ledger, genesisID, genesisInitState.Accounts)
+	blk := l.makeNewEmptyBlock(genesisID, genesisInitState.Accounts)
 	txib1, err := blk.EncodeSignedTxn(stx1, transactions.ApplyData{EvalDelta: transactions.EvalDelta{
 		GlobalDelta: basics.StateDelta{
 			"gk": basics.ValueDelta{Action: basics.SetBytesAction, Bytes: "global"},
@@ -1035,7 +1035,7 @@ func testAppAccountDeltaIndicesCompatibility(t *testing.T, source string, accoun
 	ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
 	defer ledger.Close()
-	l := ledgerTestHelper{ledger, t}
+	l := ledgerTestBlockBuilder{ledger, t}
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -1176,7 +1176,7 @@ int 1
 			ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 			a.NoError(err)
 			defer ledger.Close()
-			l := ledgerTestHelper{ledger, t}
+			l := ledgerTestBlockBuilder{ledger, t}
 
 			genesisID := t.Name()
 			txHeader := transactions.Header{
@@ -1304,7 +1304,7 @@ int 1
 	ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
 	defer ledger.Close()
-	l := ledgerTestHelper{ledger, t}
+	l := ledgerTestBlockBuilder{ledger, t}
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -1386,7 +1386,7 @@ return
 	ledger1, err := OpenLedger(logging.Base(), dbPrefix, false, genesisInitState, cfg)
 	a.NoError(err)
 	defer ledger1.Close()
-	l1 := ledgerTestHelper{ledger1, t}
+	l1 := ledgerTestBlockBuilder{ledger1, t}
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -1432,7 +1432,7 @@ return
 
 	// few empty blocks to reset deltas and flush
 	for i := 0; i < 10; i++ {
-		blk := makeNewEmptyBlock(t, l1.Ledger, genesisID, genesisInitState.Accounts)
+		blk := l1.makeNewEmptyBlock(genesisID, genesisInitState.Accounts)
 		l1.AddBlock(blk, agreement.Certificate{})
 	}
 
@@ -1448,7 +1448,7 @@ return
 	ledger2, err := OpenLedger(logging.Base(), dbPrefix, false, genesisInitState, cfg)
 	a.NoError(err)
 	defer ledger2.Close()
-	l2 := ledgerTestHelper{ledger2, t}
+	l2 := ledgerTestBlockBuilder{ledger2, t}
 
 	app, err = l2.LookupApplication(l2.Latest(), creator, appIdx)
 	a.NoError(err)

--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -210,10 +210,9 @@ return`
 	}
 
 	cfg := config.GetDefaultLocal()
-	ledger, err := OpenLedger(logging.Base(), "TestAppAccountData", true, genesisInitState, cfg)
+	l, err := OpenLedger(logging.Base(), "TestAppAccountData", true, genesisInitState, cfg)
 	a.NoError(err)
-	defer ledger.Close()
-	l := ledgerTestBlockBuilder{ledger, t}
+	defer l.Close()
 
 	txHeader := transactions.Header{
 		Sender:      creator,
@@ -267,7 +266,7 @@ return`
 	a.NoError(err)
 
 	// save data into DB and write into local state
-	commitRound(3, 0, l.Ledger)
+	commitRound(3, 0, l)
 
 	appCallFields = transactions.ApplicationCallTxnFields{
 		OnCompletion:    0,
@@ -286,7 +285,7 @@ return`
 	a.NoError(err)
 
 	// save data into DB
-	commitRound(1, 3, l.Ledger)
+	commitRound(1, 3, l)
 
 	// dump accounts
 	entryAcc, err := l.accts.accountsq.LookupAccount(creator)
@@ -436,10 +435,9 @@ return`
 	a.Contains(genesisInitState.Accounts, userLocal)
 
 	cfg := config.GetDefaultLocal()
-	ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+	l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
-	defer ledger.Close()
-	l := ledgerTestBlockBuilder{ledger, t}
+	defer l.Close()
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -504,7 +502,7 @@ return`
 	a.NoError(err)
 
 	// save data into DB and write into local state
-	commitRound(3, 0, l.Ledger)
+	commitRound(3, 0, l)
 
 	// check first write
 	blk, err := l.Block(2)
@@ -558,7 +556,7 @@ return`
 	a.NoError(err)
 
 	// save data into DB
-	commitRound(2, 3, l.Ledger)
+	commitRound(2, 3, l)
 
 	// check first write
 	blk, err = l.Block(4)
@@ -607,7 +605,7 @@ return`
 	stx1 := sign(initKeys, appCall1)
 	stx2 := sign(initKeys, appCall2)
 
-	blk = l.makeNewEmptyBlock(genesisID, genesisInitState.Accounts)
+	blk = makeNewEmptyBlock(t, l, genesisID, genesisInitState.Accounts)
 	ad1 := transactions.ApplyData{
 		EvalDelta: transactions.EvalDelta{
 			LocalDeltas: map[uint64]basics.StateDelta{0: {"lk1": basics.ValueDelta{
@@ -680,10 +678,9 @@ return`
 	a.Contains(genesisInitState.Accounts, userLocal)
 
 	cfg := config.GetDefaultLocal()
-	ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+	l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
-	defer ledger.Close()
-	l := ledgerTestBlockBuilder{ledger, t}
+	defer l.Close()
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -761,7 +758,7 @@ return`
 	stx1 := sign(initKeys, appCall)
 	stx2 := sign(initKeys, payment)
 
-	blk := l.makeNewEmptyBlock(genesisID, genesisInitState.Accounts)
+	blk := makeNewEmptyBlock(t, l, genesisID, genesisInitState.Accounts)
 	txib1, err := blk.EncodeSignedTxn(stx1, transactions.ApplyData{})
 	a.NoError(err)
 	txib2, err := blk.EncodeSignedTxn(stx2, transactions.ApplyData{ClosingAmount: balance})
@@ -777,7 +774,7 @@ return`
 	l.WaitForCommit(3)
 
 	// save data into DB and write into local state
-	commitRound(3, 0, l.Ledger)
+	commitRound(3, 0, l)
 
 	// check first write
 	blk, err = l.Block(2)
@@ -835,10 +832,9 @@ return`
 	a.Contains(genesisInitState.Accounts, userLocal)
 
 	cfg := config.GetDefaultLocal()
-	ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+	l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
-	defer ledger.Close()
-	l := ledgerTestBlockBuilder{ledger, t}
+	defer l.Close()
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -895,7 +891,7 @@ return`
 	stx1 := sign(initKeys, appCall)
 	stx2 := sign(initKeys, payment)
 
-	blk := l.makeNewEmptyBlock(genesisID, genesisInitState.Accounts)
+	blk := makeNewEmptyBlock(t, l, genesisID, genesisInitState.Accounts)
 	txib1, err := blk.EncodeSignedTxn(stx1, transactions.ApplyData{EvalDelta: transactions.EvalDelta{
 		GlobalDelta: basics.StateDelta{
 			"gk": basics.ValueDelta{Action: basics.SetBytesAction, Bytes: "global"},
@@ -913,7 +909,7 @@ return`
 	a.NoError(err)
 
 	// save data into DB and write into local state
-	commitRound(2, 0, l.Ledger)
+	commitRound(2, 0, l)
 
 	// check first write
 	blk, err = l.Block(1)
@@ -1032,10 +1028,9 @@ func testAppAccountDeltaIndicesCompatibility(t *testing.T, source string, accoun
 	a.Contains(genesisInitState.Accounts, userLocal)
 
 	cfg := config.GetDefaultLocal()
-	ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+	l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
-	defer ledger.Close()
-	l := ledgerTestBlockBuilder{ledger, t}
+	defer l.Close()
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -1096,7 +1091,7 @@ func testAppAccountDeltaIndicesCompatibility(t *testing.T, source string, accoun
 	a.NoError(err)
 
 	// save data into DB and write into local state
-	commitRound(2, 0, l.Ledger)
+	commitRound(2, 0, l)
 
 	// check first write
 	blk, err := l.Block(2)
@@ -1173,10 +1168,9 @@ int 1
 			a.Contains(genesisInitState.Accounts, userLocal)
 
 			cfg := config.GetDefaultLocal()
-			ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+			l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 			a.NoError(err)
-			defer ledger.Close()
-			l := ledgerTestBlockBuilder{ledger, t}
+			defer l.Close()
 
 			genesisID := t.Name()
 			txHeader := transactions.Header{
@@ -1208,7 +1202,7 @@ int 1
 			a.NoError(err)
 
 			if test.separateBlocks {
-				commitRound(1, 0, l.Ledger)
+				commitRound(1, 0, l)
 			}
 
 			// opt-in
@@ -1226,7 +1220,7 @@ int 1
 			a.NoError(err)
 
 			if test.separateBlocks {
-				commitRound(1, 1, l.Ledger)
+				commitRound(1, 1, l)
 			}
 
 			// run state write transaction
@@ -1261,9 +1255,9 @@ int 1
 			a.NoError(err)
 
 			if test.separateBlocks {
-				commitRound(1, 2, l.Ledger)
+				commitRound(1, 2, l)
 			} else {
-				commitRound(3, 0, l.Ledger)
+				commitRound(3, 0, l)
 			}
 
 			// check first write
@@ -1301,10 +1295,9 @@ int 1
 	a.Contains(genesisInitState.Accounts, funder)
 
 	cfg := config.GetDefaultLocal()
-	ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+	l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
-	defer ledger.Close()
-	l := ledgerTestBlockBuilder{ledger, t}
+	defer l.Close()
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -1383,10 +1376,9 @@ return
 
 	cfg := config.GetDefaultLocal()
 	cfg.MaxAcctLookback = 2
-	ledger1, err := OpenLedger(logging.Base(), dbPrefix, false, genesisInitState, cfg)
+	l1, err := OpenLedger(logging.Base(), dbPrefix, false, genesisInitState, cfg)
 	a.NoError(err)
-	defer ledger1.Close()
-	l1 := ledgerTestBlockBuilder{ledger1, t}
+	defer l1.Close()
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -1432,7 +1424,7 @@ return
 
 	// few empty blocks to reset deltas and flush
 	for i := 0; i < 10; i++ {
-		blk := l1.makeNewEmptyBlock(genesisID, genesisInitState.Accounts)
+		blk := makeNewEmptyBlock(t, l1, genesisID, genesisInitState.Accounts)
 		l1.AddBlock(blk, agreement.Certificate{})
 	}
 
@@ -1440,15 +1432,14 @@ return
 	a.NoError(err)
 	a.Greater(len(app.AppParams.ApprovalProgram), 0)
 
-	commitRound(10, 0, l1.Ledger)
+	commitRound(10, 0, l1)
 
 	// restart
 	l1.Close()
 
-	ledger2, err := OpenLedger(logging.Base(), dbPrefix, false, genesisInitState, cfg)
+	l2, err := OpenLedger(logging.Base(), dbPrefix, false, genesisInitState, cfg)
 	a.NoError(err)
-	defer ledger2.Close()
-	l2 := ledgerTestBlockBuilder{ledger2, t}
+	defer l2.Close()
 
 	app, err = l2.LookupApplication(l2.Latest(), creator, appIdx)
 	a.NoError(err)

--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -1073,7 +1073,7 @@ func testAppAccountDeltaIndicesCompatibility(t *testing.T, source string, accoun
 		Header:                   txHeader,
 		ApplicationCallTxnFields: appCallFields,
 	}
-	err = l.appendUnvalidatedTx(t, genesisInitState.Accounts, initKeys, appCall, transactions.ApplyData{
+	err = l.appendInvalidTx(t, genesisInitState.Accounts, initKeys, appCall, transactions.ApplyData{
 		EvalDelta: transactions.EvalDelta{
 			LocalDeltas: map[uint64]basics.StateDelta{
 				accountIdx: {

--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -210,9 +210,10 @@ return`
 	}
 
 	cfg := config.GetDefaultLocal()
-	l, err := OpenLedger(logging.Base(), "TestAppAccountData", true, genesisInitState, cfg)
+	ledger, err := OpenLedger(logging.Base(), "TestAppAccountData", true, genesisInitState, cfg)
 	a.NoError(err)
-	defer l.Close()
+	defer ledger.Close()
+	l := ledgerTestHelper{ledger, t}
 
 	txHeader := transactions.Header{
 		Sender:      creator,
@@ -266,7 +267,7 @@ return`
 	a.NoError(err)
 
 	// save data into DB and write into local state
-	commitRound(3, 0, l)
+	commitRound(3, 0, l.Ledger)
 
 	appCallFields = transactions.ApplicationCallTxnFields{
 		OnCompletion:    0,
@@ -285,7 +286,7 @@ return`
 	a.NoError(err)
 
 	// save data into DB
-	commitRound(1, 3, l)
+	commitRound(1, 3, l.Ledger)
 
 	// dump accounts
 	entryAcc, err := l.accts.accountsq.LookupAccount(creator)
@@ -435,9 +436,10 @@ return`
 	a.Contains(genesisInitState.Accounts, userLocal)
 
 	cfg := config.GetDefaultLocal()
-	l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+	ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
-	defer l.Close()
+	defer ledger.Close()
+	l := ledgerTestHelper{ledger, t}
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -502,7 +504,7 @@ return`
 	a.NoError(err)
 
 	// save data into DB and write into local state
-	commitRound(3, 0, l)
+	commitRound(3, 0, l.Ledger)
 
 	// check first write
 	blk, err := l.Block(2)
@@ -556,7 +558,7 @@ return`
 	a.NoError(err)
 
 	// save data into DB
-	commitRound(2, 3, l)
+	commitRound(2, 3, l.Ledger)
 
 	// check first write
 	blk, err = l.Block(4)
@@ -605,7 +607,7 @@ return`
 	stx1 := sign(initKeys, appCall1)
 	stx2 := sign(initKeys, appCall2)
 
-	blk = makeNewEmptyBlock(t, l, genesisID, genesisInitState.Accounts)
+	blk = makeNewEmptyBlock(t, l.Ledger, genesisID, genesisInitState.Accounts)
 	ad1 := transactions.ApplyData{
 		EvalDelta: transactions.EvalDelta{
 			LocalDeltas: map[uint64]basics.StateDelta{0: {"lk1": basics.ValueDelta{
@@ -678,9 +680,10 @@ return`
 	a.Contains(genesisInitState.Accounts, userLocal)
 
 	cfg := config.GetDefaultLocal()
-	l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+	ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
-	defer l.Close()
+	defer ledger.Close()
+	l := ledgerTestHelper{ledger, t}
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -758,7 +761,7 @@ return`
 	stx1 := sign(initKeys, appCall)
 	stx2 := sign(initKeys, payment)
 
-	blk := makeNewEmptyBlock(t, l, genesisID, genesisInitState.Accounts)
+	blk := makeNewEmptyBlock(t, l.Ledger, genesisID, genesisInitState.Accounts)
 	txib1, err := blk.EncodeSignedTxn(stx1, transactions.ApplyData{})
 	a.NoError(err)
 	txib2, err := blk.EncodeSignedTxn(stx2, transactions.ApplyData{ClosingAmount: balance})
@@ -774,7 +777,7 @@ return`
 	l.WaitForCommit(3)
 
 	// save data into DB and write into local state
-	commitRound(3, 0, l)
+	commitRound(3, 0, l.Ledger)
 
 	// check first write
 	blk, err = l.Block(2)
@@ -832,9 +835,10 @@ return`
 	a.Contains(genesisInitState.Accounts, userLocal)
 
 	cfg := config.GetDefaultLocal()
-	l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+	ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
-	defer l.Close()
+	defer ledger.Close()
+	l := ledgerTestHelper{ledger, t}
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -891,7 +895,7 @@ return`
 	stx1 := sign(initKeys, appCall)
 	stx2 := sign(initKeys, payment)
 
-	blk := makeNewEmptyBlock(t, l, genesisID, genesisInitState.Accounts)
+	blk := makeNewEmptyBlock(t, l.Ledger, genesisID, genesisInitState.Accounts)
 	txib1, err := blk.EncodeSignedTxn(stx1, transactions.ApplyData{EvalDelta: transactions.EvalDelta{
 		GlobalDelta: basics.StateDelta{
 			"gk": basics.ValueDelta{Action: basics.SetBytesAction, Bytes: "global"},
@@ -909,7 +913,7 @@ return`
 	a.NoError(err)
 
 	// save data into DB and write into local state
-	commitRound(2, 0, l)
+	commitRound(2, 0, l.Ledger)
 
 	// check first write
 	blk, err = l.Block(1)
@@ -1028,9 +1032,10 @@ func testAppAccountDeltaIndicesCompatibility(t *testing.T, source string, accoun
 	a.Contains(genesisInitState.Accounts, userLocal)
 
 	cfg := config.GetDefaultLocal()
-	l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+	ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
-	defer l.Close()
+	defer ledger.Close()
+	l := ledgerTestHelper{ledger, t}
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -1091,7 +1096,7 @@ func testAppAccountDeltaIndicesCompatibility(t *testing.T, source string, accoun
 	a.NoError(err)
 
 	// save data into DB and write into local state
-	commitRound(2, 0, l)
+	commitRound(2, 0, l.Ledger)
 
 	// check first write
 	blk, err := l.Block(2)
@@ -1168,9 +1173,10 @@ int 1
 			a.Contains(genesisInitState.Accounts, userLocal)
 
 			cfg := config.GetDefaultLocal()
-			l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+			ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 			a.NoError(err)
-			defer l.Close()
+			defer ledger.Close()
+			l := ledgerTestHelper{ledger, t}
 
 			genesisID := t.Name()
 			txHeader := transactions.Header{
@@ -1202,7 +1208,7 @@ int 1
 			a.NoError(err)
 
 			if test.separateBlocks {
-				commitRound(1, 0, l)
+				commitRound(1, 0, l.Ledger)
 			}
 
 			// opt-in
@@ -1220,7 +1226,7 @@ int 1
 			a.NoError(err)
 
 			if test.separateBlocks {
-				commitRound(1, 1, l)
+				commitRound(1, 1, l.Ledger)
 			}
 
 			// run state write transaction
@@ -1255,9 +1261,9 @@ int 1
 			a.NoError(err)
 
 			if test.separateBlocks {
-				commitRound(1, 2, l)
+				commitRound(1, 2, l.Ledger)
 			} else {
-				commitRound(3, 0, l)
+				commitRound(3, 0, l.Ledger)
 			}
 
 			// check first write
@@ -1295,9 +1301,10 @@ int 1
 	a.Contains(genesisInitState.Accounts, funder)
 
 	cfg := config.GetDefaultLocal()
-	l, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
+	ledger, err := OpenLedger(logging.Base(), t.Name(), true, genesisInitState, cfg)
 	a.NoError(err)
-	defer l.Close()
+	defer ledger.Close()
+	l := ledgerTestHelper{ledger, t}
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -1376,9 +1383,10 @@ return
 
 	cfg := config.GetDefaultLocal()
 	cfg.MaxAcctLookback = 2
-	l1, err := OpenLedger(logging.Base(), dbPrefix, false, genesisInitState, cfg)
+	ledger1, err := OpenLedger(logging.Base(), dbPrefix, false, genesisInitState, cfg)
 	a.NoError(err)
-	defer l1.Close()
+	defer ledger1.Close()
+	l1 := ledgerTestHelper{ledger1, t}
 
 	genesisID := t.Name()
 	txHeader := transactions.Header{
@@ -1424,7 +1432,7 @@ return
 
 	// few empty blocks to reset deltas and flush
 	for i := 0; i < 10; i++ {
-		blk := makeNewEmptyBlock(t, l1, genesisID, genesisInitState.Accounts)
+		blk := makeNewEmptyBlock(t, l1.Ledger, genesisID, genesisInitState.Accounts)
 		l1.AddBlock(blk, agreement.Certificate{})
 	}
 
@@ -1432,14 +1440,15 @@ return
 	a.NoError(err)
 	a.Greater(len(app.AppParams.ApprovalProgram), 0)
 
-	commitRound(10, 0, l1)
+	commitRound(10, 0, l1.Ledger)
 
 	// restart
 	l1.Close()
 
-	l2, err := OpenLedger(logging.Base(), dbPrefix, false, genesisInitState, cfg)
+	ledger2, err := OpenLedger(logging.Base(), dbPrefix, false, genesisInitState, cfg)
 	a.NoError(err)
-	defer l2.Close()
+	defer ledger2.Close()
+	l2 := ledgerTestHelper{ledger2, t}
 
 	app, err = l2.LookupApplication(l2.Latest(), creator, appIdx)
 	a.NoError(err)

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -893,7 +893,7 @@ func TestCatchpointTrackerNonblockingCatchpointWriting(t *testing.T) {
 	ledger, err := OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
 	require.NoError(t, err, "could not open ledger")
 	defer ledger.Close()
-	l := ledgerTestHelper{ledger, t}
+	l := ledgerTestBlockBuilder{ledger, t}
 
 	writeStallingTracker := &blockingTracker{
 		postCommitUnlockedEntryLock:   make(chan struct{}),

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -893,7 +893,6 @@ func TestCatchpointTrackerNonblockingCatchpointWriting(t *testing.T) {
 	ledger, err := OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
 	require.NoError(t, err, "could not open ledger")
 	defer ledger.Close()
-	l := ledgerTestBlockBuilder{ledger, t}
 
 	writeStallingTracker := &blockingTracker{
 		postCommitUnlockedEntryLock:   make(chan struct{}),
@@ -910,13 +909,13 @@ func TestCatchpointTrackerNonblockingCatchpointWriting(t *testing.T) {
 	// Create the first `cfg.MaxAcctLookback` blocks for which account updates tracker
 	// will skip committing.
 	for rnd := ledger.Latest() + 1; rnd <= basics.Round(cfg.MaxAcctLookback); rnd++ {
-		err = l.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
+		err = ledger.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
 		require.NoError(t, err)
 	}
 
 	// make sure to get to a first stage catchpoint round, and block the writing there.
 	for {
-		err = l.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
+		err = ledger.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
 		require.NoError(t, err)
 		if (uint64(ledger.Latest())+protoParams.CatchpointLookback)%
 			cfg.CatchpointInterval == 0 {
@@ -933,7 +932,7 @@ func TestCatchpointTrackerNonblockingCatchpointWriting(t *testing.T) {
 	}
 
 	// write additional block, so that the block queue would trigger that too
-	err = l.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
+	err = ledger.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
 	require.NoError(t, err)
 	// wait for the committedUpToRound to be called with the correct round number.
 	for {
@@ -965,7 +964,7 @@ func TestCatchpointTrackerNonblockingCatchpointWriting(t *testing.T) {
 
 	// make sure to get to a first stage catchpoint round, and block the writing there.
 	for {
-		err = l.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
+		err = ledger.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
 		require.NoError(t, err)
 		if (uint64(ledger.Latest())+protoParams.CatchpointLookback)%
 			cfg.CatchpointInterval == 0 {
@@ -975,7 +974,7 @@ func TestCatchpointTrackerNonblockingCatchpointWriting(t *testing.T) {
 		}
 	}
 	// write additional block, so that the block queue would trigger that too
-	err = l.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
+	err = ledger.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
 	require.NoError(t, err)
 	// wait for the committedUpToRound to be called with the correct round number.
 	for {

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -893,6 +893,7 @@ func TestCatchpointTrackerNonblockingCatchpointWriting(t *testing.T) {
 	ledger, err := OpenLedger(log, t.Name(), inMem, genesisInitState, cfg)
 	require.NoError(t, err, "could not open ledger")
 	defer ledger.Close()
+	l := ledgerTestHelper{ledger, t}
 
 	writeStallingTracker := &blockingTracker{
 		postCommitUnlockedEntryLock:   make(chan struct{}),
@@ -909,13 +910,13 @@ func TestCatchpointTrackerNonblockingCatchpointWriting(t *testing.T) {
 	// Create the first `cfg.MaxAcctLookback` blocks for which account updates tracker
 	// will skip committing.
 	for rnd := ledger.Latest() + 1; rnd <= basics.Round(cfg.MaxAcctLookback); rnd++ {
-		err = ledger.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
+		err = l.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
 		require.NoError(t, err)
 	}
 
 	// make sure to get to a first stage catchpoint round, and block the writing there.
 	for {
-		err = ledger.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
+		err = l.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
 		require.NoError(t, err)
 		if (uint64(ledger.Latest())+protoParams.CatchpointLookback)%
 			cfg.CatchpointInterval == 0 {
@@ -932,7 +933,7 @@ func TestCatchpointTrackerNonblockingCatchpointWriting(t *testing.T) {
 	}
 
 	// write additional block, so that the block queue would trigger that too
-	err = ledger.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
+	err = l.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
 	require.NoError(t, err)
 	// wait for the committedUpToRound to be called with the correct round number.
 	for {
@@ -964,7 +965,7 @@ func TestCatchpointTrackerNonblockingCatchpointWriting(t *testing.T) {
 
 	// make sure to get to a first stage catchpoint round, and block the writing there.
 	for {
-		err = ledger.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
+		err = l.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
 		require.NoError(t, err)
 		if (uint64(ledger.Latest())+protoParams.CatchpointLookback)%
 			cfg.CatchpointInterval == 0 {
@@ -974,7 +975,7 @@ func TestCatchpointTrackerNonblockingCatchpointWriting(t *testing.T) {
 		}
 	}
 	// write additional block, so that the block queue would trigger that too
-	err = ledger.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
+	err = l.addBlockTxns(t, genesisInitState.Accounts, []transactions.SignedTxn{}, transactions.ApplyData{})
 	require.NoError(t, err)
 	// wait for the committedUpToRound to be called with the correct round number.
 	for {

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -1329,7 +1329,7 @@ func testLedgerSingleTxApplyData(t *testing.T, version protocol.ConsensusVersion
 
 	a.NoError(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPay, ad), "could not add payment transaction")
 	a.ErrorContains(l.appendInvalidTx(t, initAccounts, initSecrets, correctClose, adCloseWrong), "applyData mismatch", "closed transaction with wrong ApplyData")
-	a.NoError(l.appendInvalidTx(t, initAccounts, initSecrets, correctClose, adClose), "could not add close transaction")
+	a.NoError(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctClose, adClose), "could not add close transaction")
 	a.NoError(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctKeyreg, ad), "could not add key registration")
 
 	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctKeyreg, ad), "transaction already in ledger", "added duplicate tx")

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -578,99 +578,99 @@ func TestLedgerSingleTx(t *testing.T) {
 
 	badTx = correctPay
 	badTx.GenesisID = "invalid"
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx with invalid genesis ID")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "tx.GenesisID <invalid> does not match expected", "added tx with invalid genesis ID")
 
 	badTx = correctPay
 	badTx.Type = "invalid"
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx with invalid tx type")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: unknown tx type invalid", "added tx with invalid tx type")
 
 	badTx = correctPay
 	badTx.KeyregTxnFields = correctKeyregFields
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added pay tx with keyreg fields set")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: transaction of type pay has non-zero fields for type keyreg", "added pay tx with keyreg fields set")
 
 	badTx = correctKeyreg
 	badTx.PaymentTxnFields = correctPayFields
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added keyreg tx with pay fields set")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: transaction of type keyreg has non-zero fields for type pay", "added keyreg tx with pay fields set")
 
 	badTx = correctKeyreg
 	badTx.PaymentTxnFields = correctCloseFields
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added keyreg tx with pay (close) fields set")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: transaction of type keyreg has non-zero fields for type pay", "added keyreg tx with pay (close) fields set")
 
 	badTx = correctPay
 	badTx.FirstValid = badTx.LastValid + 1
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx with FirstValid > LastValid")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "txn dead: round 1 outside of 11--10", "added tx with FirstValid > LastValid")
 
 	badTx = correctPay
 	badTx.LastValid += basics.Round(proto.MaxTxnLife)
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx with overly long validity")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: transaction window size excessive (1--1010)", "added tx with overly long validity")
 
 	badTx = correctPay
 	badTx.LastValid = l.Latest()
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added expired tx")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "txn dead: round 1 outside of 1--0", "added expired tx")
 
 	badTx = correctPay
 	badTx.FirstValid = l.Latest() + 2
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx which is not valid yet")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "txn dead: round 1 outside of 2--10", "added tx which is not valid yet")
 
 	badTx = correctPay
 	badTx.Note = make([]byte, proto.MaxTxnNoteBytes+1)
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx with overly large note field")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: transaction note too big: 1025 > 1024", "added tx with overly large note field")
 
 	badTx = correctPay
 	badTx.Sender = poolAddr
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx send from tx pool")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: transaction from incentive pool is invalid", "added tx send from tx pool")
 
 	badTx = correctPay
 	badTx.Sender = basics.Address{}
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx send from zero address")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: transaction cannot close account to its sender", "added tx send from zero address")
 
 	badTx = correctPay
 	badTx.Fee = basics.MicroAlgos{}
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx with zero fee")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "less than the minimum", "added tx with zero fee")
 
 	badTx = correctPay
 	badTx.Fee = basics.MicroAlgos{Raw: proto.MinTxnFee - 1}
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx with fee below minimum")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "less than the minimum", "added tx with fee below minimum")
 
 	badTx = correctKeyreg
 	fee, overflow := basics.OAddA(initAccounts[badTx.Sender].MicroAlgos, basics.MicroAlgos{Raw: 1})
 	a.False(overflow)
 	badTx.Fee = fee
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added keyreg tx with fee above user balance")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "overspend", "added keyreg tx with fee above user balance")
 
 	// TODO try excessive spending given distribution of some number of rewards
 
 	badTx = correctPay
 	sbadTx := sign(initSecrets, badTx)
 	sbadTx.Sig = crypto.Signature{}
-	a.Error(l.appendInvalidSignedTx(t, initAccounts, sbadTx, ad), "added tx with no signature")
+	a.ErrorContains(l.appendInvalidSignedTx(t, initAccounts, sbadTx, ad), "invalid : signedtxn has no sig", "added tx with no signature")
 
 	badTx = correctPay
 	sbadTx = sign(initSecrets, badTx)
 	sbadTx.Sig[5]++
-	a.Error(l.appendInvalidSignedTx(t, initAccounts, sbadTx, ad), "added tx with corrupt signature")
+	a.ErrorContains(l.appendInvalidSignedTx(t, initAccounts, sbadTx, ad), "At least one signature didn't pass verification", "added tx with corrupt signature")
 
 	// TODO set multisig and test
 
 	badTx = correctPay
 	badTx.Sender = sinkAddr
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "sink spent to non-sink address")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: cannot spend from fee sink's address", "sink spent to non-sink address")
 
 	badTx = correctPay
 	badTx.Sender = sinkAddr
 	badTx.CloseRemainderTo = addrList[0]
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "sink closed to non-sink address")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: cannot spend from fee sink's address", "sink closed to non-sink address")
 
 	badTx = correctPay
 	badTx.Sender = sinkAddr
 	badTx.Receiver = poolAddr
 	badTx.CloseRemainderTo = addrList[0]
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "sink closed to non-sink address")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: cannot close fee sink", "sink closed to non-sink address")
 
 	badTx = correctPay
 	badTx.Sender = sinkAddr
 	badTx.CloseRemainderTo = poolAddr
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "sink closed to pool address")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: cannot spend from fee sink's address", "sink closed to pool address")
 
 	badTx = correctPay
 	remainder, overflow := basics.OSubA(initAccounts[badTx.Sender].MicroAlgos, badTx.Amount)
@@ -678,7 +678,7 @@ func TestLedgerSingleTx(t *testing.T) {
 	fee, overflow = basics.OAddA(remainder, basics.MicroAlgos{Raw: 1})
 	a.False(overflow)
 	badTx.Fee = fee
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "overspent with (amount + fee)")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "overspend", "overspent with (amount + fee)")
 
 	adClose := ad
 	adClose.ClosingAmount = initAccounts[correctClose.Sender].MicroAlgos
@@ -695,7 +695,7 @@ func TestLedgerSingleTx(t *testing.T) {
 	correctPay.Receiver = poolAddr
 	a.NoError(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPay, ad), "could not spend from sink to pool")
 
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctKeyreg, ad), "added duplicate tx")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctKeyreg, ad), "transaction already in ledger", "added duplicate tx")
 }
 
 func TestLedgerSingleTxV24(t *testing.T) {
@@ -1246,68 +1246,68 @@ func testLedgerSingleTxApplyData(t *testing.T, version protocol.ConsensusVersion
 
 	badTx = correctPay
 	badTx.GenesisID = "invalid"
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx with invalid genesis ID")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "tx.GenesisID <invalid> does not match expected", "added tx with invalid genesis ID")
 
 	badTx = correctPay
 	badTx.Type = "invalid"
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx with invalid tx type")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: unknown tx type invalid", "added tx with invalid tx type")
 
 	badTx = correctPay
 	badTx.KeyregTxnFields = correctKeyregFields
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added pay tx with keyreg fields set")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: transaction of type pay has non-zero fields for type keyreg", "added pay tx with keyreg fields set")
 
 	badTx = correctKeyreg
 	badTx.PaymentTxnFields = correctPayFields
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added keyreg tx with pay fields set")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: transaction of type keyreg has non-zero fields for type pay", "added keyreg tx with pay fields set")
 
 	badTx = correctKeyreg
 	badTx.PaymentTxnFields = correctCloseFields
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added keyreg tx with pay (close) fields set")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: transaction of type keyreg has non-zero fields for type pay", "added keyreg tx with pay (close) fields set")
 
 	badTx = correctPay
 	badTx.FirstValid = badTx.LastValid + 1
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx with FirstValid > LastValid")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "txn dead: round 1 outside of 11--10", "added tx with FirstValid > LastValid")
 
 	badTx = correctPay
 	badTx.LastValid += basics.Round(proto.MaxTxnLife)
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx with overly long validity")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: transaction window size excessive (1--1010)", "added tx with overly long validity")
 
 	badTx = correctPay
 	badTx.LastValid = l.Latest()
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added expired tx")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "txn dead: round 1 outside of 1--0", "added expired tx")
 
 	badTx = correctPay
 	badTx.FirstValid = l.Latest() + 2
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx which is not valid yet")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "txn dead: round 1 outside of 2--10", "added tx which is not valid yet")
 
 	badTx = correctPay
 	badTx.Note = make([]byte, proto.MaxTxnNoteBytes+1)
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx with overly large note field")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: transaction note too big: 1025 > 1024", "added tx with overly large note field")
 
 	badTx = correctPay
 	badTx.Sender = basics.Address{}
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added tx send from zero address")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "malformed: transaction cannot close account to its sender", "added tx send from zero address")
 
 	badTx = correctPay
 	badTx.Fee = basics.MicroAlgos{}
-	a.Error(l.appendInvalidTx(t, initAccounts, initSecrets, badTx, ad), "added tx with zero fee")
+	a.ErrorContains(l.appendInvalidTx(t, initAccounts, initSecrets, badTx, ad), "fee", "added tx with zero fee")
 
 	badTx = correctPay
 	badTx.Fee = basics.MicroAlgos{Raw: proto.MinTxnFee - 1}
-	a.Error(l.appendInvalidTx(t, initAccounts, initSecrets, badTx, ad), "added tx with fee below minimum")
+	a.ErrorContains(l.appendInvalidTx(t, initAccounts, initSecrets, badTx, ad), "fee", "added tx with fee below minimum")
 
 	badTx = correctKeyreg
 	fee, overflow := basics.OAddA(initAccounts[badTx.Sender].MicroAlgos, basics.MicroAlgos{Raw: 1})
 	a.False(overflow)
 	badTx.Fee = fee
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "added keyreg tx with fee above user balance")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "overspend", "added keyreg tx with fee above user balance")
 
 	// TODO try excessive spending given distribution of some number of rewards
 
 	badTx = correctPay
 	sbadTx := sign(initSecrets, badTx)
 	sbadTx.Sig = crypto.Signature{}
-	a.Error(l.appendInvalidSignedTx(t, initAccounts, sbadTx, ad), "added tx with no signature")
+	a.ErrorContains(l.appendInvalidSignedTx(t, initAccounts, sbadTx, ad), "invalid : signedtxn has no sig", "added tx with no signature")
 
 	badTx = correctPay
 	remainder, overflow := basics.OSubA(initAccounts[badTx.Sender].MicroAlgos, badTx.Amount)
@@ -1315,7 +1315,7 @@ func testLedgerSingleTxApplyData(t *testing.T, version protocol.ConsensusVersion
 	fee, overflow = basics.OAddA(remainder, basics.MicroAlgos{Raw: 1})
 	a.False(overflow)
 	badTx.Fee = fee
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "overspent with (amount + fee)")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, badTx, ad), "overspend", "overspent with (amount + fee)")
 
 	adClose := ad
 	adClose.ClosingAmount = initAccounts[correctClose.Sender].MicroAlgos
@@ -1328,11 +1328,11 @@ func testLedgerSingleTxApplyData(t *testing.T, version protocol.ConsensusVersion
 	adCloseWrong.ClosingAmount.Raw++
 
 	a.NoError(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPay, ad), "could not add payment transaction")
-	a.Error(l.appendInvalidTx(t, initAccounts, initSecrets, correctClose, adCloseWrong), "closed transaction with wrong ApplyData")
+	a.ErrorContains(l.appendInvalidTx(t, initAccounts, initSecrets, correctClose, adCloseWrong), "applyData mismatch", "closed transaction with wrong ApplyData")
 	a.NoError(l.appendInvalidTx(t, initAccounts, initSecrets, correctClose, adClose), "could not add close transaction")
 	a.NoError(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctKeyreg, ad), "could not add key registration")
 
-	a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctKeyreg, ad), "added duplicate tx")
+	a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctKeyreg, ad), "transaction already in ledger", "added duplicate tx")
 
 	leaseReleaseRound := l.Latest() + 10
 	correctPayLease := correctPay
@@ -1345,7 +1345,7 @@ func testLedgerSingleTxApplyData(t *testing.T, version protocol.ConsensusVersion
 		correctPayLease.Note = make([]byte, 1)
 		correctPayLease.Note[0] = 1
 		correctPayLease.LastValid += 10
-		a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPayLease, ad), "added payment transaction with matching transaction lease")
+		a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPayLease, ad), "overlapping lease", "added payment transaction with matching transaction lease")
 		correctPayLeaseOther := correctPayLease
 		correctPayLeaseOther.Sender = addrList[4]
 		a.NoError(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPayLeaseOther, ad), "could not add payment transaction with matching lease but different sender")
@@ -1354,7 +1354,7 @@ func testLedgerSingleTxApplyData(t *testing.T, version protocol.ConsensusVersion
 		a.NoError(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPayLeaseOther, ad), "could not add payment transaction with matching sender but different lease")
 
 		for l.Latest() < leaseReleaseRound {
-			a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPayLease, ad), "added payment transaction with matching transaction lease")
+			a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPayLease, ad), "overlapping lease", "added payment transaction with matching transaction lease")
 
 			var totalRewardUnits uint64
 			for _, acctdata := range initAccounts {
@@ -1396,7 +1396,7 @@ func testLedgerSingleTxApplyData(t *testing.T, version protocol.ConsensusVersion
 
 		a.NoError(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPayLease, ad), "could not add payment transaction after lease was dropped")
 	} else {
-		a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPayLease, ad), "added payment transaction with transaction lease unsupported by protocol version")
+		a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPayLease, ad), "transaction tried to acquire lease", "added payment transaction with transaction lease unsupported by protocol version")
 	}
 }
 
@@ -1499,7 +1499,7 @@ func testLedgerRegressionFaultyLeaseFirstValidCheck2f3880f7(t *testing.T, versio
 	correctPayLease.LastValid = l.Latest() + 10
 
 	if proto.FixTransactionLeases {
-		a.Error(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPayLease, ad), "added payment transaction with overlapping lease")
+		a.ErrorContains(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPayLease, ad), "overlapping lease", "added payment transaction with overlapping lease")
 	} else {
 		a.NoError(l.appendUnvalidatedTx(t, initAccounts, initSecrets, correctPayLease, ad), "should allow leasing payment transaction with newer FirstValid")
 	}

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -90,7 +90,7 @@ func (h *ledgerTestBlockBuilder) appendUnvalidatedTx(t *testing.T, initAccounts 
 	return h.appendUnvalidatedSignedTx(t, initAccounts, stx, ad)
 }
 
-func initNextBlockHeader(correctHeader *bookkeeping.BlockHeader, lastBlock bookkeeping.Block, proto config.ConsensusParams) {
+func (h *ledgerTestBlockBuilder) initNextBlockHeader(correctHeader *bookkeeping.BlockHeader, lastBlock bookkeeping.Block, proto config.ConsensusParams) {
 	if proto.TxnCounter {
 		correctHeader.TxnCounter = lastBlock.TxnCounter
 	}
@@ -110,7 +110,7 @@ func initNextBlockHeader(correctHeader *bookkeeping.BlockHeader, lastBlock bookk
 
 // endOfBlock is simplified implementation of BlockEvaluator.endOfBlock so that
 // our test blocks can pass validation.
-func endOfBlock(blk *bookkeeping.Block) error {
+func (h *ledgerTestBlockBuilder) endOfBlock(blk *bookkeeping.Block) error {
 	if blk.ConsensusProtocol().Payouts.Enabled {
 		// This won't work for inner fees, and it's not bothering with overflow
 		for _, txn := range blk.Payset {
@@ -177,7 +177,7 @@ func (h *ledgerTestBlockBuilder) makeNewEmptyBlock(GenesisID string, initAccount
 		blk.BlockHeader.GenesisHash = crypto.Hash([]byte(GenesisID))
 	}
 
-	initNextBlockHeader(&blk.BlockHeader, lastBlock, proto)
+	h.initNextBlockHeader(&blk.BlockHeader, lastBlock, proto)
 
 	blk.RewardsPool = testPoolAddr
 	blk.FeeSink = testSinkAddr
@@ -208,7 +208,7 @@ func (h *ledgerTestBlockBuilder) appendUnvalidatedSignedTx(t *testing.T, initAcc
 	if proto.TxnCounter {
 		blk.TxnCounter = blk.TxnCounter + 1
 	}
-	require.NoError(t, endOfBlock(&blk))
+	require.NoError(t, h.endOfBlock(&blk))
 	return h.appendUnvalidated(blk)
 }
 
@@ -310,7 +310,7 @@ func TestLedgerBlockHeaders(t *testing.T) {
 			correctHeader.Branch512 = lastBlock.Hash512()
 		}
 
-		initNextBlockHeader(&correctHeader, lastBlock, proto)
+		l.initNextBlockHeader(&correctHeader, lastBlock, proto)
 
 		var badBlock bookkeeping.Block
 
@@ -1350,10 +1350,10 @@ func testLedgerSingleTxApplyData(t *testing.T, version protocol.ConsensusVersion
 				correctHeader.Branch512 = lastBlock.Hash512()
 			}
 
-			initNextBlockHeader(&correctHeader, lastBlock, proto)
+			l.initNextBlockHeader(&correctHeader, lastBlock, proto)
 
 			correctBlock := bookkeeping.Block{BlockHeader: correctHeader}
-			a.NoError(endOfBlock(&correctBlock))
+			a.NoError(l.endOfBlock(&correctBlock))
 
 			a.NoError(l.appendUnvalidated(correctBlock), "could not add block with correct header")
 		}


### PR DESCRIPTION
This pull request refactors and improves the ledger test utilities and error checking in transaction validation tests. The main changes introduce clearer separation between validated and intentionally invalid transaction paths, enhance error assertions to check specific error messages, and update block creation for deterministic test behavior. These improvements help make the tests more robust and easier to understand and maintain.

**Test utility refactoring and improvements:**

* Added new helper methods in `ledger/ledger_test.go` to allow explicit construction and addition of intentionally invalid transactions and blocks, such as `appendInvalidTx`, `appendInvalidSignedTx`, and `addBlockTxnsInvalid`. These bypass normal validation to facilitate negative test cases. [[1]](diffhunk://#diff-7954c85de04d018c6175f17de0ad7334034fdaf24160bd3e956911fbda50672eL193-R197) [[2]](diffhunk://#diff-7954c85de04d018c6175f17de0ad7334034fdaf24160bd3e956911fbda50672eL208-R225) [[3]](diffhunk://#diff-7954c85de04d018c6175f17de0ad7334034fdaf24160bd3e956911fbda50672eR238-R284)
* Refactored block creation in tests to ensure deterministic timestamps by incrementing from the previous block, improving reproducibility.
* Updated `addEmptyValidatedBlock` to use the new block evaluator pattern for consistency and clarity in block addition.

**Test assertion improvements:**

* Replaced generic error assertions with `ErrorContains` to check for specific error messages, making tests more precise and easier to debug. This applies to transaction validity checks throughout `TestLedgerSingleTx` and `testLedgerSingleTxApplyData`. [[1]](diffhunk://#diff-7954c85de04d018c6175f17de0ad7334034fdaf24160bd3e956911fbda50672eL523-R681) [[2]](diffhunk://#diff-7954c85de04d018c6175f17de0ad7334034fdaf24160bd3e956911fbda50672eL1198-R1318) [[3]](diffhunk://#diff-7954c85de04d018c6175f17de0ad7334034fdaf24160bd3e956911fbda50672eL1280-R1335) [[4]](diffhunk://#diff-7954c85de04d018c6175f17de0ad7334034fdaf24160bd3e956911fbda50672eL1297-R1348) [[5]](diffhunk://#diff-7954c85de04d018c6175f17de0ad7334034fdaf24160bd3e956911fbda50672eL640-R698)

**Compatibility and maintenance:**

* Updated imports in `ledger/ledger_test.go` to include the `committee` package, supporting new block proposer logic in the refactored test helpers.

**Minor compatibility fix:**

* In `ledger/applications_test.go`, updated a call from `appendUnvalidatedTx` to `appendInvalidTx` to use the new helper for constructing invalid application call transactions.