### PR TITLE
agreement: skip block assembly for accounts that are not elected

### DIFF
--- a/agreement/pseudonode.go
+++ b/agreement/pseudonode.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/algorand/go-algorand/data/account"
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/committee"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/logging/logspec"
 	"github.com/algorand/go-algorand/logging/telemetryspec"
@@ -282,11 +283,74 @@ func (n asyncPseudonode) makePseudonodeVerifier(voteVerifier *AsyncVoteVerifier)
 	return pv
 }
 
+// filterProposers returns the subset of accounts that are selected as proposers
+// for the given round and period, determined by verifying their VRF credentials
+// against committee membership. This check uses only ledger state — no block
+// assembly is required — allowing callers to skip the expensive AssembleBlock
+// call when no accounts are elected.
+func (n asyncPseudonode) filterProposers(round basics.Round, period period, accounts []account.ParticipationRecordForRound) []account.ParticipationRecordForRound {
+	cparams, err := n.ledger.ConsensusParams(ParamsRound(round))
+	if err != nil {
+		n.log.Warnf("pseudonode.filterProposers: could not get consensus params for round %d: %v", round, err)
+		return nil
+	}
+
+	balanceRound := BalanceRound(round, cparams)
+	seedRnd := seedRound(round, cparams)
+
+	// Fetch shared values once; all accounts in a round use the same seed and total money.
+	seed, err := n.ledger.Seed(seedRnd)
+	if err != nil {
+		n.log.Warnf("pseudonode.filterProposers: could not get seed for round %d: %v", seedRnd, err)
+		return nil
+	}
+
+	total, err := n.ledger.Circulation(balanceRound, round)
+	if err != nil {
+		n.log.Warnf("pseudonode.filterProposers: could not get circulation for round %d: %v", balanceRound, err)
+		return nil
+	}
+
+	sel := selector{Seed: seed, Round: round, Period: period, Step: propose}
+
+	// Pre-allocate with capacity to avoid reallocation during append.
+	selected := make([]account.ParticipationRecordForRound, 0, len(accounts))
+
+	// Create membership template with shared fields; only Record varies per account.
+	m := committee.Membership{
+		Selector:   sel,
+		TotalMoney: total,
+	}
+
+	for _, acc := range accounts {
+		record, err := n.ledger.LookupAgreement(balanceRound, acc.Account)
+		if err != nil {
+			n.log.Warnf("pseudonode.filterProposers: could not look up account %v: %v", acc.Account, err)
+			continue
+		}
+
+		m.Record = committee.BalanceRecord{OnlineAccountData: record, Addr: acc.Account}
+
+		cred := committee.MakeCredential(&acc.VRF.SK, m.Selector)
+		if _, err = cred.Verify(cparams, m); err == nil {
+			selected = append(selected, acc)
+		}
+	}
+	return selected
+}
+
 // makeProposals creates a slice of block proposals for the given round and period.
 func (n asyncPseudonode) makeProposals(round basics.Round, period period, accounts []account.ParticipationRecordForRound) ([]proposal, []unauthenticatedVote) {
-	addresses := make([]basics.Address, len(accounts))
-	for i := range accounts {
-		addresses[i] = accounts[i].Account
+	// Check credential eligibility before the expensive block assembly.
+	// Only accounts selected as proposers proceed to block generation.
+	selectedAccounts := n.filterProposers(round, period, accounts)
+	if len(selectedAccounts) == 0 {
+		return nil, nil
+	}
+
+	addresses := make([]basics.Address, len(selectedAccounts))
+	for i := range selectedAccounts {
+		addresses[i] = selectedAccounts[i].Account
 	}
 	ve, err := n.factory.AssembleBlock(round, addresses)
 	if err != nil {
@@ -296,9 +360,9 @@ func (n asyncPseudonode) makeProposals(round basics.Round, period period, accoun
 		return nil, nil
 	}
 
-	votes := make([]unauthenticatedVote, 0, len(accounts))
-	proposals := make([]proposal, 0, len(accounts))
-	for _, acc := range accounts {
+	votes := make([]unauthenticatedVote, 0, len(selectedAccounts))
+	proposals := make([]proposal, 0, len(selectedAccounts))
+	for _, acc := range selectedAccounts {
 		payload, proposal, pErr := proposalForBlock(acc.Account, acc.VRF, ve, period, n.ledger)
 		if pErr != nil {
 			n.log.Errorf("pseudonode.makeProposals: could not create proposal for block (address %v): %v", acc.Account, pErr)

--- a/agreement/pseudonode.go
+++ b/agreement/pseudonode.go
@@ -283,12 +283,21 @@ func (n asyncPseudonode) makePseudonodeVerifier(voteVerifier *AsyncVoteVerifier)
 	return pv
 }
 
+// eligibleProposer is a participating account that has been selected as a
+// proposer, along with the VRF credential that proved its selection. The
+// credential is retained so that makeProposals can reuse it in the proposal
+// vote instead of recomputing the VRF proof.
+type eligibleProposer struct {
+	account.ParticipationRecordForRound
+	cred committee.UnauthenticatedCredential
+}
+
 // filterProposers returns the subset of accounts that are selected as proposers
 // for the given round and period, determined by verifying their VRF credentials
 // against committee membership. This check uses only ledger state — no block
 // assembly is required — allowing callers to skip the expensive AssembleBlock
 // call when no accounts are elected.
-func (n asyncPseudonode) filterProposers(round basics.Round, period period, accounts []account.ParticipationRecordForRound) []account.ParticipationRecordForRound {
+func (n asyncPseudonode) filterProposers(round basics.Round, period period, accounts []account.ParticipationRecordForRound) []eligibleProposer {
 	cparams, err := n.ledger.ConsensusParams(ParamsRound(round))
 	if err != nil {
 		n.log.Warnf("pseudonode.filterProposers: could not get consensus params for round %d: %v", round, err)
@@ -314,7 +323,7 @@ func (n asyncPseudonode) filterProposers(round basics.Round, period period, acco
 	sel := selector{Seed: seed, Round: round, Period: period, Step: propose}
 
 	// Pre-allocate with capacity to avoid reallocation during append.
-	selected := make([]account.ParticipationRecordForRound, 0, len(accounts))
+	selected := make([]eligibleProposer, 0, len(accounts))
 
 	// Create membership template with shared fields; only Record varies per account.
 	m := committee.Membership{
@@ -333,7 +342,7 @@ func (n asyncPseudonode) filterProposers(round basics.Round, period period, acco
 
 		cred := committee.MakeCredential(&acc.VRF.SK, m.Selector)
 		if _, err = cred.Verify(cparams, m); err == nil {
-			selected = append(selected, acc)
+			selected = append(selected, eligibleProposer{ParticipationRecordForRound: acc, cred: cred})
 		}
 	}
 	return selected
@@ -369,9 +378,9 @@ func (n asyncPseudonode) makeProposals(round basics.Round, period period, accoun
 			continue
 		}
 
-		// attempt to make the vote
+		// attempt to make the vote, reusing the VRF credential computed by filterProposers
 		rv := rawVote{Sender: acc.Account, Round: round, Period: period, Step: propose, Proposal: proposal}
-		uv, vErr := makeVote(rv, acc.VotingSigner(), acc.VRF, n.ledger)
+		uv, vErr := makeVoteWithCredential(rv, acc.VotingSigner(), acc.cred, n.ledger)
 		if vErr != nil {
 			n.log.Warnf("pseudonode.makeProposals: could not create vote: %v", vErr)
 			continue

--- a/agreement/pseudonode_bench_test.go
+++ b/agreement/pseudonode_bench_test.go
@@ -1,0 +1,209 @@
+// Copyright (C) 2019-2026 Algorand Foundation Ltd.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package agreement
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/algorand/go-algorand/data/account"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/logging"
+)
+
+// slowBlockFactory adds a fixed delay to AssembleBlock to simulate the cost
+// of assembling a real block from the transaction pool.
+type slowBlockFactory struct {
+	BlockFactory
+	delay time.Duration
+}
+
+func (f slowBlockFactory) AssembleBlock(r basics.Round, addrs []basics.Address) (UnfinishedBlock, error) {
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+	return f.BlockFactory.AssembleBlock(r, addrs)
+}
+
+// makeProposalsOldStyle recreates the pre-filterProposers behaviour: it
+// calls AssembleBlock unconditionally and then iterates over all accounts.
+// This is the baseline that the new makeProposals (with filterProposers)
+// optimises.
+func (n asyncPseudonode) makeProposalsOldStyle(round basics.Round, period period, accounts []account.ParticipationRecordForRound) ([]proposal, []unauthenticatedVote) {
+	addresses := make([]basics.Address, len(accounts))
+	for i := range accounts {
+		addresses[i] = accounts[i].Account
+	}
+	ve, err := n.factory.AssembleBlock(round, addresses)
+	if err != nil {
+		if err != ErrAssembleBlockRoundStale {
+			n.log.Errorf("pseudonode.makeProposalsOldStyle: could not generate a proposal for round %d: %v", round, err)
+		}
+		return nil, nil
+	}
+
+	votes := make([]unauthenticatedVote, 0, len(accounts))
+	proposals := make([]proposal, 0, len(accounts))
+	for _, acc := range accounts {
+		payload, proposal, pErr := proposalForBlock(acc.Account, acc.VRF, ve, period, n.ledger)
+		if pErr != nil {
+			continue
+		}
+
+		rv := rawVote{Sender: acc.Account, Round: round, Period: period, Step: propose, Proposal: proposal}
+		uv, vErr := makeVote(rv, acc.VotingSigner(), acc.VRF, n.ledger)
+		if vErr != nil {
+			continue
+		}
+
+		proposals = append(proposals, payload)
+		votes = append(votes, uv)
+	}
+
+	return proposals, votes
+}
+
+// buildFilterBenchNode creates an asyncPseudonode ready for proposal
+// benchmarking.  If tamperAllVrf is true, every accounts SelectionID in the
+// ledger is replaced with a mismatched VRF key so that filterProposers finds
+// no eligible accounts.
+func buildFilterBenchNode(b *testing.B, numAccounts int, slowAssemble time.Duration, tamperAllVrf bool) (*asyncPseudonode, []account.ParticipationRecordForRound) {
+	b.Helper()
+
+	rootSeed := sha256.Sum256([]byte(b.Name()))
+	accounts, balances := createTestAccountsAndBalances(b, numAccounts, rootSeed[:])
+
+	if tamperAllVrf {
+		for addr := range balances {
+			differentVrf := generatePseudoRandomVRF(len(balances) + 999)
+			bd := balances[addr]
+			bd.SelectionID = differentVrf.PK
+			balances[addr] = bd
+		}
+	}
+
+	ledger := makeTestLedger(balances)
+	sLogger := serviceLogger{logging.NewLogger()}
+	sLogger.SetLevel(logging.Error) // silence warn/error logs during benchmarks
+
+	km := makeRecordingKeyManager(accounts)
+	pn := &asyncPseudonode{
+		factory:   slowBlockFactory{BlockFactory: testBlockFactory{Owner: 0}, delay: slowAssemble},
+		validator: testBlockValidator{},
+		keys:      km,
+		ledger:    ledger,
+		log:       sLogger,
+		monitor:   nil,
+	}
+
+	round := ledger.NextRound()
+	partKeys := pn.loadRoundParticipationKeys(round)
+	if len(partKeys) == 0 {
+		b.Fatal("no participation keys loaded")
+	}
+	return pn, partKeys
+}
+
+// BenchmarkFilterProposers measures the cost of the VRF credential check that
+// filterProposers performs on every account.  This is the overhead the new
+// code pays each round to determine whether any account is elected.
+//
+// On Apple M2 Pro, typical results:
+//
+//	1 account   ~0.26 ms/op
+//	5 accounts  ~1.28 ms/op
+//	10 accounts ~2.55 ms/op
+//	50 accounts ~12.76 ms/op
+func BenchmarkFilterProposers(b *testing.B) {
+	for _, n := range []int{1, 5, 10, 50} {
+		b.Run(fmt.Sprintf("%daccounts", n), func(b *testing.B) {
+			pn, partKeys := buildFilterBenchNode(b, n, 0, false)
+			round := pn.ledger.NextRound()
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				pn.filterProposers(round, period(i%10), partKeys)
+			}
+		})
+	}
+}
+
+// BenchmarkMakeProposals_OldStyle_NotElected simulates the pre-branch
+// behaviour when no accounts are elected to propose: AssembleBlock is called
+// unconditionally, paying its full cost, even though all vote credentials
+// will ultimately fail verification.
+//
+// Mismatched VRF keys ensure filterProposers (if it existed) would return
+// empty, making this a direct measurement of the waste eliminated by the
+// optimisation.
+func BenchmarkMakeProposals_OldStyle_NotElected(b *testing.B) {
+	for _, delay := range []time.Duration{1 * time.Millisecond, 10 * time.Millisecond} {
+		b.Run(fmt.Sprintf("AssembleDelay_%s", delay), func(b *testing.B) {
+			pn, partKeys := buildFilterBenchNode(b, 10, delay, true)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				pn.makeProposalsOldStyle(pn.ledger.NextRound(), period(i%5), partKeys)
+			}
+		})
+	}
+}
+
+// BenchmarkMakeProposals_NewStyle_NotElected shows the new behaviour when
+// no accounts are elected: filterProposers determines this inexpensively
+// (no AssembleBlock call), and makeProposals returns immediately.
+//
+// Compare this against BenchmarkMakeProposals_OldStyle_NotElected to see
+// the speedup: new style takes only the filterProposers cost (see
+// BenchmarkFilterProposers/10accounts), while old style also pays the
+// full AssembleBlock delay.
+func BenchmarkMakeProposals_NewStyle_NotElected(b *testing.B) {
+	for _, delay := range []time.Duration{1 * time.Millisecond, 10 * time.Millisecond} {
+		b.Run(fmt.Sprintf("AssembleDelay_%s", delay), func(b *testing.B) {
+			pn, partKeys := buildFilterBenchNode(b, 10, delay, true)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				pn.makeProposals(pn.ledger.NextRound(), period(i%5), partKeys)
+			}
+		})
+	}
+}
+
+// BenchmarkMakeProposals_Elected measures the (small) overhead that
+// filterProposers adds when accounts ARE elected: the filter still pays
+// a VRF credential check per account, then proceeds with AssembleBlock
+// and the rest of the pipeline.
+//
+// With 1 account holding 100% of the stake, election is essentially
+// deterministic (P(weight=0) ≈ e⁻²⁰), so we get a stable measurement.
+func BenchmarkMakeProposals_Elected(b *testing.B) {
+	for _, delay := range []time.Duration{1 * time.Millisecond, 10 * time.Millisecond} {
+		for _, n := range []int{1, 5, 10} {
+			b.Run(fmt.Sprintf("AssembleDelay_%s/%daccounts", delay, n), func(b *testing.B) {
+				pn, partKeys := buildFilterBenchNode(b, n, delay, false)
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					pn.makeProposals(pn.ledger.NextRound(), period(i%5), partKeys)
+				}
+			})
+		}
+	}
+}

--- a/agreement/pseudonode_test.go
+++ b/agreement/pseudonode_test.go
@@ -26,8 +26,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/account"
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/committee"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
@@ -545,5 +547,272 @@ func TestPseudonodeNonEnqueuedTasks(t *testing.T) {
 		drainChannel(ch)
 	}
 	require.Equal(t, enqueuedVotes*len(accounts), subStrLogger.instancesFound[0])
-	require.Equal(t, enqueuedProposals*len(accounts), subStrLogger.instancesFound[1])
+	// filterProposers skips block assembly and vote creation for unelected accounts,
+	// so the number of failed-to-enqueue messages may be less than enqueuedProposals*len(accounts).
+	require.LessOrEqual(t, subStrLogger.instancesFound[1], enqueuedProposals*len(accounts))
+}
+
+// TestFilterProposers verifies that filterProposers correctly identifies which
+// accounts are eligible to propose based on VRF credentials. It covers the
+// happy path (subset filtering), the zero-stake case (no eligible accounts),
+// and the mismatched VRF key case (account filtered out).
+func TestFilterProposers(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	t.Run("subsetOfInput", func(t *testing.T) {
+		t.Parallel()
+
+		rootSeed := sha256.Sum256([]byte(t.Name()))
+		accounts, balances := createTestAccountsAndBalances(t, 10, rootSeed[:])
+		ledger := makeTestLedger(balances)
+
+		sLogger := serviceLogger{logging.NewLogger()}
+		sLogger.SetLevel(logging.Warn)
+
+		keyManager := makeRecordingKeyManager(accounts)
+		pn := asyncPseudonode{
+			factory:   testBlockFactory{Owner: 0},
+			validator: testBlockValidator{},
+			keys:      keyManager,
+			ledger:    ledger,
+			log:       sLogger,
+			monitor:   nil,
+		}
+
+		round := ledger.NextRound()
+		partKeys := pn.loadRoundParticipationKeys(round)
+		require.NotEmpty(t, partKeys)
+
+		originalSet := make(map[basics.Address]bool, len(partKeys))
+		for _, acc := range partKeys {
+			originalSet[acc.Account] = true
+		}
+
+		// Test multiple periods; sortition is random and depends on
+		// the period via the selector, so we exercise different
+		// selection outcomes.
+		totalSelected := 0
+		for p := period(0); p < 20; p++ {
+			result := pn.filterProposers(round, p, partKeys)
+
+			// Result should always be a subset of the input.
+			require.LessOrEqual(t, len(result), len(partKeys),
+				"period %d: result len %d > input len %d", p, len(result), len(partKeys))
+
+			for _, acc := range result {
+				assert.True(t, originalSet[acc.Account],
+					"period %d: account %v not in original set", p, acc.Account)
+			}
+
+			totalSelected += len(result)
+		}
+		// With 10 equal-stake accounts and NumProposers=20,
+		// at least one account should be selected across 20 periods.
+		require.Greater(t, totalSelected, 0,
+			"expected at least one account to be selected across 20 periods")
+	})
+
+	t.Run("noEligibleAccounts", func(t *testing.T) {
+		t.Parallel()
+
+		rootSeed := sha256.Sum256([]byte(t.Name()))
+		accounts, balances := createTestAccountsAndBalances(t, 5, rootSeed[:])
+
+		// Keep the first account with stake; zero out the rest.
+		// A zero total circulation panics in credential.Verify, so we
+		// test that zero-stake accounts are never selected while at
+		// least one non-zero account keeps the circulation positive.
+		stakedAddr := accounts[0].Parent
+		for addr, b := range balances {
+			if addr == stakedAddr {
+				continue
+			}
+			b.MicroAlgos = basics.MicroAlgos{Raw: 0}
+			balances[addr] = b
+		}
+		ledger := makeTestLedger(balances)
+
+		sLogger := serviceLogger{logging.NewLogger()}
+		sLogger.SetLevel(logging.Warn)
+
+		keyManager := makeRecordingKeyManager(accounts)
+		pn := asyncPseudonode{
+			factory:   testBlockFactory{Owner: 0},
+			validator: testBlockValidator{},
+			keys:      keyManager,
+			ledger:    ledger,
+			log:       sLogger,
+			monitor:   nil,
+		}
+
+		round := ledger.NextRound()
+		partKeys := pn.loadRoundParticipationKeys(round)
+		require.NotEmpty(t, partKeys)
+
+		// Test multiple periods: zero-stake accounts must never appear.
+		for p := period(0); p < 10; p++ {
+			result := pn.filterProposers(round, p, partKeys)
+			for _, acc := range result {
+				assert.Equal(t, stakedAddr, acc.Account,
+					"period %d: zero-stake account %v should be filtered out", p, acc.Account)
+			}
+		}
+	})
+
+	t.Run("mismatchedVrfKey", func(t *testing.T) {
+		t.Parallel()
+
+		// Create two accounts with standard matching VRF keys.
+		rootSeed := sha256.Sum256([]byte(t.Name()))
+		accounts, balances := createTestAccountsAndBalances(t, 2, rootSeed[:])
+
+		// Tamper with the first account: replace its SelectionID in the
+		// ledger with a completely different VRF public key so that
+		// credential verification fails.
+		tamperedAddr := accounts[0].Parent
+		tamperedBalance := balances[tamperedAddr]
+		differentVrf := generatePseudoRandomVRF(999)
+		require.NotEqual(t, tamperedBalance.SelectionID, differentVrf.PK,
+			"mismatched VRF test requires different keys")
+		tamperedBalance.SelectionID = differentVrf.PK
+		balances[tamperedAddr] = tamperedBalance
+
+		ledger := makeTestLedger(balances)
+
+		sLogger := serviceLogger{logging.NewLogger()}
+		sLogger.SetLevel(logging.Warn)
+
+		keyManager := makeRecordingKeyManager(accounts)
+		pn := asyncPseudonode{
+			factory:   testBlockFactory{Owner: 0},
+			validator: testBlockValidator{},
+			keys:      keyManager,
+			ledger:    ledger,
+			log:       sLogger,
+			monitor:   nil,
+		}
+
+		round := ledger.NextRound()
+		partKeys := pn.loadRoundParticipationKeys(round)
+		require.Len(t, partKeys, 2)
+
+		// The tampered account should never appear in the result because
+		// its VRF proof cannot be verified by the ledger's SelectionID.
+		for p := period(0); p < 10; p++ {
+			result := pn.filterProposers(round, p, partKeys)
+			for _, acc := range result {
+				assert.NotEqual(t, tamperedAddr, acc.Account,
+					"period %d: tampered account %v should be filtered out", p, tamperedAddr)
+			}
+		}
+	})
+
+	t.Run("singleAccountSelected", func(t *testing.T) {
+		t.Parallel()
+
+		// A single account holding 100% of the stake (NumProposers=20)
+		// is selected with probability 1 - e^(-20), which is effectively
+		// deterministic. This gives us a positive test: filterProposers
+		// must return that account for every period.
+		rootSeed := sha256.Sum256([]byte(t.Name()))
+		accounts, balances := createTestAccountsAndBalances(t, 1, rootSeed[:])
+		ledger := makeTestLedger(balances)
+
+		sLogger := serviceLogger{logging.NewLogger()}
+		sLogger.SetLevel(logging.Warn)
+
+		keyManager := makeRecordingKeyManager(accounts)
+		pn := asyncPseudonode{
+			factory:   testBlockFactory{Owner: 0},
+			validator: testBlockValidator{},
+			keys:      keyManager,
+			ledger:    ledger,
+			log:       sLogger,
+			monitor:   nil,
+		}
+
+		round := ledger.NextRound()
+		partKeys := pn.loadRoundParticipationKeys(round)
+		require.Len(t, partKeys, 1)
+
+		for p := period(0); p < 20; p++ {
+			result := pn.filterProposers(round, p, partKeys)
+			require.Len(t, result, 1,
+				"period %d: single 100%%-stake account must be selected", p)
+			assert.Equal(t, accounts[0].Parent, result[0].Account)
+		}
+	})
+
+	t.Run("ledgerErrors", func(t *testing.T) {
+		t.Parallel()
+
+		// Use a ledger wrapper that injects errors to verify that
+		// filterProposers returns nil for each error path.
+		rootSeed := sha256.Sum256([]byte(t.Name()))
+		accounts, balances := createTestAccountsAndBalances(t, 5, rootSeed[:])
+		realLedger := makeTestLedger(balances)
+
+		sLogger := serviceLogger{logging.NewLogger()}
+		sLogger.SetLevel(logging.Warn)
+
+		keyManager := makeRecordingKeyManager(accounts)
+		round := realLedger.NextRound()
+		partKeys := keyManager.VotingKeys(round, round)
+		require.NotEmpty(t, partKeys)
+
+		// Seed error.
+		errLedger := &errorInjectingLedger{Ledger: realLedger, failSeed: true}
+		pn := asyncPseudonode{
+			factory:   testBlockFactory{Owner: 0},
+			validator: testBlockValidator{},
+			keys:      keyManager,
+			ledger:    errLedger,
+			log:       sLogger,
+			monitor:   nil,
+		}
+		result := pn.filterProposers(round, period(0), partKeys)
+		assert.Nil(t, result, "should return nil on Seed error")
+
+		// Circulation error.
+		errLedger = &errorInjectingLedger{Ledger: realLedger, failCirculation: true}
+		pn.ledger = errLedger
+		result = pn.filterProposers(round, period(0), partKeys)
+		assert.Nil(t, result, "should return nil on Circulation error")
+
+		// ConsensusParams error.
+		errLedger = &errorInjectingLedger{Ledger: realLedger, failConsensusParams: true}
+		pn.ledger = errLedger
+		result = pn.filterProposers(round, period(0), partKeys)
+		assert.Nil(t, result, "should return nil on ConsensusParams error")
+	})
+}
+
+// errorInjectingLedger wraps a Ledger and injects errors for specific methods
+// to test error-handling paths in filterProposers.
+type errorInjectingLedger struct {
+	Ledger
+	failSeed            bool
+	failCirculation     bool
+	failConsensusParams bool
+}
+
+func (l *errorInjectingLedger) Seed(r basics.Round) (committee.Seed, error) {
+	if l.failSeed {
+		return committee.Seed{}, fmt.Errorf("injected Seed error")
+	}
+	return l.Ledger.Seed(r)
+}
+
+func (l *errorInjectingLedger) Circulation(r basics.Round, voteRnd basics.Round) (basics.MicroAlgos, error) {
+	if l.failCirculation {
+		return basics.MicroAlgos{}, fmt.Errorf("injected Circulation error")
+	}
+	return l.Ledger.Circulation(r, voteRnd)
+}
+
+func (l *errorInjectingLedger) ConsensusParams(r basics.Round) (config.ConsensusParams, error) {
+	if l.failConsensusParams {
+		return config.ConsensusParams{}, fmt.Errorf("injected ConsensusParams error")
+	}
+	return l.Ledger.ConsensusParams(r)
 }

--- a/agreement/pseudonode_test.go
+++ b/agreement/pseudonode_test.go
@@ -743,6 +743,52 @@ func TestFilterProposers(t *testing.T) {
 		}
 	})
 
+	t.Run("credentialReuse", func(t *testing.T) {
+		t.Parallel()
+
+		// Votes produced by makeProposals reuse the VRF credential computed
+		// by filterProposers rather than recomputing it in makeVote. Verify
+		// that such a vote passes full verification against the ledger, and
+		// that the reused credential is identical to what makeVote would
+		// have produced.
+		rootSeed := sha256.Sum256([]byte(t.Name()))
+		accounts, balances := createTestAccountsAndBalances(t, 1, rootSeed[:])
+		ledger := makeTestLedger(balances)
+
+		sLogger := serviceLogger{logging.NewLogger()}
+		sLogger.SetLevel(logging.Warn)
+
+		keyManager := makeRecordingKeyManager(accounts)
+		pn := asyncPseudonode{
+			factory:   testBlockFactory{Owner: 0},
+			validator: testBlockValidator{},
+			keys:      keyManager,
+			ledger:    ledger,
+			log:       sLogger,
+			monitor:   nil,
+		}
+
+		round := ledger.NextRound()
+		partKeys := pn.loadRoundParticipationKeys(round)
+		require.Len(t, partKeys, 1)
+
+		// A single 100%-stake account is always elected, so makeProposals
+		// must produce exactly one proposal and one vote.
+		proposals, votes := pn.makeProposals(round, period(0), partKeys)
+		require.Len(t, proposals, 1)
+		require.Len(t, votes, 1)
+
+		// The vote (carrying the reused credential) must verify.
+		_, err := votes[0].verify(ledger)
+		require.NoError(t, err, "vote with reused credential failed verification")
+
+		// The reused credential must match the one makeVote computes from
+		// scratch: VRF proofs are deterministic for a given key and selector.
+		uv, err := makeVote(votes[0].R, partKeys[0].VotingSigner(), partKeys[0].VRF, ledger)
+		require.NoError(t, err)
+		require.Equal(t, uv.Cred, votes[0].Cred)
+	})
+
 	t.Run("ledgerErrors", func(t *testing.T) {
 		t.Parallel()
 

--- a/agreement/service_test.go
+++ b/agreement/service_test.go
@@ -637,7 +637,7 @@ func generatePseudoRandomVRF(keynum int) *crypto.VRFSecrets {
 	}
 }
 
-func createTestAccountsAndBalances(t *testing.T, numNodes int, rootSeed []byte) (accounts []account.Participation, balances map[basics.Address]basics.AccountData) {
+func createTestAccountsAndBalances(tb testing.TB, numNodes int, rootSeed []byte) (accounts []account.Participation, balances map[basics.Address]basics.AccountData) {
 	off := int(rand.Uint32() >> 2) // prevent name collision from running tests more than once
 
 	// system state setup: keygen, stake initialization
@@ -650,11 +650,11 @@ func createTestAccountsAndBalances(t *testing.T, numNodes int, rootSeed []byte) 
 		var rootAddress basics.Address
 		// add new account rootAddress to db
 		{
-			rootAccess, err := db.MakeAccessor(t.Name()+"root"+strconv.Itoa(i+off), false, true)
-			require.NoError(t, err)
+			rootAccess, err := db.MakeAccessor(tb.Name()+"root"+strconv.Itoa(i+off), false, true)
+			require.NoError(tb, err)
 			seed = sha256.Sum256(seed[:]) // rehash every node to get different root addresses
 			root, err := account.ImportRoot(rootAccess, seed)
-			require.NoError(t, err)
+			require.NoError(tb, err)
 			rootAddress = root.Address()
 		}
 

--- a/agreement/vote.go
+++ b/agreement/vote.go
@@ -161,6 +161,15 @@ func makeVote(rv rawVote, voting crypto.OneTimeSigner, selection *crypto.VRFSecr
 		return unauthenticatedVote{}, fmt.Errorf("makeVote: could not get membership parameters: %v", err)
 	}
 
+	cred := committee.MakeCredential(&selection.SK, m.Selector)
+	return makeVoteWithCredential(rv, voting, cred, l)
+}
+
+// makeVoteWithCredential creates a new unauthenticated vote using a
+// previously computed VRF credential, avoiding the membership lookup and
+// VRF prove that makeVote performs. The credential must have been created
+// for the same (sender, round, period, step) selector as rv.
+func makeVoteWithCredential(rv rawVote, voting crypto.OneTimeSigner, cred committee.UnauthenticatedCredential, l Ledger) (unauthenticatedVote, error) {
 	proto, err := l.ConsensusParams(ParamsRound(rv.Round))
 	if err != nil {
 		return unauthenticatedVote{}, fmt.Errorf("makeVote: could not get consensus params for round %d: %v", ParamsRound(rv.Round), err)
@@ -183,7 +192,6 @@ func makeVote(rv rawVote, voting crypto.OneTimeSigner, selection *crypto.VRFSecr
 		return unauthenticatedVote{}, fmt.Errorf("makeVote: got back empty signature for vote")
 	}
 
-	cred := committee.MakeCredential(&selection.SK, m.Selector)
 	ret := unauthenticatedVote{R: rv, Cred: cred, Sig: sig}
 
 	// for use when running in tests


### PR DESCRIPTION
This PR is similar to #4976 (and addresses #590) but checks whether participating keys are actually elected, rather than only whether keys exist. It supersedes the agreement-side portion of #4976; the transaction pool and `IsParticipating` pieces of that PR remain possible follow-up work.

## Summary

Every round, every participation node calls `AssembleBlock` and runs the full proposal pipeline (block finishing, encoding and digest, seed derivation, vote signing, local credential verification) for every participation key, even when none of its accounts can possibly be elected. The election result is only discovered afterwards, when the local vote verifier rejects the credentials, so for the overwhelming majority of rounds all of that work is thrown away.

This PR adds a pre-check, `filterProposers`, that verifies each account's VRF credential against committee membership using only ledger state, before any block assembly happens. `makeProposals` then runs the pipeline only for the accounts that are actually elected, and returns immediately (no `AssembleBlock` call) when none are. A follow-up commit reuses the credential computed by the filter in the proposal vote, so elected accounts pay no extra VRF prove compared to the current code.

## What is (and is not) skipped

Skipped for non-elected accounts:

- the agreement-side `AssembleBlock` call and its result handling
- `proposalForBlock` per account: seed derivation (VRF prove), payout eligibility lookups, `FinishBlock`, and the encode + digest of the full block payload per proposal
- `makeVote` per account: one-time signature and VRF prove
- local `AsyncVoteVerifier` work for votes that were always going to fail

Not skipped: the transaction pool's speculative per-round block evaluation (`recomputeBlockEvaluator`), which runs on `OnNewBlock` regardless of this change. Gating that as well (in the spirit of #4976) is left as follow-up work.

Cost added: one VRF prove + verify per key per round in `filterProposers` (~0.26 ms per account, benchmarked below). For elected accounts the prove is reused in the vote, so the elected path nets out to one extra VRF verify.

## How filterProposers stays correct

`filterProposers` computes membership from exactly the same inputs as vote verification (`membership()` in `selector.go`: same `ParamsRound`, `BalanceRound`, seed round, and circulation arguments), so its accept/reject decision is identical to what the async vote verifier would decide later. Sortition is deterministic given the key and selector, so no account that could have produced a valid proposal vote is ever filtered out, and nothing that previously reached the network can fail to reach it now.

The credential reuse is safe for the same reason: the vote carries a credential proven over the identical selector, and a test (`credentialReuse`) asserts the reused credential is byte-identical to one computed from scratch and that the resulting vote passes full `unauthenticatedVote.verify`.

Reproposals are unaffected: the `repropose` action goes through `MakeVotes` -> `makeVote`, not through `makeProposals`.

Note: in the `makeVote` wrapper the credential is now computed before signing (previously after), so a vote that fails at signing pays for one unused VRF prove. That path only occurs when the one-time voting key for the round is unavailable, and was judged not worth the complexity of deferring the prove.

## Real-world impact

Election probability depends on the account's share of online stake (`P = 1 - (1 - f)^20`). Against the current MainNet online stake distribution (1,430 online accounts, ~1.66B ALGO online):

| Online stake | Elected per round | Rounds skipped |
| --- | --- | --- |
| 30M ALGO | 30.6% | 69.4% |
| 10M ALGO | 11.4% | 88.6% |
| 1M ALGO | 1.2% | 98.8% |
| 100k ALGO | 0.12% | 99.88% |
| 30k ALGO | 0.04% | 99.96% |

94% of MainNet participation accounts hold under 3M ALGO and skip more than 98% of rounds. Network-wide, ~44.1M proposal pipeline executions per day drop to ~0.53M, a 98.8% reduction, in exchange for the cheap filter check.

Log analysis from a participation node with 2 keys over 1,087 rounds (~50 minutes) showed the agreement-side assembly call was useful in 1 round and wasted in the other 1,086 (99.9%).

## Benchmarks (Apple M2 Pro)

```
BenchmarkFilterProposers/1accounts     0.26 ms/op
BenchmarkFilterProposers/10accounts    2.55 ms/op
BenchmarkFilterProposers/50accounts   12.76 ms/op
```

Comparison, 10 accounts, not elected:

| Simulated AssembleBlock | Old-style | New-style | Speedup |
| --- | --- | --- | --- |
| 1 ms | 3.51 ms | 2.62 ms | 1.3x |
| 10 ms | 14.17 ms | 2.63 ms | 5.4x |

New-style time is independent of AssembleBlock latency; it only pays the VRF credential check.

## E2E validation

Two private-network comparisons against the merge-base build, identical topology and load on each side:

- 5 nodes with equal 20% stake, 150 rounds: all nodes in sync every round, identical proposer coverage and broadcast rates, one startup-only period recovery on both sides, zero errors.
- 10 nodes with a MainNet-shaped skew (2 whale nodes at 35%, 6 nodes with 5 keys of 0.25% each, 1 node with no keys, 1 relay) under 200 TPS pingpong load (~900 txns/block), 200+ rounds: the 5-key nodes skipped assembly in ~72% of rounds (theory predicts 72.4%), including many partial rounds where only 1-3 of 5 keys proceeded; wire behavior, proposer distribution, liveness, and recovery behavior were indistinguishable from the base build; zero errors on either side.

## Observability note

The `pseudonode: made N proposals` log line and the `ProposalAssembled` logspec event now report the elected count (usually 0) instead of the number of participation keys, and the transaction pool's assemble-block telemetry fires only on elected rounds. Anything parsing these will see lower numbers; that reduction is the point of the PR.

## Test coverage

`TestFilterProposers` - 6 subtests:

- `subsetOfInput` - result is a subset of input across 20 periods; positive assertion that at least one account is selected
- `noEligibleAccounts` - zero-stake accounts never appear
- `mismatchedVrfKey` - wrong VRF key is filtered out
- `singleAccountSelected` - 100% stake is always elected (P(fail) ~ 1e-9)
- `credentialReuse` - a vote built from the reused credential passes full verification and its credential is byte-identical to one computed from scratch
- `ledgerErrors` - returns nil on Seed / Circulation / ConsensusParams failures (matching the rounds where the old pipeline would also have failed)

All existing agreement tests pass, including the agreement fuzzer, with race detection enabled.
