### PR TITLE
CICD: don't require vars for nightlies

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -283,6 +283,7 @@ jobs:
       CI_PLATFORM: ${{ matrix.platform }}
       CI_KEEP_TEMP_PLATFORM: "ubuntu-24.04"
       S3_TESTDATA: ${{ secrets.S3_TESTDATA }}
+      AWS_ROLE: ${{ secrets.AWS_ROLE }}
     steps:
       - name: Set CI_E2E_FILENAME for e2e test data publishing
         run: |
@@ -305,6 +306,7 @@ jobs:
         with:
           cache-prefix: buildsrc
       - name: Configure AWS credentials
+        if: env.AWS_ROLE != ''
         uses: aws-actions/configure-aws-credentials@v4.2.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -4,7 +4,7 @@ on:
     branches: 
       - master
       - 'rel/**'
-      - review-vars
+
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -4,6 +4,7 @@ on:
     branches: 
       - master
       - 'rel/**'
+      - review-vars
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -142,7 +142,7 @@ jobs:
           retention-days: 7
       - name: Upload coverage
         # Only upload coverage from ubuntu-24.04 platform
-        if: matrix.platform == 'ubuntu-24.04' && ${{ !cancelled() }}
+        if: ${{ matrix.platform == 'ubuntu-24.04' && !cancelled() }}
         uses: codecov/codecov-action@v4
         env:
           GITHUB_ACTIONS: True

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -4,7 +4,6 @@ on:
     branches: 
       - master
       - 'rel/**'
-
   workflow_dispatch:
     inputs:
       branch:

--- a/test/scripts/e2e.sh
+++ b/test/scripts/e2e.sh
@@ -7,8 +7,6 @@ set -e
 # Suppress telemetry reporting for tests
 export ALGOTEST=1
 
-S3_TESTDATA=${S3_TESTDATA:-algorand-testdata}
-
 SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
 SRCROOT="$(pwd -P)"
 
@@ -208,9 +206,11 @@ if [ -z "$E2E_TEST_FILTER" ] || [ "$E2E_TEST_FILTER" == "SCRIPTS" ]; then
         pushd "${TEMPDIR}" || exit 1
         tar -j -c -f "${CI_E2E_FILENAME}.tar.bz2" --exclude node.log --exclude agreement.cdv net
         rm -rf "${TEMPDIR}/net"
-        RSTAMP=$(TZ=UTC python -c 'import time; print("{:08x}".format(0xffffffff - int(time.time() - time.mktime((2020,1,1,0,0,0,-1,-1,-1)))))')
-        echo aws s3 cp --acl public-read "${TEMPDIR}/${CI_E2E_FILENAME}.tar.bz2" "s3://${S3_TESTDATA}/indexer/e2e4/${RSTAMP}/${CI_E2E_FILENAME}.tar.bz2"
-        aws s3 cp --acl public-read "${TEMPDIR}/${CI_E2E_FILENAME}.tar.bz2" "s3://${S3_TESTDATA}/indexer/e2e4/${RSTAMP}/${CI_E2E_FILENAME}.tar.bz2"
+        if [ -n "${S3_TESTDATA}" ]; then
+            RSTAMP=$(TZ=UTC python -c 'import time; print("{:08x}".format(0xffffffff - int(time.time() - time.mktime((2020,1,1,0,0,0,-1,-1,-1)))))')
+            echo aws s3 cp --acl public-read "${TEMPDIR}/${CI_E2E_FILENAME}.tar.bz2" "s3://${S3_TESTDATA}/indexer/e2e4/${RSTAMP}/${CI_E2E_FILENAME}.tar.bz2"
+            aws s3 cp --acl public-read "${TEMPDIR}/${CI_E2E_FILENAME}.tar.bz2" "s3://${S3_TESTDATA}/indexer/e2e4/${RSTAMP}/${CI_E2E_FILENAME}.tar.bz2"
+        fi
         popd
     fi
 


### PR DESCRIPTION
## Summary

For validation purposes testing data is retained to validate other pipelines. This is not necessary for the average fork user.

If you ware running a fork, you may want to run nightly tests, which would fail as of #6368. To remedy this we make the credential information and upload optional. If AWS_ROLE is unset, then the credential setup is a no-op. We also only upload if S3_TESTDATA is defined.

## Test Plan

Tested that nightly tests ran in the absence of this information.

