### PR TITLE
Tools: Default Cloudflare DNS records to 60s TTL

### DIFF
--- a/cmd/algons/dnsCmd.go
+++ b/cmd/algons/dnsCmd.go
@@ -36,6 +36,7 @@ import (
 var (
 	addFromName    string
 	addToAddress   string
+	addTTL         uint
 	deleteNetwork  string
 	listNetwork    string
 	recordType     string
@@ -60,6 +61,7 @@ func init() {
 	addCmd.MarkFlagRequired("from")
 	addCmd.Flags().StringVarP(&addToAddress, "to", "t", "", "To address to map new DNS entry to")
 	addCmd.MarkFlagRequired("to")
+	addCmd.Flags().UintVar(&addTTL, "ttl", 60, "TTL (seconds) for the DNS record; pass 1 to use Cloudflare's Automatic TTL (~300s)")
 
 	deleteCmd.Flags().StringVarP(&deleteNetwork, "network", "n", "", "Network name for records to delete")
 	deleteCmd.Flags().BoolVarP(&noPrompt, "no-prompt", "y", false, "No prompting for records deletion")
@@ -151,7 +153,7 @@ var addCmd = &cobra.Command{
 	Example: "algons dns add -f a.test.algodev.network -t r1.algodev.network\n" +
 		"algons dns add -f a.test.algodev.network -t 192.168.100.10",
 	Run: func(cmd *cobra.Command, args []string) {
-		err := doAddDNS(addFromName, addToAddress)
+		err := doAddDNS(addFromName, addToAddress, addTTL)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error adding DNS entry: %v\n", err)
 			os.Exit(1)
@@ -181,7 +183,7 @@ var exportCmd = &cobra.Command{
 	},
 }
 
-func doAddTXT(from string, to string) error {
+func doAddTXT(from string, to string, ttl uint) error {
 	cfZoneID, cfToken, err := getClouldflareCredentials()
 	if err != nil {
 		return fmt.Errorf("error getting DNS credentials: %v", err)
@@ -191,10 +193,10 @@ func doAddTXT(from string, to string) error {
 
 	const priority = 1
 	const proxied = false
-	return cloudflareDNS.CreateDNSRecord(context.Background(), "TXT", from, to, cloudflare.AutomaticTTL, priority, proxied)
+	return cloudflareDNS.CreateDNSRecord(context.Background(), "TXT", from, to, ttl, priority, proxied)
 }
 
-func doAddDNS(from string, to string) (err error) {
+func doAddDNS(from string, to string, ttl uint) (err error) {
 	cfZoneID, cfToken, err := getClouldflareCredentials()
 	if err != nil {
 		return fmt.Errorf("error getting DNS credentials: %v", err)
@@ -215,7 +217,7 @@ func doAddDNS(from string, to string) (err error) {
 	} else {
 		recordType = "CNAME"
 	}
-	err = cloudflareDNS.SetDNSRecord(context.Background(), recordType, from, to, cloudflare.AutomaticTTL, priority, proxied)
+	err = cloudflareDNS.SetDNSRecord(context.Background(), recordType, from, to, ttl, priority, proxied)
 
 	return
 }

--- a/cmd/algons/dnsaddrCmd.go
+++ b/cmd/algons/dnsaddrCmd.go
@@ -33,6 +33,7 @@ var (
 	secure        bool
 	cmdMultiaddrs []string
 	nodeSize      int
+	dnsaddrTTL    uint
 )
 
 func init() {
@@ -46,6 +47,7 @@ func init() {
 	dnsaddrTreeCreateCmd.Flags().StringArrayVarP(&cmdMultiaddrs, "multiaddrs", "m", []string{}, "multiaddrs to add")
 	dnsaddrTreeCreateCmd.Flags().StringVarP(&dnsaddrDomain, "domain", "d", "", "Top level domain")
 	dnsaddrTreeCreateCmd.Flags().IntVarP(&nodeSize, "node-size", "n", 50, "Number of multiaddrs entries per TXT record")
+	dnsaddrTreeCreateCmd.Flags().UintVar(&dnsaddrTTL, "ttl", 60, "TTL (seconds) for created TXT records; pass 1 to use Cloudflare's Automatic TTL (~300s)")
 	dnsaddrTreeCreateCmd.MarkFlagRequired("domain")
 	dnsaddrTreeCreateCmd.MarkFlagRequired("multiaddrs")
 
@@ -159,7 +161,7 @@ var dnsaddrTreeCreateCmd = &cobra.Command{
 				if len(dnsaddrsTo) > 0 {
 					newDnsaddr := fmt.Sprintf("dnsaddr=/dnsaddr/%s", dnsaddrsTo[len(dnsaddrsTo)-1])
 					fmt.Printf("writing %s => %s\n", from, newDnsaddr)
-					err := doAddTXT(from, newDnsaddr)
+					err := doAddTXT(from, newDnsaddr, dnsaddrTTL)
 					if err != nil {
 						fmt.Printf("failed writing dnsaddr entry %s: %s\n", newDnsaddr, err)
 						os.Exit(1)
@@ -169,7 +171,7 @@ var dnsaddrTreeCreateCmd = &cobra.Command{
 				}
 				newDnsaddr := fmt.Sprintf("dnsaddr=%s", cmdMultiaddrs[len(cmdMultiaddrs)-1])
 				fmt.Printf("writing %s => %s\n", from, newDnsaddr)
-				err := doAddTXT(from, newDnsaddr)
+				err := doAddTXT(from, newDnsaddr, dnsaddrTTL)
 				if err != nil {
 					fmt.Printf("failed writing dns entry %s\n", err)
 					os.Exit(1)

--- a/cmd/algons/dnsaddrCmd.go
+++ b/cmd/algons/dnsaddrCmd.go
@@ -47,7 +47,7 @@ func init() {
 	dnsaddrTreeCreateCmd.Flags().StringArrayVarP(&cmdMultiaddrs, "multiaddrs", "m", []string{}, "multiaddrs to add")
 	dnsaddrTreeCreateCmd.Flags().StringVarP(&dnsaddrDomain, "domain", "d", "", "Top level domain")
 	dnsaddrTreeCreateCmd.Flags().IntVarP(&nodeSize, "node-size", "n", 50, "Number of multiaddrs entries per TXT record")
-	dnsaddrTreeCreateCmd.Flags().UintVar(&dnsaddrTTL, "ttl", 60, "TTL (seconds) for created TXT records; pass 1 to use Cloudflare's Automatic TTL (~300s)")
+	dnsaddrTreeCreateCmd.Flags().UintVar(&dnsaddrTTL, "ttl", 60, "TTL (seconds) for created TXT records; pass 1 to use Cloudflare's Automatic TTL (~300s); values 2-59 are clamped to 60 seconds")
 	dnsaddrTreeCreateCmd.MarkFlagRequired("domain")
 	dnsaddrTreeCreateCmd.MarkFlagRequired("multiaddrs")
 

--- a/cmd/algorelay/relayCmd.go
+++ b/cmd/algorelay/relayCmd.go
@@ -39,6 +39,7 @@ var (
 	defaultPortArg  uint16
 	dnsBootstrapArg string // e.g. mainnet or testnet
 	recordIDArg     int64
+	ttlArg          uint
 
 	cfToken string
 )
@@ -88,6 +89,7 @@ func init() {
 	updateCmd.MarkFlagRequired("defaultport")
 	updateCmd.Flags().StringVarP(&dnsBootstrapArg, "dnsbootstrap", "b", "", "Bootstrap name for SRV records (eg mainnet)")
 	updateCmd.MarkFlagRequired("dnsbootstrap")
+	updateCmd.Flags().UintVar(&ttlArg, "ttl", 60, "TTL (seconds) for created DNS/SRV records; pass 1 to use Cloudflare's Automatic TTL (~300s)")
 }
 
 func loadRelays(file string) []eb.Relay {
@@ -612,7 +614,7 @@ func addDNSRecord(from string, to string, cfZoneID string) error {
 	} else {
 		recordType = "CNAME"
 	}
-	return cloudflareDNS.SetDNSRecord(context.Background(), recordType, from, to, cloudflare.AutomaticTTL, priority, proxied)
+	return cloudflareDNS.SetDNSRecord(context.Background(), recordType, from, to, ttlArg, priority, proxied)
 }
 
 func addSRVRecord(srvNetwork string, target string, port uint16, serviceShortName string, cfZoneID string) error {
@@ -621,7 +623,7 @@ func addSRVRecord(srvNetwork string, target string, port uint16, serviceShortNam
 	const priority = 1
 	const weight = 1
 
-	return cloudflareDNS.SetSRVRecord(context.Background(), srvNetwork, target, cloudflare.AutomaticTTL, priority, uint(port), serviceShortName, "_tcp", weight)
+	return cloudflareDNS.SetSRVRecord(context.Background(), srvNetwork, target, ttlArg, priority, uint(port), serviceShortName, "_tcp", weight)
 }
 
 func clearSRVRecord(srvNetwork string, target string, serviceShortName string, cfZoneID string) error {

--- a/cmd/algorelay/relayCmd.go
+++ b/cmd/algorelay/relayCmd.go
@@ -89,7 +89,7 @@ func init() {
 	updateCmd.MarkFlagRequired("defaultport")
 	updateCmd.Flags().StringVarP(&dnsBootstrapArg, "dnsbootstrap", "b", "", "Bootstrap name for SRV records (eg mainnet)")
 	updateCmd.MarkFlagRequired("dnsbootstrap")
-	updateCmd.Flags().UintVar(&ttlArg, "ttl", 60, "TTL (seconds) for created DNS/SRV records; pass 1 to use Cloudflare's Automatic TTL (~300s)")
+	updateCmd.Flags().UintVar(&ttlArg, "ttl", 60, "TTL (seconds) for created DNS/SRV records; pass 1 to use Cloudflare's Automatic TTL (~300s); values 2-59 are clamped to 60 seconds")
 }
 
 func loadRelays(file string) []eb.Relay {

--- a/cmd/nodecfg/apply.go
+++ b/cmd/nodecfg/apply.go
@@ -54,7 +54,7 @@ func init() {
 
 	applyCmd.Flags().BoolVarP(&disableDNS, "disable-dns", "N", false, "disable setting DNS entries")
 
-	applyCmd.Flags().UintVar(&applyDNSTTL, "ttl", 60, "TTL (seconds) for created DNS records; pass 1 to use Cloudflare's Automatic TTL (~300s)")
+	applyCmd.Flags().UintVar(&applyDNSTTL, "ttl", 60, "TTL (seconds) for created DNS records; pass 0 or 1 to use Cloudflare's Automatic TTL (~300s); values 2-59 are clamped to 60 seconds")
 }
 
 var applyCmd = &cobra.Command{

--- a/cmd/nodecfg/apply.go
+++ b/cmd/nodecfg/apply.go
@@ -35,6 +35,7 @@ var applyRootNodeDir string
 var applyPublicAddress string
 var nodeConfigBucket string
 var disableDNS bool
+var applyDNSTTL uint
 
 func init() {
 	applyCmd.Flags().StringVarP(&applyChannel, "channel", "c", "", "Channel for the nodes we are configuring")
@@ -52,6 +53,8 @@ func init() {
 	applyCmd.Flags().StringVarP(&nodeConfigBucket, "bucket", "b", "", "S3 bucket to get node configuration from.")
 
 	applyCmd.Flags().BoolVarP(&disableDNS, "disable-dns", "N", false, "disable setting DNS entries")
+
+	applyCmd.Flags().UintVar(&applyDNSTTL, "ttl", 60, "TTL (seconds) for created DNS records; pass 1 to use Cloudflare's Automatic TTL (~300s)")
 }
 
 var applyCmd = &cobra.Command{
@@ -78,13 +81,13 @@ var applyCmd = &cobra.Command{
 			reportErrorf("Error creating data dir: %v", err)
 		}
 
-		if err := doApply(applyRootDir, applyRootNodeDir, applyChannel, applyHostName, applyPublicAddress); err != nil {
+		if err := doApply(applyRootDir, applyRootNodeDir, applyChannel, applyHostName, applyPublicAddress, applyDNSTTL); err != nil {
 			reportErrorf("Error applying configuration: %v", err)
 		}
 	},
 }
 
-func doApply(rootDir string, rootNodeDir, channel string, hostName string, dnsName string) (err error) {
+func doApply(rootDir string, rootNodeDir, channel string, hostName string, dnsName string, dnsTTL uint) (err error) {
 	var missing bool
 	var cfg remote.DeployedNetworkConfig
 	if rootDir == "" {
@@ -130,7 +133,7 @@ func doApply(rootDir string, rootNodeDir, channel string, hostName string, dnsNa
 	}
 
 	fmt.Fprintf(os.Stdout, "Applying config for host '%s' (%d nodes)...\n", hostName, len(hostCfg.Nodes))
-	err = nodecfg.ApplyConfigurationToHost(hostCfg, rootDir, rootNodeDir, dnsName)
+	err = nodecfg.ApplyConfigurationToHost(hostCfg, rootDir, rootNodeDir, dnsName, dnsTTL)
 
 	return
 }

--- a/netdeploy/remote/nodecfg/nodeConfigurator.go
+++ b/netdeploy/remote/nodecfg/nodeConfigurator.go
@@ -235,7 +235,9 @@ func (nc *nodeConfigurator) registerDNSRecords() (err error) {
 	}
 
 	fmt.Fprintf(os.Stdout, "...... Adding DNS Record '%s' -> '%s' .\n", networkHostName, nc.dnsName)
-	cloudflareDNS.SetDNSRecord(context.Background(), recordType, networkHostName, nc.dnsName, nc.dnsTTL, priority, proxied)
+	if err = cloudflareDNS.SetDNSRecord(context.Background(), recordType, networkHostName, nc.dnsName, nc.dnsTTL, priority, proxied); err != nil {
+		return fmt.Errorf("error setting %s record %s -> %s: %w", recordType, networkHostName, nc.dnsName, err)
+	}
 
 	for _, entry := range nc.relayEndpoints {
 		port, parseErr := strconv.ParseInt(strings.Split(entry.port, ":")[1], 10, 64)

--- a/netdeploy/remote/nodecfg/nodeConfigurator.go
+++ b/netdeploy/remote/nodecfg/nodeConfigurator.go
@@ -35,6 +35,7 @@ import (
 type nodeConfigurator struct {
 	config                  remote.HostConfig
 	dnsName                 string
+	dnsTTL                  uint
 	genesisFile             string
 	genesisData             bookkeeping.Genesis
 	bootstrappedBlockFile   string
@@ -57,11 +58,14 @@ type txtEntry struct {
 
 // ApplyConfigurationToHost attempts to apply the provided configuration to the local host,
 // based on the configuration specified for the provided hostName, with node
-// directories being created / updated under the specified rootNodeDir
-func ApplyConfigurationToHost(cfg remote.HostConfig, rootConfigDir, rootNodeDir string, dnsName string) (err error) {
+// directories being created / updated under the specified rootNodeDir.
+// dnsTTL is the TTL (in seconds) applied to any DNS records created; pass
+// cloudflare.AutomaticTTL (1) to defer to Cloudflare's Automatic setting.
+func ApplyConfigurationToHost(cfg remote.HostConfig, rootConfigDir, rootNodeDir string, dnsName string, dnsTTL uint) (err error) {
 	nc := nodeConfigurator{
 		config:  cfg,
 		dnsName: dnsName,
+		dnsTTL:  dnsTTL,
 	}
 
 	return nc.apply(rootConfigDir, rootNodeDir)
@@ -231,7 +235,7 @@ func (nc *nodeConfigurator) registerDNSRecords() (err error) {
 	}
 
 	fmt.Fprintf(os.Stdout, "...... Adding DNS Record '%s' -> '%s' .\n", networkHostName, nc.dnsName)
-	cloudflareDNS.SetDNSRecord(context.Background(), recordType, networkHostName, nc.dnsName, cloudflare.AutomaticTTL, priority, proxied)
+	cloudflareDNS.SetDNSRecord(context.Background(), recordType, networkHostName, nc.dnsName, nc.dnsTTL, priority, proxied)
 
 	for _, entry := range nc.relayEndpoints {
 		port, parseErr := strconv.ParseInt(strings.Split(entry.port, ":")[1], 10, 64)
@@ -241,7 +245,7 @@ func (nc *nodeConfigurator) registerDNSRecords() (err error) {
 		fmt.Fprintf(os.Stdout, "...... Adding Relay SRV Record [%s.%s] '%s' [%d %d] -> '%s' .\n",
 			relayBootstrap, tcpProto, entry.srvName, priority, port, networkHostName)
 		err = cloudflareDNS.SetSRVRecord(context.Background(), entry.srvName, networkHostName,
-			cloudflare.AutomaticTTL, priority, uint(port), relayBootstrap, tcpProto, weight)
+			nc.dnsTTL, priority, uint(port), relayBootstrap, tcpProto, weight)
 		if err != nil {
 			return
 		}
@@ -256,7 +260,7 @@ func (nc *nodeConfigurator) registerDNSRecords() (err error) {
 		fmt.Fprintf(os.Stdout, "...... Adding Metrics SRV Record [%s.%s] '%s' [%d %d] -> '%s' .\n",
 			metricsSrv, tcpProto, entry.srvName, priority, port, networkHostName)
 		err = cloudflareDNS.SetSRVRecord(context.Background(), entry.srvName, networkHostName,
-			cloudflare.AutomaticTTL, priority, uint(port), metricsSrv, tcpProto, weight)
+			nc.dnsTTL, priority, uint(port), metricsSrv, tcpProto, weight)
 		if err != nil {
 			fmt.Fprintf(os.Stdout, "Error creating srv record: %s (%v)\n", err, entry)
 			return
@@ -281,7 +285,7 @@ func (nc *nodeConfigurator) registerDNSRecords() (err error) {
 		fmt.Fprintf(os.Stdout, "...... Adding P2P TXT Record '%s' -> '%s' .\n", dnsaddrsFrom, to)
 		const priority = 1
 		const proxied = false
-		dnsErr := cloudflareDNS.CreateDNSRecord(context.Background(), "TXT", dnsaddrsFrom, to, cloudflare.AutomaticTTL, priority, proxied)
+		dnsErr := cloudflareDNS.CreateDNSRecord(context.Background(), "TXT", dnsaddrsFrom, to, nc.dnsTTL, priority, proxied)
 		if dnsErr != nil {
 			return dnsErr
 		}

--- a/tools/network/cloudflare/createRecord.go
+++ b/tools/network/cloudflare/createRecord.go
@@ -157,8 +157,7 @@ func parseCreateDNSRecordResponse(response *http.Response) (*CreateDNSRecordResp
 // clampTTL clamps the input ttl value to the accepted range of 60 - 2147483647 or 1 ( automatic ).
 // Per Cloudflare, Automatic resolves to 300s. The documented per-plan minimum is 60s on
 // Free/Pro/Business and 30s on Enterprise; this helper enforces a 60s floor so the resulting
-// value is accepted by every plan tier. Enterprise callers that genuinely need 30s should
-// bypass this helper.
+// value is accepted by every plan tier. This function ensures success by setting a universal minimum.
 // see documentation at https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl/
 func clampTTL(ttl uint) uint {
 	if ttl <= AutomaticTTL {

--- a/tools/network/cloudflare/createRecord.go
+++ b/tools/network/cloudflare/createRecord.go
@@ -155,7 +155,10 @@ func parseCreateDNSRecordResponse(response *http.Response) (*CreateDNSRecordResp
 }
 
 // clampTTL clamps the input ttl value to the accepted range of 60 - 2147483647 or 1 ( automatic ).
-// Per Cloudflare, the per-plan minimum is 60s (30s on Enterprise) and Automatic resolves to 300s.
+// Per Cloudflare, Automatic resolves to 300s. The documented per-plan minimum is 60s on
+// Free/Pro/Business and 30s on Enterprise; this helper enforces a 60s floor so the resulting
+// value is accepted by every plan tier. Enterprise callers that genuinely need 30s should
+// bypass this helper.
 // see documentation at https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl/
 func clampTTL(ttl uint) uint {
 	if ttl <= AutomaticTTL {

--- a/tools/network/cloudflare/createRecord.go
+++ b/tools/network/cloudflare/createRecord.go
@@ -154,14 +154,15 @@ func parseCreateDNSRecordResponse(response *http.Response) (*CreateDNSRecordResp
 	return &parsedReponse, nil
 }
 
-// clampTTL clamps the input ttl value to the accepted range of 120 - 2147483647 or 1 ( automatic )
-// see documentation at https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record
+// clampTTL clamps the input ttl value to the accepted range of 60 - 2147483647 or 1 ( automatic ).
+// Per Cloudflare, the per-plan minimum is 60s (30s on Enterprise) and Automatic resolves to 300s.
+// see documentation at https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl/
 func clampTTL(ttl uint) uint {
 	if ttl <= AutomaticTTL {
 		ttl = AutomaticTTL // automatic.
 	}
-	if ttl > AutomaticTTL && ttl < 120 {
-		ttl = 120
+	if ttl > AutomaticTTL && ttl < 60 {
+		ttl = 60
 	}
 	if ttl > 2147483647 {
 		ttl = 2147483647


### PR DESCRIPTION
## Summary

nodecfg, algons, and algorelay all created Cloudflare DNS records with AutomaticTTL, which Cloudflare resolves to 300s. This change makes 60s the default and exposes a --ttl flag on each command for manual overrides. Per Cloudflare's TTL docs: minimum 60s on Free/Pro/Business plans, 30s on Enterprise, Auto = 300s.

### Changes

`tools/network/cloudflare/createRecord.go`
- clampTTL: floor lowered 120 → 60 to match the actual per-plan minimum.

`netdeploy/remote/nodecfg/nodeConfigurator.go`
- Added dnsTTL uint field on nodeConfigurator.
- ApplyConfigurationToHost(...) gains a dnsTTL uint parameter.
- The four cloudflare.AutomaticTTL literals in registerDNSRecords() (A/CNAME, two SRV record loops, p2p TXT) now use nc.dnsTTL.

`cmd/nodecfg/apply.go`
- New --ttl flag (default 60), threaded through doApply → ApplyConfigurationToHost.

`cmd/algons/dnsCmd.go and cmd/algons/dnsaddrCmd.go`
- New --ttl flag on dns add and on dnsaddr tree create (each default 60).
- doAddDNS and doAddTXT now accept ttl uint.

`cmd/algorelay/relayCmd.go`
- New --ttl flag on update (default 60), stored in package-level ttlArg.
- addDNSRecord and addSRVRecord now use ttlArg instead of AutomaticTTL.

### Behavioral notes

- Existing automation that runs these commands without --ttl will rewrite records with 60s TTL instead of auto.
- Pass --ttl 1 to restore the previous Cloudflare automatic TTL.

## Test Plan

- go build clean on all five affected packages
- go vet clean on all five affected packages
- Manual: test deployment works
