### PR TITLE
chore: ensure heartbeat lsig is an invalid ed25519 point

### DIFF
--- a/heartbeat/service.go
+++ b/heartbeat/service.go
@@ -161,10 +161,11 @@ func (s *Service) loop() {
 	}
 }
 
-// acceptingByteCode is the byte code to a logic signature that will accept anything (except rekeying).
+// acceptingByteCode is the byte code to a logic signature that will accept anything (except rekeying)
+// and whose address does not decompress to a valid Ed25519 point (trailing intcblock).
 var acceptingByteCode = logic.MustAssemble(`
 #pragma version 11
-txn RekeyTo; global ZeroAddress; ==
+txn RekeyTo; global ZeroAddress; ==; intcblock 2;
 `)
 var acceptingSender = basics.Address(logic.HashProgram(acceptingByteCode))
 


### PR DESCRIPTION
## Summary

The Heartbeat LSig address (`GAU5WA6DT2EPFS6LKOA333BQP67NXIHZ7JPOOHMZWJDPZRL4XMHDDDUCKA`) is a valid Ed25519 point, so it is potentially vulnerable to key recovery via Shor's quantum algorithm. Even if the point is not in the base-point subgroup, `libsodium` Ed25519 signature verification does not enforce any subgroup check, therefore the signature would still be "valid".

This PR adds a trailing `intcblock` with the lowest integer that makes the Heartbeat LSig address not a valid Ed25519 point, following the approach of #6592.

This change does not require a protocol upgrade and should be seamless for node's synchronization.

## Test Plan

We could use the `programHashIsEdwardsPoint` introduced by #6592 (once merged) to add a small test to prove that the Heartbeat LSig address does not decompress to a valid Ed25519 point.