### PR TITLE
build: support macports in configure_dev.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,10 @@ GOLINTCOMMAND := go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v
 ifeq ($(OS_TYPE), darwin)
 # M1 Mac--homebrew install location in /opt/homebrew
 ifeq ($(ARCH), arm64)
+ifneq ($(shell command -v brew 2>/dev/null),)
 export CPATH=/opt/homebrew/include
 export LIBRARY_PATH=/opt/homebrew/lib
+endif
 endif
 endif
 

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -56,6 +56,7 @@ function port_install_or_upgrade {
         PORT_FORCE="-f"
     fi
 
+    echo "===>  $pkg..."
     if port installed "$pkg" 2>/dev/null | grep -q "(active)"; then
         if ! "${port_cmd[@]}" upgrade ${PORT_FORCE} "$pkg"; then
             return 1
@@ -103,15 +104,6 @@ elif [ "${OS}" = "darwin" ]; then
     DARWIN_DEPS=(pkg-config libtool shellcheck jq autoconf automake python3 diffutils)
     DARWIN_DEPS_OPTIONAL=(lnav)
 
-    # MacPorts uses different names for a couple of packages.
-    port_name() {
-        case "$1" in
-            pkg-config) echo pkgconfig ;;
-            python3)    echo python312 ;;
-            *)          echo "$1" ;;
-        esac
-    }
-
     if which port >/dev/null 2>&1; then
         port_cmd=(port -N)
         if which sudo >/dev/null 2>&1; then
@@ -120,24 +112,41 @@ elif [ "${OS}" = "darwin" ]; then
 
         "${port_cmd[@]}" selfupdate
 
+        # Use the latest python3 port available from MacPorts.
+        latest_python3_port=$(port search python3 | grep -E '^python3[0-9]{1,2}\s+' | awk '{print $1}' | sort -V | tail -n 1)
+
+        have_python3=false
+        if which python3 >/dev/null 2>&1; then
+            have_python3=true
+        fi
+
+        # MacPorts uses different names for a couple of packages.
+        port_name() {
+            case "$1" in
+                pkg-config) echo pkgconfig ;;
+                python3)    echo "$latest_python3_port" ;;
+                *)          echo "$1" ;;
+            esac
+        }
+
         for pkg in "${DARWIN_DEPS[@]}"; do
+            if [ "$pkg" = "python3" ] && $have_python3; then
+                echo "Skipping python3 [$(python3 --version)] as already installed"
+                echo "Install with 'port install $latest_python3_port && port select --set python3 $latest_python3_port' to use the latest MacPorts version"
+                continue
+            fi
             port_install_or_upgrade "$(port_name "$pkg")"
         done
-        if [ "$CI" != "true" ] && [ "$CIRCLECI" != "true" ]; then
+        if [ "$CI" != "true" ] ; then
             for pkg in "${DARWIN_DEPS_OPTIONAL[@]}"; do
                 port_install_or_upgrade "$(port_name "$pkg")"
             done
             lnav -i "$SCRIPTPATH/algorand_node_log.json"
         fi
 
-        # port select --set python3 python312
-        for pkg in "${DARWIN_DEPS[@]}"; do
-            if [[ "$pkg" == *python3* ]]; then
-                port_pkg="$(port_name "$pkg")"
-                "${port_cmd[@]}" select --set python3 "$port_pkg"
-                break
-            fi
-        done
+        if ! $have_python3; then
+            "${port_cmd[@]}" select --set python3 "$latest_python3_port"
+        fi
 
         # all done, no need to fallback to homebrew
         exit 0
@@ -154,7 +163,7 @@ elif [ "${OS}" = "darwin" ]; then
     for pkg in "${DARWIN_DEPS[@]}"; do
         install_or_upgrade "$pkg"
     done
-    if [ "$CI" != "true" ] && [ "$CIRCLECI" != "true" ]; then
+    if [ "$CI" != "true" ] ; then
         for pkg in "${DARWIN_DEPS_OPTIONAL[@]}"; do
             install_or_upgrade "$pkg"
         done

--- a/scripts/configure_dev.sh
+++ b/scripts/configure_dev.sh
@@ -46,6 +46,27 @@ function install_or_upgrade {
     fi
 }
 
+function port_install_or_upgrade {
+    # MacPorts does not have an exact Homebrew-style install/upgrade UX.
+    # We approximate it by upgrading if installed+active, otherwise installing.
+    # Caller is expected to have populated the script-level `port_cmd` array.
+    local pkg="$1"
+
+    if ${FORCE}; then
+        PORT_FORCE="-f"
+    fi
+
+    if port installed "$pkg" 2>/dev/null | grep -q "(active)"; then
+        if ! "${port_cmd[@]}" upgrade ${PORT_FORCE} "$pkg"; then
+            return 1
+        fi
+    else
+        if ! "${port_cmd[@]}" install ${PORT_FORCE} "$pkg"; then
+            return 1
+        fi
+    fi
+}
+
 function install_windows_shellcheck() {
     version="v0.7.1"
     if ! wget https://github.com/koalaman/shellcheck/releases/download/$version/shellcheck-$version.zip -O /tmp/shellcheck-$version.zip; then
@@ -78,6 +99,50 @@ if [ "${OS}" = "linux" ]; then
         sudo "$SCRIPTPATH/install_linux_deps.sh"
     fi
 elif [ "${OS}" = "darwin" ]; then
+    # Canonical dep list. Names are resolved per package manager below.
+    DARWIN_DEPS=(pkg-config libtool shellcheck jq autoconf automake python3 diffutils)
+    DARWIN_DEPS_OPTIONAL=(lnav)
+
+    # MacPorts uses different names for a couple of packages.
+    port_name() {
+        case "$1" in
+            pkg-config) echo pkgconfig ;;
+            python3)    echo python312 ;;
+            *)          echo "$1" ;;
+        esac
+    }
+
+    if which port >/dev/null 2>&1; then
+        port_cmd=(port -N)
+        if which sudo >/dev/null 2>&1; then
+            port_cmd=(sudo port -N)
+        fi
+
+        "${port_cmd[@]}" selfupdate
+
+        for pkg in "${DARWIN_DEPS[@]}"; do
+            port_install_or_upgrade "$(port_name "$pkg")"
+        done
+        if [ "$CI" != "true" ] && [ "$CIRCLECI" != "true" ]; then
+            for pkg in "${DARWIN_DEPS_OPTIONAL[@]}"; do
+                port_install_or_upgrade "$(port_name "$pkg")"
+            done
+            lnav -i "$SCRIPTPATH/algorand_node_log.json"
+        fi
+
+        # port select --set python3 python312
+        for pkg in "${DARWIN_DEPS[@]}"; do
+            if [[ "$pkg" == *python3* ]]; then
+                port_pkg="$(port_name "$pkg")"
+                "${port_cmd[@]}" select --set python3 "$port_pkg"
+                break
+            fi
+        done
+
+        # all done, no need to fallback to homebrew
+        exit 0
+    fi
+
     brew update
     brew_version=$(brew --version | head -1 | cut -d' ' -f2)
     major_version=$(echo $brew_version | cut -d. -f1)
@@ -86,16 +151,13 @@ elif [ "${OS}" = "darwin" ]; then
     if (($(echo "$version_decimal < 2.5" | bc -l))); then
         brew tap homebrew/cask
     fi
-    install_or_upgrade pkg-config
-    install_or_upgrade libtool
-    install_or_upgrade shellcheck
-    install_or_upgrade jq
-    install_or_upgrade autoconf
-    install_or_upgrade automake
-    install_or_upgrade python3
-    install_or_upgrade diffutils
+    for pkg in "${DARWIN_DEPS[@]}"; do
+        install_or_upgrade "$pkg"
+    done
     if [ "$CI" != "true" ] && [ "$CIRCLECI" != "true" ]; then
-        install_or_upgrade lnav
+        for pkg in "${DARWIN_DEPS_OPTIONAL[@]}"; do
+            install_or_upgrade "$pkg"
+        done
         lnav -i "$SCRIPTPATH/algorand_node_log.json"
     fi
 elif [ "${OS}" = "windows" ]; then


### PR DESCRIPTION
## Summary

MacPorts for dependencies installation on mac systems.

* `brew` is kept as fallback when no `port` available
* dependencies list is unified

## Test Plan

Run `./scripts/configure_dev.sh` locally. CI should also pass