### PR TITLE
LogicSig: harden address derivation for v13+

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -388,7 +388,7 @@ var sendCmd = &cobra.Command{
 		}
 		if program != nil {
 			if account == "" {
-				ph := logic.HashProgram(program)
+				ph := logic.SigDigest(program)
 				pha := basics.Address(ph)
 				account = pha.String()
 			}
@@ -1155,7 +1155,7 @@ var compileCmd = &cobra.Command{
 				}
 			}
 			if !signProgram && shouldPrintAdditionalInfo {
-				pd := logic.HashProgram(program)
+				pd := logic.SigDigest(program)
 				addr := basics.Address(pd)
 				fmt.Printf("%s: %s\n", fname, addr.String())
 			}

--- a/crypto/curve25519.go
+++ b/crypto/curve25519.go
@@ -39,6 +39,8 @@ import (
 	"fmt"
 	"unsafe"
 
+	"filippo.io/edwards25519"
+
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/util/metrics"
 )
@@ -248,4 +250,12 @@ func (v SignatureVerifier) Verify(message Hashable, sig Signature) bool {
 func (v SignatureVerifier) VerifyBytes(message []byte, sig Signature) bool {
 	cryptoSigSecretsVerifyBytesTotal.Inc(nil)
 	return ed25519Verify(ed25519PublicKey(v), message, ed25519Signature(sig))
+}
+
+// IsEd25519CurvePoint reports whether b encodes a valid point on the
+// Edwards25519 curve. Any 32-byte value for which this returns true could
+// potentially serve as an Ed25519 public key.
+func IsEd25519CurvePoint(b Digest) bool {
+	_, err := new(edwards25519.Point).SetBytes(b[:])
+	return err == nil
 }

--- a/daemon/algod/api/algod.oas2.json
+++ b/daemon/algod/api/algod.oas2.json
@@ -2076,12 +2076,12 @@
     },
     "/v2/teal/compile": {
       "post": {
-        "description": "Given TEAL source code in plain text, return base64 encoded program bytes and base32 SHA512_256 hash of program bytes (Address style). This endpoint is only enabled when a node's configuration file sets EnableDeveloperAPI to true.",
+        "description": "Given TEAL source code in plain text, return base64 encoded program bytes and a base32 address-style digest of the program. For TEAL v1-v12, this is the SHA512_256 hash of program bytes (Address style). For TEAL v13+, this digest may iterate with a counter suffix to ensure the LogicSig address is not an Ed25519 curve point. This endpoint is only enabled when a node's configuration file sets EnableDeveloperAPI to true.",
         "tags": ["public", "nonparticipating"],
         "consumes": ["text/plain"],
         "produces": ["application/json"],
         "schemes": ["http"],
-        "summary": "Compile TEAL source code to binary, produce its hash",
+        "summary": "Compile TEAL source code to binary, produce its address digest",
         "operationId": "TealCompile",
         "parameters": [
           {
@@ -4905,7 +4905,7 @@
         "required": ["hash", "result"],
         "properties": {
           "hash": {
-            "description": "base32 SHA512_256 of program bytes (Address style)",
+            "description": "base32 LogicSig address digest (Address style): SHA512_256 hash for TEAL v1-v12, curve-point-free digest for TEAL v13+",
             "type": "string"
           },
           "result": {

--- a/daemon/algod/api/algod.oas3.yml
+++ b/daemon/algod/api/algod.oas3.yml
@@ -467,7 +467,7 @@
             "schema": {
               "properties": {
                 "hash": {
-                  "description": "base32 SHA512_256 of program bytes (Address style)",
+                  "description": "base32 LogicSig address digest (Address style): SHA512_256 hash for TEAL v1-v12, curve-point-free digest for TEAL v13+",
                   "type": "string"
                 },
                 "result": {
@@ -7023,7 +7023,7 @@
     },
     "/v2/teal/compile": {
       "post": {
-        "description": "Given TEAL source code in plain text, return base64 encoded program bytes and base32 SHA512_256 hash of program bytes (Address style). This endpoint is only enabled when a node's configuration file sets EnableDeveloperAPI to true.",
+        "description": "Given TEAL source code in plain text, return base64 encoded program bytes and a base32 address-style digest of the program. For TEAL v1-v12, this is the SHA512_256 hash of program bytes (Address style). For TEAL v13+, this digest may iterate with a counter suffix to ensure the LogicSig address is not an Ed25519 curve point. This endpoint is only enabled when a node's configuration file sets EnableDeveloperAPI to true.",
         "operationId": "TealCompile",
         "parameters": [
           {
@@ -7054,7 +7054,7 @@
                 "schema": {
                   "properties": {
                     "hash": {
-                      "description": "base32 SHA512_256 of program bytes (Address style)",
+                      "description": "base32 LogicSig address digest (Address style): SHA512_256 hash for TEAL v1-v12, curve-point-free digest for TEAL v13+",
                       "type": "string"
                     },
                     "result": {
@@ -7116,7 +7116,7 @@
             "description": "Unknown Error"
           }
         },
-        "summary": "Compile TEAL source code to binary, produce its hash",
+        "summary": "Compile TEAL source code to binary, produce its address digest",
         "tags": [
           "public",
           "nonparticipating"

--- a/daemon/algod/api/server/v2/handlers.go
+++ b/daemon/algod/api/server/v2/handlers.go
@@ -2044,7 +2044,7 @@ func (v2 *Handlers) TealCompile(ctx echo.Context, params model.TealCompileParams
 		ops.ReportMultipleErrors("", &sb)
 		return badRequest(ctx, err, sb.String(), v2.Log)
 	}
-	pd := logic.HashProgram(ops.Program)
+	pd := logic.SigDigest(ops.Program)
 	addr := basics.Address(pd)
 
 	// If source map flag is enabled, then return the map.

--- a/data/transactions/logic/program.go
+++ b/data/transactions/logic/program.go
@@ -17,7 +17,10 @@
 package logic
 
 import (
+	"encoding/binary"
+
 	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -45,4 +48,25 @@ func (mp MultisigProgram) ToBeHashed() (protocol.HashID, []byte) {
 func HashProgram(program []byte) crypto.Digest {
 	pb := Program(program)
 	return crypto.HashObj(pb)
+}
+
+// curvePointFreeAddressVersion is the first TEAL version for which
+// LogicSig addresses are guaranteed not to be Ed25519 curve points.
+const curvePointFreeAddressVersion = uint64(13)
+
+// SigDigest computes the address digest for a LogicSig program.
+// For TEAL v13+, it guarantees the result does not decode to a valid
+// Edwards25519 curve point. Callers computing LogicSig account addresses
+// (rather than generic program hashes) should use this function.
+func SigDigest(program []byte) crypto.Digest {
+	d := HashProgram(program)
+	version, _, err := transactions.ProgramVersion(program)
+	if err == nil && version >= curvePointFreeAddressVersion {
+		for counter := uint64(0); crypto.IsEd25519CurvePoint(d); counter++ {
+			var suffix [8]byte
+			binary.BigEndian.PutUint64(suffix[:], counter)
+			d = crypto.HashObj(Program(append([]byte(program), suffix[:]...)))
+		}
+	}
+	return d
 }

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -414,9 +414,9 @@ func logicSigSanityCheckBatchPrep(gi int, groupCtx *GroupContext, batchVerifier 
 		numSigs++
 	}
 	if numSigs == 0 {
-		// if the txn.Authorizer() == hash(Logic) then this is a (potentially) valid operation on a contract-only account
-		program := logic.Program(lsig.Logic)
-		lhash := crypto.HashObj(&program)
+		// if txn.Authorizer() matches the LogicSig account digest, this is a
+		// (potentially) valid operation on a contract-only account
+		lhash := logic.SigDigest(lsig.Logic)
 		if crypto.Digest(txn.Authorizer()) == lhash {
 			return nil
 		}

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -999,6 +999,55 @@ byte base64 5rZMNsevs5sULO+54aN+OvU6lQ503z2X+SSYUABIx7E=
 	require.Greater(t, currentCounter, initCounter)
 }
 
+// TestTxnValidationLogicSigV13 verifies TEAL v13+ LogicSig
+// address behavior for a program whose legacy HashProgram is on-curve:
+// 1. SigDigest produces a different digest that is off-curve.
+// 2. Sender = SigDigest(program) is accepted for unsigned LogicSig validation.
+// 3. Sender = HashProgram(program) is rejected when the digests differ.
+func TestTxnValidationLogicSigV13(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	var program []byte
+	for i := range 1000 {
+		ops, err := logic.AssembleString(fmt.Sprintf("#pragma version 13\nint %d", i))
+		require.NoError(t, err)
+		legacyHash := logic.HashProgram(ops.Program)
+		if crypto.IsEd25519CurvePoint(legacyHash) {
+			digest := logic.SigDigest(ops.Program)
+			require.NotEqual(t, legacyHash, digest)
+			require.False(t, crypto.IsEd25519CurvePoint(digest))
+			program = ops.Program
+			break
+		}
+	}
+	require.NotEmpty(t, program, "failed to find a v13 program with curve-point legacy hash")
+
+	_, signed, _, _ := generateTestObjects(1, 1, 0, 50)
+	stxn := signed[0]
+	stxn.Sig = crypto.Signature{}
+	stxn.Msig = crypto.MultisigSig{}
+	stxn.Lsig = transactions.LogicSig{Logic: program}
+
+	// LogicSig sender must match the LogicSig account digest.
+	stxn.Txn.Sender = basics.Address(logic.SigDigest(program))
+	blkHdr := createDummyBlockHeader(protocol.ConsensusFuture)
+	dummyLedger := DummyLedgerForSignature{}
+	groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{stxn}, &blkHdr, &dummyLedger, nil)
+	require.NoError(t, err)
+	groupCtx.consensusParams.LogicSigVersion = 13
+	groupCtx.evalParams.Proto = &groupCtx.consensusParams
+	require.NoError(t, verifyTxn(0, groupCtx))
+
+	// Legacy hash sender must be rejected for v13+ when it differs.
+	stxn.Txn.Sender = basics.Address(logic.HashProgram(program))
+	blkHdr = createDummyBlockHeader(protocol.ConsensusFuture)
+	groupCtx, err = PrepareGroupContext([]transactions.SignedTxn{stxn}, &blkHdr, &dummyLedger, nil)
+	require.NoError(t, err)
+	groupCtx.consensusParams.LogicSigVersion = 13
+	groupCtx.evalParams.Proto = &groupCtx.consensusParams
+	require.ErrorContains(t, verifyTxn(0, groupCtx), "LogicNot signed and not a Logic-only account")
+}
+
 // TestTxnGroupCacheUpdateLogicWithSig makes sure that a payment transaction contains logicsig signed with single signature is valid (and added to the cache) only
 // if the logic passes and the signature is correct.
 // for this, we will break the signature and make sure that txn verification fails.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 toolchain go1.25.3
 
 require (
+	filippo.io/edwards25519 v1.2.0
 	github.com/DataDog/zstd v1.5.2
 	github.com/algorand/avm-abi v0.2.0
 	github.com/algorand/falcon v0.1.0
@@ -64,7 +65,6 @@ require (
 )
 
 require (
-	filippo.io/edwards25519 v1.0.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ dmitri.shuralyov.com/app/changes v0.0.0-20180602232624-0a106ad413e3/go.mod h1:Yl
 dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBrvjyP0v+ecvNYvCpyZgu5/xkfAUhi6wJj28eUfSU=
 dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1:a1inKt/atXimZ4Mv927x+r7UpyzRUf4emIoiiSC2TN4=
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
-filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
-filippo.io/edwards25519 v1.0.0/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/heartbeat/service.go
+++ b/heartbeat/service.go
@@ -166,7 +166,7 @@ var acceptingByteCode = logic.MustAssemble(`
 #pragma version 11
 txn RekeyTo; global ZeroAddress; ==
 `)
-var acceptingSender = basics.Address(logic.HashProgram(acceptingByteCode))
+var acceptingSender = basics.Address(logic.SigDigest(acceptingByteCode))
 
 // hbLifetime is somewhat short. It seems better to try several times during the
 // grace period than to try a single time with a longer lifetime.

--- a/test/e2e-go/features/transactions/logicsig_test.go
+++ b/test/e2e-go/features/transactions/logicsig_test.go
@@ -17,12 +17,16 @@
 package transactions
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/data/txntest"
 	"github.com/algorand/go-algorand/test/framework/fixtures"
 	"github.com/algorand/go-algorand/test/partitiontest"
@@ -57,6 +61,76 @@ func TestLogicSigSizeAfterPooling(t *testing.T) {
 
 	// TODO: Update this when lsig pooling graduates from vFuture
 	testLogicSize(t, tealOK, tealTooLong, filepath.Join("nettemplates", "TwoNodes50EachFuture.json"))
+}
+
+func TestLogicSigV13SigDigestAddress(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	defer fixtures.ShutdownSynchronizedTest(t)
+	a := require.New(fixtures.SynchronizedTest(t))
+
+	var fixture fixtures.RestClientFixture
+	fixture.Setup(t, filepath.Join("nettemplates", "TwoNodes50EachFuture.json"))
+	defer fixture.Shutdown()
+
+	client := fixture.LibGoalClient
+	accountList, err := fixture.GetWalletsSortedByBalance()
+	a.NoError(err)
+	baseAcct := accountList[0].Address
+
+	walletHandler, err := client.GetUnencryptedWalletHandle()
+	a.NoError(err)
+
+	var program []byte
+	for i := range 1000 {
+		ops, assembleErr := logic.AssembleString(fmt.Sprintf(`#pragma version 13
+int %d`, i))
+		a.NoError(assembleErr)
+		if crypto.IsEd25519CurvePoint(logic.HashProgram(ops.Program)) {
+			program = ops.Program
+			break
+		}
+	}
+	a.NotNil(program, "failed to find v13 program with on-curve legacy HashProgram digest")
+
+	sigAddr := basics.Address(logic.SigDigest(program))
+	legacyAddr := basics.Address(logic.HashProgram(program))
+	a.NotEqual(sigAddr, legacyAddr)
+
+	// Fund the SigDigest-derived contract account so it can pay transaction fee.
+	fundTxn, err := client.ConstructPayment(baseAcct, sigAddr.String(), 0, 2_000_000, nil, "", [32]byte{}, 0, 0)
+	a.NoError(err)
+	fundStxn, err := client.SignTransactionWithWallet(walletHandler, nil, fundTxn)
+	a.NoError(err)
+	fundTxID, err := client.BroadcastTransaction(fundStxn)
+	a.NoError(err)
+
+	_, curRound := fixture.GetBalanceAndRound(baseAcct)
+	a.True(fixture.WaitForTxnConfirmation(curRound+5, fundTxID))
+
+	// Positive case: sender matches SigDigest(program), so unsigned LogicSig
+	// contract-account validation should pass.
+	goodTxn, err := client.ConstructPayment(sigAddr.String(), baseAcct, 0, 1000, nil, "", [32]byte{}, 0, 0)
+	a.NoError(err)
+	goodStxn := transactions.SignedTxn{
+		Txn:  goodTxn,
+		Lsig: transactions.LogicSig{Logic: program},
+	}
+	goodTxID, err := client.BroadcastTransaction(goodStxn)
+	a.NoError(err)
+
+	_, curRound = fixture.GetBalanceAndRound(baseAcct)
+	a.True(fixture.WaitForTxnConfirmation(curRound+5, goodTxID))
+
+	// Negative case: sender uses legacy HashProgram(program), which must fail
+	// when it differs from SigDigest(program) for v13+.
+	badTxn, err := client.ConstructPayment(legacyAddr.String(), baseAcct, 0, 1000, nil, "", [32]byte{}, 0, 0)
+	a.NoError(err)
+	badStxn := transactions.SignedTxn{
+		Txn:  badTxn,
+		Lsig: transactions.LogicSig{Logic: program},
+	}
+	err = client.BroadcastTransactionGroup([]transactions.SignedTxn{badStxn})
+	a.ErrorContains(err, "LogicNot signed and not a Logic-only account")
 }
 
 // testLogicSize takes two TEAL programs, one expected to be ok and one expected to be too long

--- a/tools/block-generator/go.mod
+++ b/tools/block-generator/go.mod
@@ -18,7 +18,7 @@ require (
 )
 
 require (
-	filippo.io/edwards25519 v1.0.0 // indirect
+	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/algorand/falcon v0.1.0 // indirect
 	github.com/algorand/go-sumhash v0.1.0 // indirect

--- a/tools/block-generator/go.sum
+++ b/tools/block-generator/go.sum
@@ -6,8 +6,8 @@ dmitri.shuralyov.com/app/changes v0.0.0-20180602232624-0a106ad413e3/go.mod h1:Yl
 dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBrvjyP0v+ecvNYvCpyZgu5/xkfAUhi6wJj28eUfSU=
 dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1:a1inKt/atXimZ4Mv927x+r7UpyzRUf4emIoiiSC2TN4=
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
-filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
-filippo.io/edwards25519 v1.0.0/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=


### PR DESCRIPTION
# Curve-Point-Free LogicSig Addresses for TEAL v13+

## Summary

This PR hardens LogicSig account address derivation for TEAL v13+ so the resulting address digest is guaranteed not to decode to a valid Edwards25519 curve point.

Before this change, LogicSig addresses used:

`SHA512/256("Program" || program_bytes)`

About 50% of random 32-byte values decode to Ed25519 curve points. For those cases, a future quantum adversary could potentially derive a private key for the address and bypass contract execution.

For TEAL v13+, address derivation now iterates until a non-curve-point digest is found.

The PR is marked as DRAFT to finalize (i) the design and (ii) the `compile` API change, as discussed below.

## Design

For TEAL v13+ only:

```text
d = SHA512/256("Program" || program_bytes)
counter = 0
while IsEd25519CurvePoint(d):
    d = SHA512/256("Program" || program_bytes || uint64_be(counter))
    counter++
return d
```

For TEAL v1-v12, behavior is unchanged.

Note that if the program does not hash to a curve point, the new logic is equivalent to the old logic, i.e., no counter is appended before hashing.

The **alternative design** is to always append a counter starting at 0.

## What Changed

### Core crypto / logic

- Added `crypto.IsEd25519CurvePoint(b Digest) bool` using point validation from `filippo.io/edwards25519` (already a dependency).
- Added `logic.SigDigest(program []byte) crypto.Digest` in `data/transactions/logic/program.go` that implements the v13+ mitigation.

### LogicSig address call sites

Updated LogicSig-account-address derivation from `HashProgram` to `SigDigest` in 5 call sites across 4 files:

- `cmd/goal/clerk.go`
- `daemon/algod/api/server/v2/handlers.go` (`/v2/teal/compile` response `hash`) - *api change discussed below*
- `data/transactions/verify/txn.go`
- `heartbeat/service.go` (technically unnecessary since it uses a LogicSig hardcoded with v11)

### Unchanged

- App approval/clear hashing is unchanged.
- `tealsign` / `ed25519verify` domain separation still uses legacy `HashProgram` semantics.
- Existing tests that use LogicSig with hardcoded TEAL Version <13 are unchanged (and still use `HashProgram`).

### API docs

Updated `daemon/algod/api/algod.oas2.json` and `daemon/algod/api/algod.oas3.yml` wording for `/v2/teal/compile` to reflect v13+ LogicSig address-digest behavior.

## API Change

`/v2/teal/compile` compiles generic TEAL and outputs two fields:
- `result`: the compiled TEAL bytecode (unchanged)
- `hash`: the address-format digest of the TEAL program that now reflects LogicSig address semantics (`SigDigest`) for v13+.

This may affect consumers that interpreted compile `hash` as a generic program hash.

Options to decide on API change:

1. Change `hash` to the new semantic and document/warn clearly - *current code*
2. Keep `hash` as the legacy hash and add a new `lsigAddress` field.
3. Keep current `hash` as new semantic and add a `legacyHash` field.

## Tests

Added:

- `TestTxnValidationLogicSigV13` in `data/transactions/verify/txn_test.go`

The test verifies that for TEAL v13+ a LogicSig address that would be on the curve with HashProgram:
1. is indeed not a point on the Ed25519 curve with the new SigDigest.
2. is accepted as a sender in a transaction with the new SigDigest.
3. is rejected as a sender in a transaction with the old HashProgram.

- `TestLogicSigV13SigDigestAddress` in `test/e2e-go/features/transactions/logicsig_test.go`

The e2e test additionally verifies this behavior on a running future network by:
1. funding `Address(SigDigest(program))`;
2. submitting an unsigned LogicSig txn with sender `SigDigest(program)` (accepted);
3. submitting the same with sender `HashProgram(program)` (rejected).

## Next Steps
1. Decide if we are happy with the current design.
2. Decide if we are happy with the API change for `/v2/teal/compile` response.
3. Decide if we want more tests and if we want to keep the expensive e2e test.
