### PR TITLE
build: rebuild copied libsodium tree from scratch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,7 @@ libsodium: crypto/libs/$(OS_TYPE)/$(ARCH)/lib/libsodium.a
 
 crypto/libs/$(OS_TYPE)/$(ARCH)/lib/libsodium.a:
 	mkdir -p crypto/copies/$(OS_TYPE)/$(ARCH)
+	rm -rf crypto/copies/$(OS_TYPE)/$(ARCH)/libsodium-fork
 	cp -R crypto/libsodium-fork/. crypto/copies/$(OS_TYPE)/$(ARCH)/libsodium-fork
 	cd crypto/copies/$(OS_TYPE)/$(ARCH)/libsodium-fork && \
 		./autogen.sh --prefix $(SRCPATH)/crypto/libs/$(OS_TYPE)/$(ARCH) && \

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,10 @@ ALWAYS:
 libsodium: crypto/libs/$(OS_TYPE)/$(ARCH)/lib/libsodium.a
 
 crypto/libs/$(OS_TYPE)/$(ARCH)/lib/libsodium.a:
+	# ARCH and OS_TYPE feed the cleanup/copy paths below and can be overridden by callers.
+	# Validate them here so the recipe only operates on expected target paths.
+	@case "$(OS_TYPE)" in (darwin|linux|windows) ;; (*) echo "Invalid OS_TYPE: $(OS_TYPE)"; exit 1;; esac
+	@case "$(ARCH)" in (amd64|arm64|arm|riscv64) ;; (*) echo "Invalid ARCH: $(ARCH)"; exit 1;; esac
 	mkdir -p crypto/copies/$(OS_TYPE)/$(ARCH)
 	rm -rf crypto/copies/$(OS_TYPE)/$(ARCH)/libsodium-fork
 	cp -R crypto/libsodium-fork/. crypto/copies/$(OS_TYPE)/$(ARCH)/libsodium-fork


### PR DESCRIPTION
# Make libsodium builds start from a clean copied source tree

## Summary

This change makes the vendored `libsodium` build recipe remove the generated copy under `crypto/copies/$(OS_TYPE)/$(ARCH)/libsodium-fork` before repopulating it from `crypto/libsodium-fork`.

## Problem

The current recipe does:

```make
cp -R crypto/libsodium-fork/. crypto/copies/$(OS_TYPE)/$(ARCH)/libsodium-fork
```

when the destination may already exist from a previous build.

That means a fresh source copy can be merged with stale autotools output and other generated files left behind by an older configure/build run. In practice this can make `make test` fail in the copied `libsodium-fork` tree even though a clean scratch copy of the same source configures and builds correctly.

## Change

Delete the generated copy first:

```make
rm -rf crypto/copies/$(OS_TYPE)/$(ARCH)/libsodium-fork
```

and then copy the vendored source tree into place as before.

This ensures that whenever `libsodium.a` is rebuilt, the build starts from a clean copy of the vendored source rather than a potentially stale one.

## Testing

- Reproduced a `libsodium` build failure in a reused copied tree where a fresh scratch copy of the same source configured and built cleanly.