### PR TITLE
agreement: use specific error assertions in tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,8 @@ linters:
     - staticcheck
     - testifylint
     - unused
-  
+    - forbidigo
+
   settings:
     dupword:
       comments-only: true
@@ -101,6 +102,11 @@ linters:
       enable:
         - error-is-as
       disable-all: true
+    forbidigo:
+      forbid:
+        - p: ^(require|assert)\.Error$
+          pkg: ^github\.com/stretchr/testify/(require|assert)$
+          msg: use ErrorContains, ErrorIs, or ErrorAs instead
 
   exclusions:
     generated: lax
@@ -147,6 +153,8 @@ linters:
         text: '^empty-block: this block is empty, you can remove it'
       - linters: revive
         text: '^superfluous-else: if block ends with .* so drop this else and outdent its block'
+      - linters: forbidigo
+        path-except: ^agreement/
 
 issues:
   # Work our way back over time to be clean against all these

--- a/agreement/bundle_test.go
+++ b/agreement/bundle_test.go
@@ -90,7 +90,7 @@ func TestBundleCreationWithZeroVotes(t *testing.T) {
 		makeBundlePanicWrapper(t, "makeBundle: no votes present in bundle (len(equivocationVotes) =", proposal, votes, nil)
 
 		bundle, err := ub.verify(context.Background(), ledger, avv)
-		require.Error(t, err)
+		require.ErrorContains(t, err, `unauthenticatedBundle.verify: b.Step = 0`)
 
 		bundles = append(bundles, bundle)
 	}
@@ -248,38 +248,38 @@ func TestBundleCreationWithEquivocationVotes(t *testing.T) {
 	voteBadCredBundle := unauthenticatedBundles[0]
 	voteBadCredBundle.Votes[0].Cred = committee.UnauthenticatedCredential{}
 	_, err := voteBadCredBundle.verify(context.Background(), ledger, avv)
-	require.Error(t, err)
+	require.ErrorContains(t, err, `sender was not selected`)
 
 	voteBadSenderBundle := unauthenticatedBundles[1]
 	voteBadSenderBundle.Votes[0].Sender = basics.Address{}
 	_, err = voteBadSenderBundle.verify(context.Background(), ledger, avv)
-	require.Error(t, err)
+	require.ErrorContains(t, err, `could not verify FS signature`)
 
 	voteNoQuorumBundle := unauthenticatedBundles[2]
 	voteNoQuorumBundle.Votes = voteNoQuorumBundle.Votes[:2]
 	voteNoQuorumBundle.EquivocationVotes = voteNoQuorumBundle.EquivocationVotes[:2]
 	_, err = voteNoQuorumBundle.verify(context.Background(), ledger, avv)
-	require.Error(t, err)
+	require.ErrorContains(t, err, `bundle: did not see enough votes: 1`)
 
 	evBadCredBundle := unauthenticatedBundles[3]
 	evBadCredBundle.EquivocationVotes[0].Cred = committee.UnauthenticatedCredential{}
 	_, err = evBadCredBundle.verify(context.Background(), ledger, avv)
-	require.Error(t, err)
+	require.ErrorContains(t, err, `sender was not selected`)
 
 	evBadEVBundle := unauthenticatedBundles[4]
 	evBadEVBundle.EquivocationVotes[0].Sigs = [2]crypto.OneTimeSignature{{}, {}}
 	_, err = evBadEVBundle.verify(context.Background(), ledger, avv)
-	require.Error(t, err)
+	require.ErrorContains(t, err, `could not verify FS signature`)
 
 	duplicateVoteBundle := unauthenticatedBundles[5]
 	duplicateVoteBundle.Votes = append(duplicateVoteBundle.Votes, duplicateVoteBundle.Votes[0])
 	_, err = duplicateVoteBundle.verify(context.Background(), ledger, avv)
-	require.Error(t, err)
+	require.ErrorContains(t, err, `was duplicated in bundle`)
 
 	duplicateEquivocationVoteBundle := unauthenticatedBundles[6]
 	duplicateEquivocationVoteBundle.EquivocationVotes = append(duplicateEquivocationVoteBundle.EquivocationVotes, duplicateEquivocationVoteBundle.EquivocationVotes[0])
 	_, err = duplicateEquivocationVoteBundle.verify(context.Background(), ledger, avv)
-	require.Error(t, err)
+	require.ErrorContains(t, err, `was duplicated in bundle`)
 
 }
 

--- a/agreement/bundle_test.go
+++ b/agreement/bundle_test.go
@@ -89,8 +89,9 @@ func TestBundleCreationWithZeroVotes(t *testing.T) {
 		var ub unauthenticatedBundle
 		makeBundlePanicWrapper(t, "makeBundle: no votes present in bundle (len(equivocationVotes) =", proposal, votes, nil)
 
+		ub.Step = step(s)
 		bundle, err := ub.verify(context.Background(), ledger, avv)
-		require.ErrorContains(t, err, `unauthenticatedBundle.verify: b.Step = 0`)
+		require.ErrorContains(t, err, `bundle: did not see enough votes: 0`)
 
 		bundles = append(bundles, bundle)
 	}

--- a/agreement/certificate_test.go
+++ b/agreement/certificate_test.go
@@ -178,7 +178,7 @@ func TestCertificateBadCertificateWithFakeDoubleVote(t *testing.T) {
 
 	avv := MakeAsyncVoteVerifier(nil)
 	defer avv.Quit()
-	require.Error(t, cert.Authenticate(block, ledger, avv))
+	require.ErrorContains(t, cert.Authenticate(block, ledger, avv), `not an equivocation pair`)
 }
 
 func TestCertificateDifferentBlock(t *testing.T) {
@@ -204,12 +204,12 @@ func TestCertificateDifferentBlock(t *testing.T) {
 	bundle := unauthenticatedBundle(cert)
 	require.NotEqual(t, Certificate{}, cert)
 
-	require.Error(t, cert.claimsToAuthenticate(block))
+	require.ErrorContains(t, cert.claimsToAuthenticate(block), `certificate claims to validate the wrong hash`)
 
 	avv := MakeAsyncVoteVerifier(nil)
 	defer avv.Quit()
 	require.NoError(t, verifyBundleAgainstLedger(bundle, ledger, avv))
-	require.Error(t, cert.Authenticate(block, ledger, avv))
+	require.ErrorContains(t, cert.Authenticate(block, ledger, avv), `certificate claims to validate the wrong hash`)
 }
 
 func TestCertificateNoCertStep(t *testing.T) {
@@ -293,12 +293,12 @@ func TestCertificateCertWrongRound(t *testing.T) {
 	cert := makeCertTesting(block.Digest(), votes, equiVotes)
 	bundle := unauthenticatedBundle(cert)
 	require.NotEqual(t, Certificate{}, cert)
-	require.Error(t, cert.claimsToAuthenticate(block))
+	require.ErrorContains(t, cert.claimsToAuthenticate(block), `certificate claims to validate the wrong round: 1 != 0`)
 
 	avv := MakeAsyncVoteVerifier(nil)
 	defer avv.Quit()
 	require.NoError(t, verifyBundleAgainstLedger(bundle, ledger, avv))
-	require.Error(t, cert.Authenticate(block, ledger, avv))
+	require.ErrorContains(t, cert.Authenticate(block, ledger, avv), `certificate claims to validate the wrong round: 1 != 0`)
 }
 
 func TestCertificateCertWithTooFewVotes(t *testing.T) {
@@ -363,6 +363,6 @@ func TestCertificateDupVote(t *testing.T) {
 
 	avv := MakeAsyncVoteVerifier(nil)
 	defer avv.Quit()
-	require.Error(t, verifyBundleAgainstLedger(bundle, ledger, avv))
-	require.Error(t, cert.Authenticate(block, ledger, avv))
+	require.ErrorContains(t, verifyBundleAgainstLedger(bundle, ledger, avv), `was duplicated in bundle`)
+	require.ErrorContains(t, cert.Authenticate(block, ledger, avv), `was duplicated in bundle`)
 }

--- a/agreement/fuzzer/dropMessageFilter_test.go
+++ b/agreement/fuzzer/dropMessageFilter_test.go
@@ -18,6 +18,7 @@ package fuzzer
 
 import (
 	"encoding/json"
+
 	"github.com/algorand/go-algorand/protocol"
 )
 

--- a/agreement/fuzzer/messageDelayFilter_test.go
+++ b/agreement/fuzzer/messageDelayFilter_test.go
@@ -19,6 +19,7 @@ package fuzzer
 import (
 	"container/heap"
 	"encoding/json"
+
 	"github.com/algorand/go-deadlock"
 
 	"github.com/algorand/go-algorand/protocol"

--- a/agreement/fuzzer/messagePriorityQueue_test.go
+++ b/agreement/fuzzer/messagePriorityQueue_test.go
@@ -18,6 +18,7 @@ package fuzzer
 
 import (
 	"container/heap"
+
 	"github.com/algorand/go-algorand/protocol"
 )
 

--- a/agreement/proposalTracker_test.go
+++ b/agreement/proposalTracker_test.go
@@ -77,7 +77,8 @@ func TestProposalTrackerProposalSeeker(t *testing.T) {
 	assert.Equal(t, s.Lowest, s.lowestIncludingLate)
 
 	s, effect, err = s.accept(votes[3])
-	assert.ErrorContains(t, err, `proposalSeeker.accept: credential from`)
+	var errProposalSeekerNotLess errProposalSeekerNotLess
+	assert.ErrorAs(t, err, &errProposalSeekerNotLess)
 	assert.Equal(t, effect, NoLateCredentialTrackingImpact)
 	assert.False(t, s.Frozen)
 	assert.True(t, s.Filled)
@@ -103,7 +104,8 @@ func TestProposalTrackerProposalSeeker(t *testing.T) {
 	assert.Equal(t, s.Lowest, s.lowestIncludingLate)
 
 	s, effect, err = s.accept(votes[0])
-	assert.ErrorContains(t, err, `proposalSeeker.accept: seeker is already frozen`)
+	var errProposalSeekerFrozen errProposalSeekerFrozen
+	assert.ErrorAs(t, err, &errProposalSeekerFrozen)
 	assert.Equal(t, effect, VerifiedBetterLateCredentialForTracking)
 	assert.Equal(t, s.Lowest, lowestBeforeFreeze)
 	assert.True(t, s.Frozen)

--- a/agreement/proposalTracker_test.go
+++ b/agreement/proposalTracker_test.go
@@ -77,7 +77,7 @@ func TestProposalTrackerProposalSeeker(t *testing.T) {
 	assert.Equal(t, s.Lowest, s.lowestIncludingLate)
 
 	s, effect, err = s.accept(votes[3])
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, `proposalSeeker.accept: credential from`)
 	assert.Equal(t, effect, NoLateCredentialTrackingImpact)
 	assert.False(t, s.Frozen)
 	assert.True(t, s.Filled)
@@ -103,7 +103,7 @@ func TestProposalTrackerProposalSeeker(t *testing.T) {
 	assert.Equal(t, s.Lowest, s.lowestIncludingLate)
 
 	s, effect, err = s.accept(votes[0])
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, `proposalSeeker.accept: seeker is already frozen`)
 	assert.Equal(t, effect, VerifiedBetterLateCredentialForTracking)
 	assert.Equal(t, s.Lowest, lowestBeforeFreeze)
 	assert.True(t, s.Frozen)

--- a/agreement/proposal_test.go
+++ b/agreement/proposal_test.go
@@ -147,10 +147,10 @@ func TestProposalFunctions(t *testing.T) {
 		require.NoError(t, err)
 
 		err = proposalValue.matches(encDigest, encDigest)
-		require.Error(t, err)
+		require.ErrorContains(t, err, `proposal block digest mismatches payload`)
 
 		err = proposalValue.matches(digest, digest)
-		require.Error(t, err)
+		require.ErrorContains(t, err, `proposal encoding digest mismatches payload`)
 
 	}
 }
@@ -182,7 +182,7 @@ func TestProposalUnauthenticated(t *testing.T) {
 
 	// test bad round number
 	proposal, err = unauthenticatedProposal.validate(context.Background(), round+1, ledger, validator)
-	require.Error(t, err)
+	require.ErrorContains(t, err, `proposed entry from wrong round: entry.Round() != current: 1 != 2`)
 	proposal, err = unauthenticatedProposal.validate(context.Background(), round, ledger, validator)
 	require.NotNil(t, proposal)
 	require.NoError(t, err)
@@ -200,7 +200,7 @@ func TestProposalUnauthenticated(t *testing.T) {
 	unauthenticatedProposal3 := proposal3.u()
 	unauthenticatedProposal3.SeedProof = unauthenticatedProposal.SeedProof
 	_, err = unauthenticatedProposal3.validate(context.Background(), round, ledger, validator)
-	require.Error(t, err)
+	require.ErrorContains(t, err, `unable to verify header: seed proof malformed (`)
 
 	// validate mismatch proposer address between block and unauthenticatedProposal
 	proposal4, _, _ := proposalForBlock(accounts.addresses[accountIndex], accounts.vrfs[accountIndex], testBlockFactory, period, ledger)

--- a/agreement/pseudonode_test.go
+++ b/agreement/pseudonode_test.go
@@ -174,7 +174,7 @@ func TestPseudonode(t *testing.T) {
 		}
 		channels = append(channels, ch)
 	}
-	assert.Error(t, err, "MakeProposals did not returned an error when being overflowed with requests")
+	assert.ErrorContains(t, err, `pseudonode input channel is full`, "MakeProposals did not returned an error when being overflowed with requests")
 
 	persist := make(chan error)
 	close(persist)
@@ -186,7 +186,7 @@ func TestPseudonode(t *testing.T) {
 		}
 		channels = append(channels, ch)
 	}
-	assert.Error(t, err, "MakeVotes did not returned an error when being overflowed with requests")
+	assert.ErrorContains(t, err, `pseudonode input channel is full`, "MakeVotes did not returned an error when being overflowed with requests")
 
 	// drain output channels.
 	for _, ch := range channels {
@@ -525,7 +525,6 @@ func TestPseudonodeNonEnqueuedTasks(t *testing.T) {
 		channels = append(channels, ch)
 	}
 	enqueuedProposals := len(channels)
-	require.Error(t, err, "MakeProposals did not returned an error when being overflowed with requests")
 	require.ErrorIs(t, err, errPseudonodeBacklogFull)
 
 	persist := make(chan error)
@@ -538,7 +537,7 @@ func TestPseudonodeNonEnqueuedTasks(t *testing.T) {
 		}
 		channels = append(channels, ch)
 	}
-	require.Error(t, err, "MakeVotes did not returned an error when being overflowed with requests")
+	require.ErrorContains(t, err, `pseudonode input channel is full`, "MakeVotes did not returned an error when being overflowed with requests")
 	enqueuedVotes := len(channels) - enqueuedProposals
 	// drain output channels.
 	for _, ch := range channels {

--- a/agreement/pseudonode_test.go
+++ b/agreement/pseudonode_test.go
@@ -537,7 +537,7 @@ func TestPseudonodeNonEnqueuedTasks(t *testing.T) {
 		}
 		channels = append(channels, ch)
 	}
-	require.ErrorContains(t, err, `pseudonode input channel is full`, "MakeVotes did not returned an error when being overflowed with requests")
+	require.ErrorIs(t, err, errPseudonodeBacklogFull, "MakeVotes did not returned an error when being overflowed with requests")
 	enqueuedVotes := len(channels) - enqueuedProposals
 	// drain output channels.
 	for _, ch := range channels {

--- a/agreement/vote_test.go
+++ b/agreement/vote_test.go
@@ -113,37 +113,37 @@ func TestVoteValidation(t *testing.T) {
 			noSig := unauthenticatedVote
 			noSig.Sig = crypto.OneTimeSignature{}
 			_, err = noSig.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `could not verify FS signature`)
 
 			noCred := unauthenticatedVote
 			noCred.Cred = committee.UnauthenticatedCredential{}
 			_, err = noCred.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `sender was not selected`)
 
 			badRound := unauthenticatedVote
 			badRound.R.Round++
 			_, err = badRound.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `could not verify FS signature`)
 
 			badPeriod := unauthenticatedVote
 			badPeriod.R.Period++
 			_, err = badPeriod.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `could not verify FS signature`)
 
 			badStep := unauthenticatedVote
 			badStep.R.Step++
 			_, err = badStep.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `could not verify FS signature`)
 
 			badBlockHash := unauthenticatedVote
 			badBlockHash.R.Proposal.BlockDigest = randomBlockHash()
 			_, err = badBlockHash.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `could not verify FS signature`)
 
 			badProposer := unauthenticatedVote
 			badProposer.R.Proposal.OriginalProposer = basics.Address(randomBlockHash())
 			_, err = badProposer.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `could not verify FS signature`)
 		}
 	}
 	require.True(t, processedVote, "No votes were processed")
@@ -194,7 +194,7 @@ func TestVoteReproposalValidation(t *testing.T) {
 			badReproposalVote, err := makeVote(rv, otSecrets[i], vrfSecrets[i], ledger)
 			require.NoError(t, err)
 			_, err = badReproposalVote.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `unauthenticatedVote.verify: proposal-vote sender mismatches with proposal-value`)
 
 			// bad period-1 reproposal for a period 2 original proposal
 			rv = rawVote{Sender: address, Round: round, Period: per, Step: step(0), Proposal: proposal}
@@ -203,7 +203,7 @@ func TestVoteReproposalValidation(t *testing.T) {
 			badReproposalVote, err = makeVote(rv, otSecrets[i], vrfSecrets[i], ledger)
 			require.NoError(t, err)
 			_, err = badReproposalVote.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `unauthenticatedVote.verify: proposal-vote in period 1 claims to repropose block from future period 2`)
 		}
 	}
 	require.True(t, processedVote, "No votes were processed")
@@ -274,7 +274,7 @@ func TestVoteValidationStepCertAndProposalBottom(t *testing.T) {
 			unauthenticatedVote.R.Step = cert
 			unauthenticatedVote.R.Proposal = bottom
 			_, err = unauthenticatedVote.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `unauthenticatedVote.verify: votes from step 2 cannot validate bottom`)
 
 		}
 	}
@@ -343,7 +343,7 @@ func TestEquivocationVoteValidation(t *testing.T) {
 
 			// check for same vote
 			_, err = evSameVote.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `isEquivocationPair: not an equivocation pair: identical vote (block hash`)
 
 			// test vote accessors
 			v0 := aev.v0()
@@ -357,42 +357,42 @@ func TestEquivocationVoteValidation(t *testing.T) {
 			noSig := ev
 			noSig.Sigs = [2]crypto.OneTimeSignature{{}, {}}
 			_, err = noSig.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `could not verify FS signature`)
 
 			noCred := ev
 			noCred.Cred = committee.UnauthenticatedCredential{}
 			_, err = noCred.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `sender was not selected`)
 
 			badRound := ev
 			badRound.Round++
 			_, err = badRound.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `could not verify FS signature`)
 
 			badPeriod := ev
 			badPeriod.Period++
 			_, err = badPeriod.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `could not verify FS signature`)
 
 			badStep := ev
 			badStep.Step++
 			_, err = badStep.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `could not verify FS signature`)
 
 			badBlockHash1 := ev
 			badBlockHash1.Proposals[0].BlockDigest = randomBlockHash()
 			_, err = badBlockHash1.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `could not verify FS signature`)
 
 			badBlockHash2 := ev
 			badBlockHash2.Proposals[1].BlockDigest = randomBlockHash()
 			_, err = badBlockHash2.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `could not verify FS signature`)
 
 			badSender := ev
 			badSender.Sender = basics.Address{}
 			_, err = badSender.verify(ledger)
-			require.Error(t, err)
+			require.ErrorContains(t, err, `unauthenticatedEquivocationVote.verify: failed to verify pair 0: unauthenticatedVote.verify: could not verify FS signature on vote by AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ given`)
 		}
 	}
 	require.True(t, processedVote, "No votes were processed")


### PR DESCRIPTION
## Summary

Replace bare `require.Error`/`assert.Error` calls with `ErrorContains` in agreement tests. This ensures tests verify the actual error message, not just that some error occurred.

Also adds a `forbidigo` lint rule to prevent `require.Error`/`assert.Error` in `agreement/` going forward. Split off from #6512 to make review easier.

## Test Plan

Existing tests should pass with the new, more precise error assertions.