### PR TITLE
docs: fix falcon_verify opcode documentation

### DIFF
--- a/data/transactions/logic/TEAL_opcodes_v12.md
+++ b/data/transactions/logic/TEAL_opcodes_v12.md
@@ -1163,10 +1163,12 @@ pushints args are not added to the intcblock during assembly processes
 ## falcon_verify
 
 - Bytecode: 0x85
-- Stack: ..., A: []byte, B: [1232]byte, C: [1793]byte &rarr; ..., bool
-- for (data A, compressed-format signature B, pubkey C) verify the signature of data against the pubkey => {0 or 1}
+- Stack: ..., A: []byte, B: []byte, C: [1793]byte &rarr; ..., bool
+- for (data A, deterministic FALCON-1024 compressed-format signature B, pubkey C) verify the signature of data against the pubkey => {0 or 1}
 - **Cost**: 1700
 - Availability: v12
+
+Signature B is variable-length, with maximum size 1423 bytes.
 
 ## callsub
 

--- a/data/transactions/logic/TEAL_opcodes_v13.md
+++ b/data/transactions/logic/TEAL_opcodes_v13.md
@@ -1164,10 +1164,12 @@ pushints args are not added to the intcblock during assembly processes
 ## falcon_verify
 
 - Bytecode: 0x85
-- Stack: ..., A: []byte, B: [1232]byte, C: [1793]byte &rarr; ..., bool
-- for (data A, compressed-format signature B, pubkey C) verify the signature of data against the pubkey => {0 or 1}
+- Stack: ..., A: []byte, B: []byte, C: [1793]byte &rarr; ..., bool
+- for (data A, deterministic FALCON-1024 compressed-format signature B, pubkey C) verify the signature of data against the pubkey => {0 or 1}
 - **Cost**: 1700
 - Availability: v12
+
+Signature B is variable-length, with maximum size 1423 bytes.
 
 ## sumhash512
 

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -40,8 +40,13 @@ var opDescByName = map[string]OpDesc{
 	"sha3_256":   {"SHA3_256 hash of value A, yields [32]byte", "", nil, ""},
 	"sha512":     {"SHA512 of value A, yields [64]byte", "", nil, ""},
 
-	"sumhash512":    {"sumhash512 of value A, yields [64]byte", "", nil, ""},
-	"falcon_verify": {"for (data A, compressed-format signature B, pubkey C) verify the signature of data against the pubkey => {0 or 1}", "", nil, ""},
+	"sumhash512": {"sumhash512 of value A, yields [64]byte", "", nil, ""},
+	"falcon_verify": {
+		"for (data A, deterministic FALCON-1024 compressed-format signature B, pubkey C) verify the signature of data against the pubkey => {0 or 1}",
+		"Signature B is variable-length, with maximum size 1423 bytes.",
+		nil,
+		"",
+	},
 
 	"mimc": {"MiMC hash of scalars A, using curve and parameters specified by configuration C", "" +
 		"A is a list of concatenated 32 byte big-endian unsigned integer scalars.  Fail if A's length is not a multiple of 32 or any element exceeds the curve modulus.\n\n" +

--- a/data/transactions/logic/langspec_v12.json
+++ b/data/transactions/logic/langspec_v12.json
@@ -3085,7 +3085,7 @@
       "Name": "falcon_verify",
       "Args": [
         "[]byte",
-        "[1232]byte",
+        "[]byte",
         "[1793]byte"
       ],
       "Returns": [
@@ -3093,7 +3093,8 @@
       ],
       "Size": 1,
       "DocCost": "1700",
-      "Doc": "for (data A, compressed-format signature B, pubkey C) verify the signature of data against the pubkey =\u003e {0 or 1}",
+      "Doc": "for (data A, deterministic FALCON-1024 compressed-format signature B, pubkey C) verify the signature of data against the pubkey =\u003e {0 or 1}",
+      "DocExtra": "Signature B is variable-length, with maximum size 1423 bytes.",
       "IntroducedVersion": 12,
       "Groups": [
         "Cryptography"

--- a/data/transactions/logic/langspec_v13.json
+++ b/data/transactions/logic/langspec_v13.json
@@ -3087,7 +3087,7 @@
       "Name": "falcon_verify",
       "Args": [
         "[]byte",
-        "[1232]byte",
+        "[]byte",
         "[1793]byte"
       ],
       "Returns": [
@@ -3095,7 +3095,8 @@
       ],
       "Size": 1,
       "DocCost": "1700",
-      "Doc": "for (data A, compressed-format signature B, pubkey C) verify the signature of data against the pubkey =\u003e {0 or 1}",
+      "Doc": "for (data A, deterministic FALCON-1024 compressed-format signature B, pubkey C) verify the signature of data against the pubkey =\u003e {0 or 1}",
+      "DocExtra": "Signature B is variable-length, with maximum size 1423 bytes.",
       "IntroducedVersion": 12,
       "Groups": [
         "Cryptography"

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -671,7 +671,7 @@ var OpSpecs = []OpSpec{
 	{0x83, "pushints", opPushInts, proto(":", "", "[N items]").stackExplain(opPushIntsStackChange), 8, constants(asmPushInts, checkIntImmArgs, "uint ...", immInts).typed(typePushInts).trust()},
 
 	{0x84, "ed25519verify_bare", opEd25519VerifyBare, proto("bb{64}b{32}:T"), 7, costly(1900)},
-	{0x85, "falcon_verify", opFalconVerify, proto("bb{1232}b{1793}:T"), 12, costly(1700)}, // dynamic for internal hash?
+	{0x85, "falcon_verify", opFalconVerify, proto("bbb{1793}:T"), 12, costly(1700)},
 	{0x86, "sumhash512", opSumhash512, proto("b:b{64}"), sumhashVersion, costByLength(150, 7, 4, 0)},
 	{0x87, "sha512", opSHA512, proto("b:b{64}"), 13, costByLength(15, 32, 2, 0)},
 


### PR DESCRIPTION
 ## Summary

  Fixes the `falcon_verify` TEAL opcode documentation to show the signature argument as
  variable-length bytes instead of a fixed `[1232]byte`.

  The opcode now documents the stack input as:

  `A: []byte, B: []byte, C: [1793]byte -> bool`

  and notes that signature `B` is a deterministic FALCON-1024 compressed-format signature with
  maximum size 1423 bytes.