### PR TITLE
build: fix allocbound directive lookup

### DIFF
--- a/protocol/codec_test.go
+++ b/protocol/codec_test.go
@@ -269,3 +269,10 @@ func TestRandomizeObjectWithPtrField(t *testing.T) {
 	require.True(t, sawNonZeroU16, "RandomizeObject made all zeroes for testObjB.U16")
 	require.True(t, sawNonZeroU64, "RandomizeObject made all zeroes for testObjA.U64")
 }
+
+func TestCheckMsgpAllocBoundDirectiveCrossPackage(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	require.True(t, hasMsgpAllocBoundDirective("github.com/algorand/go-algorand/protocol/test", "testSlice"))
+}

--- a/protocol/codec_tester.go
+++ b/protocol/codec_tester.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -150,35 +149,77 @@ func printWarning(warnMsg string) {
 var testedDatatypesForAllocBound = map[string]bool{}
 var testedDatatypesForAllocBoundMu = deadlock.Mutex{}
 
+// Walk upward from this source file until we find the module root.
+// (we look for the go.mod file declaring the go-algorand module)
+func repoRootFromGoMod() (string, error) {
+	const repositoryModulePath = "github.com/algorand/go-algorand"
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("runtime.Caller failed")
+	}
+
+	for dir := filepath.Dir(file); ; {
+		matches, err := goModDeclaresModule(filepath.Join(dir, "go.mod"),
+			repositoryModulePath)
+		if err != nil {
+			return "", err
+		}
+		if matches {
+			return dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("could not find go-algorand module root from %s", file)
+		}
+		dir = parent
+	}
+}
+
+// Report whether goModPath declares the expected module.
+func goModDeclaresModule(goModPath, modulePath string) (bool, error) {
+	fileBytes, err := os.ReadFile(goModPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("reading %s: %w", goModPath, err)
+	}
+
+	for line := range strings.SplitSeq(string(fileBytes), "\n") {
+		line = strings.TrimSpace(line)
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "module" && fields[1] == modulePath {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 func checkMsgpAllocBoundDirective(dataType reflect.Type) bool {
-	// does any of the go files in the package directory has the msgp:allocbound defined for that datatype ?
-	gopath := os.Getenv("GOPATH")
-	const repositoryRoot = "go-algorand/"
-	const thisFile = "protocol/codec_tester.go"
-	packageFilesPath := path.Join(gopath, "src", dataType.PkgPath())
+	return hasMsgpAllocBoundDirective(dataType.PkgPath(), dataType.Name())
+}
+
+// hasMsgpAllocBoundDirective checks whether any of the go files in the package directory
+// has the msgp:allocbound defined for the given datatype.
+func hasMsgpAllocBoundDirective(pkgPath, typeName string) bool {
+	const repositoryImportPath = "github.com/algorand/go-algorand/"
+	packageFilesPath := filepath.Join(os.Getenv("GOPATH"), "src", filepath.FromSlash(pkgPath))
 
 	if _, err := os.Stat(packageFilesPath); os.IsNotExist(err) {
-		// no such directory. Try to assemble the path based on the current working directory.
-		cwd, err := os.Getwd()
+		// no such directory. Fall back to the source tree containing this module.
+		repoRoot, err := repoRootFromGoMod()
 		if err != nil {
 			return false
 		}
-		if cwdPaths := strings.SplitAfter(cwd, repositoryRoot); len(cwdPaths) == 2 {
-			cwd = cwdPaths[0]
-		} else {
-			// try to assemble the project directory based on the current stack frame
-			_, file, _, ok := runtime.Caller(0)
-			if !ok {
-				return false
-			}
-			cwd = strings.TrimSuffix(file, thisFile)
-		}
 
-		relPkdPath := strings.SplitAfter(dataType.PkgPath(), repositoryRoot)
-		if len(relPkdPath) != 2 {
+		relPkgPath, ok := strings.CutPrefix(pkgPath, repositoryImportPath)
+		if !ok {
 			return false
 		}
-		packageFilesPath = path.Join(cwd, relPkdPath[1])
+		packageFilesPath = filepath.Join(repoRoot, filepath.FromSlash(relPkgPath))
 		if _, err := os.Stat(packageFilesPath); os.IsNotExist(err) {
 			return false
 		}
@@ -195,9 +236,13 @@ func checkMsgpAllocBoundDirective(dataType reflect.Type) bool {
 		if err != nil {
 			continue
 		}
-		if strings.Contains(string(fileBytes), fmt.Sprintf("msgp:allocbound %s", dataType.Name())) {
-			// message pack alloc bound definition was found.
-			return true
+		for line := range strings.SplitSeq(string(fileBytes), "\n") {
+			line = strings.TrimSpace(line)
+			fields := strings.Fields(line)
+			if len(fields) >= 2 && fields[0] == "//msgp:allocbound" && fields[1] == typeName {
+				// message pack alloc bound definition was found.
+				return true
+			}
 		}
 	}
 	return false

--- a/protocol/codec_tester.go
+++ b/protocol/codec_tester.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -148,10 +149,15 @@ func printWarning(warnMsg string) {
 
 var testedDatatypesForAllocBound = map[string]bool{}
 var testedDatatypesForAllocBoundMu = deadlock.Mutex{}
+var repoRootFromGoModCached = sync.OnceValues(findRepoRootFromGoMod)
 
 // Walk upward from this source file until we find the module root.
 // (we look for the go.mod file declaring the go-algorand module)
 func repoRootFromGoMod() (string, error) {
+	return repoRootFromGoModCached()
+}
+
+func findRepoRootFromGoMod() (string, error) {
 	const repositoryModulePath = "github.com/algorand/go-algorand"
 
 	_, file, _, ok := runtime.Caller(0)
@@ -203,26 +209,23 @@ func checkMsgpAllocBoundDirective(dataType reflect.Type) bool {
 }
 
 // hasMsgpAllocBoundDirective checks whether any of the go files in the package directory
-// has the msgp:allocbound defined for the given datatype.
+// have the msgp:allocbound defined for the given datatype.
 func hasMsgpAllocBoundDirective(pkgPath, typeName string) bool {
-	const repositoryImportPath = "github.com/algorand/go-algorand/"
-	packageFilesPath := filepath.Join(os.Getenv("GOPATH"), "src", filepath.FromSlash(pkgPath))
+	const repositoryModulePath = "github.com/algorand/go-algorand"
 
+	repoRoot, err := repoRootFromGoMod()
+	if err != nil {
+		return false
+	}
+
+	relPkgPath, ok := strings.CutPrefix(pkgPath, repositoryModulePath+"/")
+	if !ok {
+		return false
+	}
+
+	packageFilesPath := filepath.Join(repoRoot, filepath.FromSlash(relPkgPath))
 	if _, err := os.Stat(packageFilesPath); os.IsNotExist(err) {
-		// no such directory. Fall back to the source tree containing this module.
-		repoRoot, err := repoRootFromGoMod()
-		if err != nil {
-			return false
-		}
-
-		relPkgPath, ok := strings.CutPrefix(pkgPath, repositoryImportPath)
-		if !ok {
-			return false
-		}
-		packageFilesPath = filepath.Join(repoRoot, filepath.FromSlash(relPkgPath))
-		if _, err := os.Stat(packageFilesPath); os.IsNotExist(err) {
-			return false
-		}
+		return false
 	}
 	packageFiles := []string{}
 	filepath.Walk(packageFilesPath, func(path string, info os.FileInfo, err error) error {

--- a/protocol/codec_tester.go
+++ b/protocol/codec_tester.go
@@ -149,59 +149,35 @@ func printWarning(warnMsg string) {
 
 var testedDatatypesForAllocBound = map[string]bool{}
 var testedDatatypesForAllocBoundMu = deadlock.Mutex{}
-var repoRootFromGoModCached = sync.OnceValues(findRepoRootFromGoMod)
+var moduleRootFromGoModCached = sync.OnceValues(findModuleRootFromGoMod)
 
-// Walk upward from this source file until we find the module root.
-// (we look for the go.mod file declaring the go-algorand module)
-func repoRootFromGoMod() (string, error) {
-	return repoRootFromGoModCached()
+// Walk upward from this source file until we find the containing module root.
+func moduleRootFromGoMod() (string, error) {
+	return moduleRootFromGoModCached()
 }
 
-func findRepoRootFromGoMod() (string, error) {
-	const repositoryModulePath = "github.com/algorand/go-algorand"
-
+func findModuleRootFromGoMod() (string, error) {
 	_, file, _, ok := runtime.Caller(0)
 	if !ok {
 		return "", fmt.Errorf("runtime.Caller failed")
 	}
 
 	for dir := filepath.Dir(file); ; {
-		matches, err := goModDeclaresModule(filepath.Join(dir, "go.mod"),
-			repositoryModulePath)
-		if err != nil {
-			return "", err
-		}
-		if matches {
+		goModPath := filepath.Join(dir, "go.mod")
+		_, err := os.Stat(goModPath)
+		if err == nil {
 			return dir, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("stat %s: %w", goModPath, err)
 		}
 
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return "", fmt.Errorf("could not find go-algorand module root from %s", file)
+			return "", fmt.Errorf("could not find module root from %s", file)
 		}
 		dir = parent
 	}
-}
-
-// Report whether goModPath declares the expected module.
-func goModDeclaresModule(goModPath, modulePath string) (bool, error) {
-	fileBytes, err := os.ReadFile(goModPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("reading %s: %w", goModPath, err)
-	}
-
-	for line := range strings.SplitSeq(string(fileBytes), "\n") {
-		line = strings.TrimSpace(line)
-		fields := strings.Fields(line)
-		if len(fields) >= 2 && fields[0] == "module" && fields[1] == modulePath {
-			return true, nil
-		}
-	}
-
-	return false, nil
 }
 
 func checkMsgpAllocBoundDirective(dataType reflect.Type) bool {
@@ -213,7 +189,7 @@ func checkMsgpAllocBoundDirective(dataType reflect.Type) bool {
 func hasMsgpAllocBoundDirective(pkgPath, typeName string) bool {
 	const repositoryModulePath = "github.com/algorand/go-algorand"
 
-	repoRoot, err := repoRootFromGoMod()
+	moduleRoot, err := moduleRootFromGoMod()
 	if err != nil {
 		return false
 	}
@@ -223,7 +199,7 @@ func hasMsgpAllocBoundDirective(pkgPath, typeName string) bool {
 		return false
 	}
 
-	packageFilesPath := filepath.Join(repoRoot, filepath.FromSlash(relPkgPath))
+	packageFilesPath := filepath.Join(moduleRoot, filepath.FromSlash(relPkgPath))
 	if _, err := os.Stat(packageFilesPath); os.IsNotExist(err) {
 		return false
 	}

--- a/protocol/codec_tester.go
+++ b/protocol/codec_tester.go
@@ -149,13 +149,9 @@ func printWarning(warnMsg string) {
 
 var testedDatatypesForAllocBound = map[string]bool{}
 var testedDatatypesForAllocBoundMu = deadlock.Mutex{}
-var moduleRootFromGoModCached = sync.OnceValues(findModuleRootFromGoMod)
+var moduleRootFromGoMod = sync.OnceValues(findModuleRootFromGoMod)
 
 // Walk upward from this source file until we find the containing module root.
-func moduleRootFromGoMod() (string, error) {
-	return moduleRootFromGoModCached()
-}
-
 func findModuleRootFromGoMod() (string, error) {
 	_, file, _, ok := runtime.Caller(0)
 	if !ok {
@@ -200,17 +196,18 @@ func hasMsgpAllocBoundDirective(pkgPath, typeName string) bool {
 	}
 
 	packageFilesPath := filepath.Join(moduleRoot, filepath.FromSlash(relPkgPath))
-	if _, err := os.Stat(packageFilesPath); os.IsNotExist(err) {
+	if _, statErr := os.Stat(packageFilesPath); os.IsNotExist(statErr) {
 		return false
 	}
-	packageFiles := []string{}
-	filepath.Walk(packageFilesPath, func(path string, info os.FileInfo, err error) error {
-		if filepath.Ext(path) == ".go" {
-			packageFiles = append(packageFiles, path)
+	packageEntries, err := os.ReadDir(packageFilesPath)
+	if err != nil {
+		return false
+	}
+	for _, entry := range packageEntries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" {
+			continue
 		}
-		return nil
-	})
-	for _, packageFile := range packageFiles {
+		packageFile := filepath.Join(packageFilesPath, entry.Name())
 		fileBytes, err := os.ReadFile(packageFile)
 		if err != nil {
 			continue


### PR DESCRIPTION
## Summary

This fixes a path-resolution bug in `protocol/codec_tester.go`.

Randomized codec tests check whether a type's package defines a `//msgp:allocbound ...` directive before generating bounded slices, maps, and strings. In a sibling git worktree layout, the fallback path logic could resolve the repository root incorrectly and fail to find directives that were actually present in source.

## Root Cause

When the package could not be found through the old `$GOPATH/src/...` path, `checkMsgpAllocBoundDirective` fell back to reconstructing the repo path from the current working directory by splitting on `go-algorand/`.

This does not work if, for instance, you have a git worktree checkout with a worktree path like:

```text
.../go-algorand/pr-1234        # worktree for PR #1234
```

## Change

Keep the existing `$GOPATH/src/...` lookup, but change the fallback to anchor on the real location of `protocol/codec_tester.go` via `runtime.Caller(0)`, then walk upward until it finds the repository `go.mod` declaring:

```text
module github.com/algorand/go-algorand
```

From that module root, map:

```text
github.com/algorand/go-algorand/<pkg>
```

to the corresponding relative path in that source tree, and scan the package's `.go` files for the `msgp:allocbound` directive.

This makes the fallback independent of the current working directory, of the worktree name, and of the exact depth of `codec_tester.go` within the repository.

## Test Coverage

Adds `TestCheckMsgpAllocBoundDirectiveCrossPackage`, which verifies that allocbound lookup succeeds for `protocol/test.testSlice`.