### PR TITLE
goal: add empty refs flag

### DIFF
--- a/cmd/goal/application.go
+++ b/cmd/goal/application.go
@@ -77,6 +77,8 @@ var (
 	appStrBoxes    []string // parse these as we do app args, with optional number and comma in front
 	appStrAccounts []string
 
+	appEmptyRefs uint64
+
 	// for these, an omitted addr is the sender. an omitted app is the called app.
 	appStrHoldings []string // format: asset+addr OR asset ex: 5245+XQJEJECPWUOXSKMIC5TCSARPVGHQJIIOKHO7WTKEPPLJMKG3D7VWWID66E
 	appStrLocals   []string // format: app+addr OR app OR addr
@@ -112,6 +114,7 @@ func init() {
 	appCmd.PersistentFlags().StringSliceVar(&appStrAccounts, "app-account", nil, "Accounts that may be accessed from application logic")
 	appCmd.PersistentFlags().StringSliceVar(&appStrHoldings, "holding", nil, "A Holding that may be accessed from application logic. An asset-id followed by a plus sign and an address")
 	appCmd.PersistentFlags().StringSliceVar(&appStrLocals, "local", nil, "A Local State that may be accessed from application logic. An optional app-id and a plus sign, followed by an address. Zero or omitted app-id indicates the local state for app being called.")
+	appCmd.PersistentFlags().Uint64Var(&appEmptyRefs, "empty-refs", 0, "Number of empty references to add for additional I/O budget. With --access, these are empty access-list refs; otherwise, empty box refs.")
 	appCmd.PersistentFlags().BoolVar(&appUseAccess, "access", false, "Put references into the transaction's access list, instead of foreign arrays.")
 
 	appCmd.PersistentFlags().StringVar(&approvalProgFile, "approval-prog", "", "(Uncompiled) TEAL assembly program filename for approving/rejecting transactions")
@@ -228,6 +231,7 @@ type appCallInputs struct {
 	Boxes         []boxRef            `codec:"boxes"`
 	Holdings      []holdingRef        `codec:"holdings"`
 	Locals        []localRef          `codec:"locals"`
+	EmptyRefs     uint64              `codec:"emptyrefs"`
 	UseAccess     bool                `codec:"access"`
 	Args          []apps.AppCallBytes `codec:"args"`
 }
@@ -361,6 +365,7 @@ func parseAppInputs(inputs appCallInputs) ([][]byte, libgoal.RefBundle) {
 		Accounts:  util.Map(inputs.Accounts, cliAddress),
 		Apps:      util.Map(inputs.ForeignApps, func(idx uint64) basics.AppIndex { return basics.AppIndex(idx) }),
 		Assets:    util.Map(inputs.ForeignAssets, func(idx uint64) basics.AssetIndex { return basics.AssetIndex(idx) }),
+		EmptyRefs: inputs.EmptyRefs,
 
 		Locals:   locals,
 		Holdings: holdings,
@@ -406,10 +411,11 @@ func getAppInputsFromCLI() appCallInputs {
 		ForeignAssets: util.Map(foreignAssets, func(s string) uint64 {
 			return parseUInt64(s, "asset id", "foreign-asset")
 		}),
-		Boxes:    util.Map(appStrBoxes, parseBoxRef),
-		Holdings: util.Map(appStrHoldings, parseHoldingRef),
-		Locals:   util.Map(appStrLocals, parseLocalRef),
-		Args:     encodedArgs,
+		Boxes:     util.Map(appStrBoxes, parseBoxRef),
+		Holdings:  util.Map(appStrHoldings, parseHoldingRef),
+		Locals:    util.Map(appStrLocals, parseLocalRef),
+		EmptyRefs: appEmptyRefs,
+		Args:      encodedArgs,
 	}
 }
 

--- a/libgoal/libgoal_test.go
+++ b/libgoal/libgoal_test.go
@@ -226,6 +226,11 @@ func TestForeignResolution(t *testing.T) {
 		{Index: 2, Name: []byte("xxx")},
 	}, tx.Boxes)
 
+	boxCount := len(tx.Boxes)
+	attachForeignRefs(&tx, RefBundle{EmptyRefs: 2})
+	a.Equal(boxCount+2, len(tx.Boxes))
+	a.Equal([]transactions.BoxRef{{}, {}}, tx.Boxes[boxCount:])
+
 	zero := basics.Address{0x00}
 	one := basics.Address{0x01}
 	two := basics.Address{0x02}
@@ -380,4 +385,9 @@ func TestAccessResolution(t *testing.T) {
 		{App: 444},
 		{Locals: transactions.LocalsRef{App: 22, Address: 15}},
 	}, tx.Access)
+
+	accessCount := len(tx.Access)
+	attachAccessList(&tx, RefBundle{EmptyRefs: 2})
+	a.Equal(accessCount+2, len(tx.Access))
+	a.Equal([]transactions.ResourceRef{{}, {}}, tx.Access[accessCount:])
 }

--- a/libgoal/transactions.go
+++ b/libgoal/transactions.go
@@ -523,6 +523,8 @@ type RefBundle struct {
 	Apps     []basics.AppIndex
 	Locals   []basics.LocalRef
 	Boxes    []basics.BoxRef
+
+	EmptyRefs uint64
 }
 
 // MakeUnsignedAppCreateTx makes a transaction for creating an application
@@ -662,6 +664,10 @@ func attachAccessList(tx *transactions.Transaction, refs RefBundle) {
 			Name:  []byte(br.Name),
 		}})
 	}
+
+	for i := uint64(0); i < refs.EmptyRefs; i++ {
+		tx.Access = append(tx.Access, transactions.ResourceRef{})
+	}
 }
 
 // maybeAppend looks for something in a slice. If found, it returns its index. If
@@ -714,6 +720,10 @@ func attachForeignRefs(tx *transactions.Transaction, refs RefBundle) {
 			Index: uint64(index),
 			Name:  []byte(br.Name),
 		})
+	}
+
+	for i := uint64(0); i < refs.EmptyRefs; i++ {
+		tx.Boxes = append(tx.Boxes, transactions.BoxRef{})
 	}
 }
 


### PR DESCRIPTION
This was identified while reviewing #6528, where empty refs are used for calling large applications, but the change is purely a convenience change for `goal`. Empty references were already valid at the transaction level and could be constructed by other means; this simply adds direct CLI support.

This PR adds a `--empty-refs` flag to `goal app` commands.

The flag appends empty references to application transactions for additional I/O budget:
  - with `--access`, it appends empty access-list references
  - without `--access`, it appends empty box references using the older resource reference arrays