### PR TITLE
Assembler: Properly perform stack type tracking for match opcode

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1234,12 +1234,16 @@ func getImm(args []token, argIndex int, signed bool) (int, bool) {
 	return int(n), true
 }
 
-func anyTypes(n int) StackTypes {
+func sameTypes(n int, t StackType) StackTypes {
 	as := make(StackTypes, n)
 	for i := range as {
-		as[i] = StackAny
+		as[i] = t
 	}
 	return as
+}
+
+func anyTypes(n int) StackTypes {
+	return sameTypes(n, StackAny)
 }
 
 func typeSwap(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
@@ -1610,6 +1614,20 @@ func typeByte(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, erro
 	val, _, _ := parseBinaryArgs(args)
 	l := uint64(len(val))
 	return nil, StackTypes{NewStackType(avmBytes, static(l), fmt.Sprintf("[%d]byte", l))}, nil
+}
+
+func typeMatch(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
+	targetCount := len(args)
+	if targetCount == 0 {
+		return nil, nil, nil
+	}
+	top := len(pgm.stack) - 1
+	if top < 0 {
+		return nil, nil, nil
+	}
+	// I'd sort of like to use `sameTypes` with the top type, but it is legal to
+	// mix types.
+	return anyTypes(targetCount + 1), nil, nil
 }
 
 func joinIntsOnOr(singularTerminator string, list ...int) string {

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -1617,17 +1617,9 @@ func typeByte(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, erro
 }
 
 func typeMatch(pgm *ProgramKnowledge, args []token) (StackTypes, StackTypes, error) {
-	targetCount := len(args)
-	if targetCount == 0 {
-		return nil, nil, nil
-	}
-	top := len(pgm.stack) - 1
-	if top < 0 {
-		return nil, nil, nil
-	}
 	// I'd sort of like to use `sameTypes` with the top type, but it is legal to
 	// mix types.
-	return anyTypes(targetCount + 1), nil, nil
+	return anyTypes(len(args) + 1), nil, nil
 }
 
 func joinIntsOnOr(singularTerminator string, list ...int) string {

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -3638,24 +3638,30 @@ int 1
 
 	// test that 255 labels is ok
 	source = fmt.Sprintf(`
-	pushint 1
+	%s
 	match %s
 	%s
-	`, strings.Join(labels, " "), strings.Join(labels, ":\n")+":\n")
+	`,
+		strings.Repeat("pushint 1; ", 256), // 255 labels, and the match value
+		strings.Join(labels, " "),
+		strings.Join(labels, ":\n")+":\n")
 	ops = testProg(t, source, AssemblerMaxVersion)
-	require.Len(t, ops.Program, 515) // ver (1) + pushint (2) + opcode (1) + length (1) + labels (2*255)
+	require.Len(t, ops.Program, 1025) // ver (1) + pushints (2*256) + opcode (1) + length (1) + labels (2*255)
 
 	// 256 is too many
 	source = fmt.Sprintf(`
-	pushint 1
+	%s
 	match %s extra
 	%s
-	`, strings.Join(labels, " "), strings.Join(labels, ":\n")+":\n")
+	`,
+		strings.Repeat("pushint 1; ", 257), // 256 labels, and the match value
+		strings.Join(labels, " "),
+		strings.Join(labels, ":\n")+":\n")
 	testProg(t, source, AssemblerMaxVersion, exp(3, "match cannot take more than 255 labels"))
 
 	// allow duplicate label reference
 	source = `
-	pushint 1
+	pushints 1 2 1
 	match label1 label1
 	label1:
 	`
@@ -3895,4 +3901,22 @@ func TestDisassembleBadMatch(t *testing.T) {
 
 	dis, err = Disassemble(ops.Program[:len(ops.Program)-1])
 	require.ErrorContains(t, err, "could not decode labels for match", dis)
+}
+
+// TestMatchTyping ensures the stack types are tracked properly across `match`
+func TestMatchTyping(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	source := `
+    pushint 0                   // I
+    pushbytes 0xb17ea35d        // I,B
+    txna ApplicationArgs 0      // I,B,B
+    match done					// I
+    dup               // I, I
+    !                 // I, I
+    return
+done:
+	`
+	testProg(t, source, AssemblerMaxVersion)
 }

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -3632,7 +3632,7 @@ int 1
 	testProg(t, source, AssemblerMaxVersion)
 
 	var labels []string
-	for i := 0; i < 255; i++ {
+	for i := range 255 {
 		labels = append(labels, fmt.Sprintf("label%d", i))
 	}
 
@@ -3666,6 +3666,25 @@ int 1
 	label1:
 	`
 	testProg(t, source, AssemblerMaxVersion)
+
+	// allow empty match
+	source = `
+	pushints 1
+	match
+	`
+	testProg(t, source, AssemblerMaxVersion)
+
+	// allow empty match (ensure types track properly though)
+	source = `
+	pushbytess 0xaa 0xbb
+	pushint 1
+	match
+	concat
+	`
+	testProg(t, source, AssemblerMaxVersion)
+
+	// even an empty match consumes top of stack
+	testProg(t, "match", AssemblerMaxVersion, exp(1, "match expects 1 stack argument..."))
 }
 
 func TestAssemblePushConsts(t *testing.T) {

--- a/data/transactions/logic/langspec_v10.json
+++ b/data/transactions/logic/langspec_v10.json
@@ -3137,6 +3137,9 @@
     {
       "Opcode": 142,
       "Name": "match",
+      "Args": [
+        "any"
+      ],
       "Size": 0,
       "DocCost": "1",
       "Doc": "given match cases from A[1] to A[N], branch to the Ith label where A[I] = B. Continue to the following instruction if no matches are found.",

--- a/data/transactions/logic/langspec_v11.json
+++ b/data/transactions/logic/langspec_v11.json
@@ -3193,6 +3193,9 @@
     {
       "Opcode": 142,
       "Name": "match",
+      "Args": [
+        "any"
+      ],
       "Size": 0,
       "DocCost": "1",
       "Doc": "given match cases from A[1] to A[N], branch to the Ith label where A[I] = B. Continue to the following instruction if no matches are found.",

--- a/data/transactions/logic/langspec_v12.json
+++ b/data/transactions/logic/langspec_v12.json
@@ -3220,6 +3220,9 @@
     {
       "Opcode": 142,
       "Name": "match",
+      "Args": [
+        "any"
+      ],
       "Size": 0,
       "DocCost": "1",
       "Doc": "given match cases from A[1] to A[N], branch to the Ith label where A[I] = B. Continue to the following instruction if no matches are found.",

--- a/data/transactions/logic/langspec_v8.json
+++ b/data/transactions/logic/langspec_v8.json
@@ -3131,6 +3131,9 @@
     {
       "Opcode": 142,
       "Name": "match",
+      "Args": [
+        "any"
+      ],
       "Size": 0,
       "DocCost": "1",
       "Doc": "given match cases from A[1] to A[N], branch to the Ith label where A[I] = B. Continue to the following instruction if no matches are found.",

--- a/data/transactions/logic/langspec_v9.json
+++ b/data/transactions/logic/langspec_v9.json
@@ -3131,6 +3131,9 @@
     {
       "Opcode": 142,
       "Name": "match",
+      "Args": [
+        "any"
+      ],
       "Size": 0,
       "DocCost": "1",
       "Doc": "given match cases from A[1] to A[N], branch to the Ith label where A[I] = B. Continue to the following instruction if no matches are found.",

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -665,7 +665,7 @@ var OpSpecs = []OpSpec{
 	{0x8b, "frame_dig", opFrameDig, proto(":a").stackExplain(opFrameDigStackChange), fpVersion, immKinded(immInt8, "i").typed(typeFrameDig)},
 	{0x8c, "frame_bury", opFrameBury, proto("a:").stackExplain(opFrameBuryStackChange), fpVersion, immKinded(immInt8, "i").typed(typeFrameBury)},
 	{0x8d, "switch", opSwitch, proto("i:"), 8, detSwitch()},
-	{0x8e, "match", opMatch, proto(":", "[A1, A2, ..., AN], B", "").stackExplain(opMatchStackChange), 8, detSwitch().trust()},
+	{0x8e, "match", opMatch, proto("a:", "[A1, A2, ..., AN], B", "").stackExplain(opMatchStackChange), 8, detSwitch().typed(typeMatch).trust()},
 
 	// More math
 	{0x90, "shl", opShiftLeft, proto("ii:i"), 4, detDefault()},


### PR DESCRIPTION
We never wrote `typeMatch`, so the `match` opcode was not tracking types properly.  This is one reason `puya` turned off typetracking.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
