### PR TITLE
txn: group signature fields into embedded struct

### DIFF
--- a/cmd/goal/application.go
+++ b/cmd/goal/application.go
@@ -1492,9 +1492,11 @@ var methodAppCmd = &cobra.Command{
 
 			if !txnFromArgs.Lsig.Blank() {
 				signedTxnGroup = append(signedTxnGroup, transactions.SignedTxn{
-					Lsig:     txnFromArgs.Lsig,
-					AuthAddr: txnFromArgs.AuthAddr,
-					Txn:      unsignedTxn,
+					SignatureFields: transactions.SignatureFields{
+						Lsig:     txnFromArgs.Lsig,
+						AuthAddr: txnFromArgs.AuthAddr,
+					},
+					Txn: unsignedTxn,
 				})
 				continue
 			}

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -466,8 +466,10 @@ var sendCmd = &cobra.Command{
 			}
 			proto := protocol.ConsensusVersion(params.ConsensusVersion)
 			uncheckedTxn := transactions.SignedTxn{
-				Txn:  payment,
-				Lsig: lsig,
+				Txn: payment,
+				SignatureFields: transactions.SignatureFields{
+					Lsig: lsig,
+				},
 			}
 			blockHeader := bookkeeping.BlockHeader{
 				UpgradeState: bookkeeping.UpgradeState{
@@ -485,11 +487,13 @@ var sendCmd = &cobra.Command{
 		} else if program != nil {
 			stx = transactions.SignedTxn{
 				Txn: payment,
-				Lsig: transactions.LogicSig{
-					Logic: program,
-					Args:  programArgs,
+				SignatureFields: transactions.SignatureFields{
+					Lsig: transactions.LogicSig{
+						Logic: program,
+						Args:  programArgs,
+					},
+					AuthAddr: authAddr,
 				},
-				AuthAddr: authAddr,
 			}
 		} else {
 			signTx := sign || (outFilename == "")

--- a/cmd/goal/inspect.go
+++ b/cmd/goal/inspect.go
@@ -126,11 +126,13 @@ func stxnToInspect(stxn transactions.SignedTxn) inspectSignedTxn {
 
 func stxnFromInspect(sti inspectSignedTxn) transactions.SignedTxn {
 	return transactions.SignedTxn{
-		Txn:      sti.Txn,
-		Sig:      sti.Sig,
-		Msig:     msigFromInspect(sti.Msig),
-		Lsig:     lsigFromInspect(sti.Lsig),
-		AuthAddr: sti.AuthAddr,
+		Txn: sti.Txn,
+		SignatureFields: transactions.SignatureFields{
+			Sig:      sti.Sig,
+			Msig:     msigFromInspect(sti.Msig),
+			Lsig:     lsigFromInspect(sti.Lsig),
+			AuthAddr: sti.AuthAddr,
+		},
 	}
 }
 

--- a/daemon/algod/api/server/v2/dryrun_test.go
+++ b/daemon/algod/api/server/v2/dryrun_test.go
@@ -206,8 +206,10 @@ func TestDryrunLogicSig(t *testing.T) {
 
 	dr.Txns = []transactions.SignedTxn{
 		{
-			Lsig: transactions.LogicSig{
-				Logic: unB64("AiABASI="),
+			SignatureFields: transactions.SignatureFields{
+				Lsig: transactions.LogicSig{
+					Logic: unB64("AiABASI="),
+				},
 			},
 		},
 		// it doesn't actually care about any txn content

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -516,7 +516,9 @@ func addBlockHelper(t *testing.T) (v2.Handlers, echo.Context, *httptest.Response
 				OnCompletion:  transactions.ClearStateOC,
 			},
 		},
-		Lsig: lsig,
+		SignatureFields: transactions.SignatureFields{
+			Lsig: lsig,
+		},
 	}
 	ad := transactions.ApplyData{
 		EvalDelta: transactions.EvalDelta{

--- a/daemon/kmd/wallet/driver/ledger.go
+++ b/daemon/kmd/wallet/driver/ledger.go
@@ -346,7 +346,9 @@ func (lw *LedgerWallet) SignTransaction(tx transactions.Transaction, pk crypto.P
 
 	stxn := transactions.SignedTxn{
 		Txn: tx,
-		Sig: sig,
+		SignatureFields: transactions.SignatureFields{
+			Sig: sig,
+		},
 	}
 
 	// Set the AuthAddr if the key we signed with doesn't match the txn sender

--- a/data/pools/transactionPool_test.go
+++ b/data/pools/transactionPool_test.go
@@ -992,8 +992,10 @@ func TestLogicSigOK(t *testing.T) {
 	}
 	signedTx := transactions.SignedTxn{
 		Txn: tx,
-		Lsig: transactions.LogicSig{
-			Logic: ops.Program,
+		SignatureFields: transactions.SignatureFields{
+			Lsig: transactions.LogicSig{
+				Logic: ops.Program,
+			},
 		},
 	}
 	require.NoError(t, transactionPool.RememberOne(signedTx))

--- a/data/transactions/logic/evalBench_test.go
+++ b/data/transactions/logic/evalBench_test.go
@@ -33,7 +33,12 @@ func BenchmarkCheckSignature(b *testing.B) {
 	txns := txntest.CreateTinyManTxGroup(b, true)
 	ops, err := logic.AssembleString(txntest.TmLsig)
 	require.NoError(b, err)
-	stxns := []transactions.SignedTxn{{Txn: txns[3].Txn(), Lsig: transactions.LogicSig{Logic: ops.Program}}}
+	stxns := []transactions.SignedTxn{{
+		Txn: txns[3].Txn(),
+		SignatureFields: transactions.SignatureFields{
+			Lsig: transactions.LogicSig{Logic: ops.Program},
+		},
+	}}
 	ep := logic.NewSigEvalParams(stxns, &proto, &logic.NoHeaderLedger{})
 	b.ResetTimer()
 

--- a/data/transactions/msgp_gen.go
+++ b/data/transactions/msgp_gen.go
@@ -188,6 +188,16 @@ import (
 //      |-----> (*) MsgIsZero
 //      |-----> ResourceRefMaxSize()
 //
+// SignatureFields
+//        |-----> (*) MarshalMsg
+//        |-----> (*) CanMarshalMsg
+//        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalMsgWithState
+//        |-----> (*) CanUnmarshalMsg
+//        |-----> (*) Msgsize
+//        |-----> (*) MsgIsZero
+//        |-----> SignatureFieldsMaxSize()
+//
 // SignedTxn
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
@@ -5152,11 +5162,11 @@ func ResourceRefMaxSize() (s int) {
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *SignedTxn) MarshalMsg(b []byte) (o []byte) {
+func (z *SignatureFields) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0001Len := uint32(5)
-	var zb0001Mask uint8 /* 6 bits */
+	zb0001Len := uint32(4)
+	var zb0001Mask uint8 /* 5 bits */
 	if (*z).Lsig.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x2
@@ -5172,10 +5182,6 @@ func (z *SignedTxn) MarshalMsg(b []byte) (o []byte) {
 	if (*z).Sig.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x10
-	}
-	if (*z).Txn.MsgIsZero() {
-		zb0001Len--
-		zb0001Mask |= 0x20
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -5200,22 +5206,17 @@ func (z *SignedTxn) MarshalMsg(b []byte) (o []byte) {
 			o = append(o, 0xa3, 0x73, 0x69, 0x67)
 			o = (*z).Sig.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x20) == 0 { // if not empty
-			// string "txn"
-			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
-			o = (*z).Txn.MarshalMsg(o)
-		}
 	}
 	return
 }
 
-func (_ *SignedTxn) CanMarshalMsg(z interface{}) bool {
-	_, ok := (z).(*SignedTxn)
+func (_ *SignatureFields) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(*SignatureFields)
 	return ok
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
-func (z *SignedTxn) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []byte, err error) {
+func (z *SignatureFields) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []byte, err error) {
 	if st.AllowableDepth == 0 {
 		err = msgp.ErrMaxDepthExceeded{}
 		return
@@ -5258,14 +5259,6 @@ func (z *SignedTxn) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 		}
 		if zb0001 > 0 {
 			zb0001--
-			bts, err = (*z).Txn.UnmarshalMsgWithState(bts, st)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "Txn")
-				return
-			}
-		}
-		if zb0001 > 0 {
-			zb0001--
 			bts, err = (*z).AuthAddr.UnmarshalMsgWithState(bts, st)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "AuthAddr")
@@ -5285,7 +5278,7 @@ func (z *SignedTxn) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 			return
 		}
 		if zb0002 {
-			(*z) = SignedTxn{}
+			(*z) = SignatureFields{}
 		}
 		for zb0001 > 0 {
 			zb0001--
@@ -5313,16 +5306,222 @@ func (z *SignedTxn) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o
 					err = msgp.WrapError(err, "Lsig")
 					return
 				}
-			case "txn":
-				bts, err = (*z).Txn.UnmarshalMsgWithState(bts, st)
-				if err != nil {
-					err = msgp.WrapError(err, "Txn")
-					return
-				}
 			case "sgnr":
 				bts, err = (*z).AuthAddr.UnmarshalMsgWithState(bts, st)
 				if err != nil {
 					err = msgp.WrapError(err, "AuthAddr")
+					return
+				}
+			default:
+				err = msgp.ErrNoField(string(field))
+				if err != nil {
+					err = msgp.WrapError(err)
+					return
+				}
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *SignatureFields) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.UnmarshalMsgWithState(bts, msgp.DefaultUnmarshalState)
+}
+func (_ *SignatureFields) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*SignatureFields)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *SignatureFields) Msgsize() (s int) {
+	s = 1 + 4 + (*z).Sig.Msgsize() + 5 + (*z).Msig.Msgsize() + 5 + (*z).Lsig.Msgsize() + 5 + (*z).AuthAddr.Msgsize()
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z *SignatureFields) MsgIsZero() bool {
+	return ((*z).Sig.MsgIsZero()) && ((*z).Msig.MsgIsZero()) && ((*z).Lsig.MsgIsZero()) && ((*z).AuthAddr.MsgIsZero())
+}
+
+// SignatureFieldsMaxSize returns a maximum valid message size for this message type
+func SignatureFieldsMaxSize() (s int) {
+	s = 1 + 4 + crypto.SignatureMaxSize() + 5 + crypto.MultisigSigMaxSize() + 5 + LogicSigMaxSize() + 5 + basics.AddressMaxSize()
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *SignedTxn) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	// omitempty: check for empty values
+	zb0001Len := uint32(5)
+	var zb0001Mask uint8 /* 7 bits */
+	if (*z).SignatureFields.Lsig.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if (*z).SignatureFields.Msig.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if (*z).SignatureFields.AuthAddr.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	if (*z).SignatureFields.Sig.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if (*z).Txn.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x4) == 0 { // if not empty
+			// string "lsig"
+			o = append(o, 0xa4, 0x6c, 0x73, 0x69, 0x67)
+			o = (*z).SignatureFields.Lsig.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not empty
+			// string "msig"
+			o = append(o, 0xa4, 0x6d, 0x73, 0x69, 0x67)
+			o = (*z).SignatureFields.Msig.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not empty
+			// string "sgnr"
+			o = append(o, 0xa4, 0x73, 0x67, 0x6e, 0x72)
+			o = (*z).SignatureFields.AuthAddr.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not empty
+			// string "sig"
+			o = append(o, 0xa3, 0x73, 0x69, 0x67)
+			o = (*z).SignatureFields.Sig.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not empty
+			// string "txn"
+			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
+			o = (*z).Txn.MarshalMsg(o)
+		}
+	}
+	return
+}
+
+func (_ *SignedTxn) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(*SignedTxn)
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *SignedTxn) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []byte, err error) {
+	if st.AllowableDepth == 0 {
+		err = msgp.ErrMaxDepthExceeded{}
+		return
+	}
+	st.AllowableDepth--
+	var field []byte
+	_ = field
+	var zb0001 int
+	var zb0002 bool
+	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if _, ok := err.(msgp.TypeError); ok {
+		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).SignatureFields.Sig.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Sig")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).SignatureFields.Msig.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Msig")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).SignatureFields.Lsig.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Lsig")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).SignatureFields.AuthAddr.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "AuthAddr")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Txn.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Txn")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			err = msgp.ErrTooManyArrayFields(zb0001)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array")
+				return
+			}
+		}
+	} else {
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0002 {
+			(*z) = SignedTxn{}
+		}
+		for zb0001 > 0 {
+			zb0001--
+			field, bts, err = msgp.ReadMapKeyZC(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+			switch string(field) {
+			case "sig":
+				bts, err = (*z).SignatureFields.Sig.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Sig")
+					return
+				}
+			case "msig":
+				bts, err = (*z).SignatureFields.Msig.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Msig")
+					return
+				}
+			case "lsig":
+				bts, err = (*z).SignatureFields.Lsig.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Lsig")
+					return
+				}
+			case "sgnr":
+				bts, err = (*z).SignatureFields.AuthAddr.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "AuthAddr")
+					return
+				}
+			case "txn":
+				bts, err = (*z).Txn.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Txn")
 					return
 				}
 			default:
@@ -5348,18 +5547,18 @@ func (_ *SignedTxn) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *SignedTxn) Msgsize() (s int) {
-	s = 1 + 4 + (*z).Sig.Msgsize() + 5 + (*z).Msig.Msgsize() + 5 + (*z).Lsig.Msgsize() + 4 + (*z).Txn.Msgsize() + 5 + (*z).AuthAddr.Msgsize()
+	s = 1 + 4 + (*z).SignatureFields.Sig.Msgsize() + 5 + (*z).SignatureFields.Msig.Msgsize() + 5 + (*z).SignatureFields.Lsig.Msgsize() + 5 + (*z).SignatureFields.AuthAddr.Msgsize() + 4 + (*z).Txn.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *SignedTxn) MsgIsZero() bool {
-	return ((*z).Sig.MsgIsZero()) && ((*z).Msig.MsgIsZero()) && ((*z).Lsig.MsgIsZero()) && ((*z).Txn.MsgIsZero()) && ((*z).AuthAddr.MsgIsZero())
+	return ((*z).SignatureFields.Sig.MsgIsZero()) && ((*z).SignatureFields.Msig.MsgIsZero()) && ((*z).SignatureFields.Lsig.MsgIsZero()) && ((*z).SignatureFields.AuthAddr.MsgIsZero()) && ((*z).Txn.MsgIsZero())
 }
 
 // SignedTxnMaxSize returns a maximum valid message size for this message type
 func SignedTxnMaxSize() (s int) {
-	s = 1 + 4 + crypto.SignatureMaxSize() + 5 + crypto.MultisigSigMaxSize() + 5 + LogicSigMaxSize() + 4 + TransactionMaxSize() + 5 + basics.AddressMaxSize()
+	s = 1 + 4 + crypto.SignatureMaxSize() + 5 + crypto.MultisigSigMaxSize() + 5 + LogicSigMaxSize() + 5 + basics.AddressMaxSize() + 4 + TransactionMaxSize()
 	return
 }
 
@@ -5368,141 +5567,141 @@ func (z *SignedTxnInBlock) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(15)
-	var zb0001Mask uint32 /* 19 bits */
+	var zb0001Mask uint32 /* 20 bits */
 	if (*z).SignedTxnWithAD.ApplyData.AssetClosingAmount == 0 {
-		zb0001Len--
-		zb0001Mask |= 0x10
-	}
-	if (*z).SignedTxnWithAD.ApplyData.ApplicationID.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x20
 	}
-	if (*z).SignedTxnWithAD.ApplyData.ClosingAmount.MsgIsZero() {
+	if (*z).SignedTxnWithAD.ApplyData.ApplicationID.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x40
 	}
-	if (*z).SignedTxnWithAD.ApplyData.ConfigAsset.MsgIsZero() {
+	if (*z).SignedTxnWithAD.ApplyData.ClosingAmount.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x80
 	}
-	if (*z).SignedTxnWithAD.ApplyData.EvalDelta.MsgIsZero() {
+	if (*z).SignedTxnWithAD.ApplyData.ConfigAsset.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x100
 	}
-	if (*z).HasGenesisHash == false {
+	if (*z).SignedTxnWithAD.ApplyData.EvalDelta.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x200
 	}
-	if (*z).HasGenesisID == false {
+	if (*z).HasGenesisHash == false {
 		zb0001Len--
 		zb0001Mask |= 0x400
 	}
-	if (*z).SignedTxnWithAD.SignedTxn.Lsig.MsgIsZero() {
+	if (*z).HasGenesisID == false {
 		zb0001Len--
 		zb0001Mask |= 0x800
 	}
-	if (*z).SignedTxnWithAD.SignedTxn.Msig.MsgIsZero() {
+	if (*z).SignedTxnWithAD.SignedTxn.SignatureFields.Lsig.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x1000
 	}
-	if (*z).SignedTxnWithAD.ApplyData.CloseRewards.MsgIsZero() {
+	if (*z).SignedTxnWithAD.SignedTxn.SignatureFields.Msig.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x2000
 	}
-	if (*z).SignedTxnWithAD.ApplyData.ReceiverRewards.MsgIsZero() {
+	if (*z).SignedTxnWithAD.ApplyData.CloseRewards.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x4000
 	}
-	if (*z).SignedTxnWithAD.ApplyData.SenderRewards.MsgIsZero() {
+	if (*z).SignedTxnWithAD.ApplyData.ReceiverRewards.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x8000
 	}
-	if (*z).SignedTxnWithAD.SignedTxn.AuthAddr.MsgIsZero() {
+	if (*z).SignedTxnWithAD.ApplyData.SenderRewards.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x10000
 	}
-	if (*z).SignedTxnWithAD.SignedTxn.Sig.MsgIsZero() {
+	if (*z).SignedTxnWithAD.SignedTxn.SignatureFields.AuthAddr.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x20000
 	}
-	if (*z).SignedTxnWithAD.SignedTxn.Txn.MsgIsZero() {
+	if (*z).SignedTxnWithAD.SignedTxn.SignatureFields.Sig.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x40000
+	}
+	if (*z).SignedTxnWithAD.SignedTxn.Txn.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x80000
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
 	if zb0001Len != 0 {
-		if (zb0001Mask & 0x10) == 0 { // if not empty
+		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "aca"
 			o = append(o, 0xa3, 0x61, 0x63, 0x61)
 			o = msgp.AppendUint64(o, (*z).SignedTxnWithAD.ApplyData.AssetClosingAmount)
 		}
-		if (zb0001Mask & 0x20) == 0 { // if not empty
+		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "apid"
 			o = append(o, 0xa4, 0x61, 0x70, 0x69, 0x64)
 			o = (*z).SignedTxnWithAD.ApplyData.ApplicationID.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x40) == 0 { // if not empty
+		if (zb0001Mask & 0x80) == 0 { // if not empty
 			// string "ca"
 			o = append(o, 0xa2, 0x63, 0x61)
 			o = (*z).SignedTxnWithAD.ApplyData.ClosingAmount.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x80) == 0 { // if not empty
+		if (zb0001Mask & 0x100) == 0 { // if not empty
 			// string "caid"
 			o = append(o, 0xa4, 0x63, 0x61, 0x69, 0x64)
 			o = (*z).SignedTxnWithAD.ApplyData.ConfigAsset.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x100) == 0 { // if not empty
+		if (zb0001Mask & 0x200) == 0 { // if not empty
 			// string "dt"
 			o = append(o, 0xa2, 0x64, 0x74)
 			o = (*z).SignedTxnWithAD.ApplyData.EvalDelta.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x200) == 0 { // if not empty
+		if (zb0001Mask & 0x400) == 0 { // if not empty
 			// string "hgh"
 			o = append(o, 0xa3, 0x68, 0x67, 0x68)
 			o = msgp.AppendBool(o, (*z).HasGenesisHash)
 		}
-		if (zb0001Mask & 0x400) == 0 { // if not empty
+		if (zb0001Mask & 0x800) == 0 { // if not empty
 			// string "hgi"
 			o = append(o, 0xa3, 0x68, 0x67, 0x69)
 			o = msgp.AppendBool(o, (*z).HasGenesisID)
 		}
-		if (zb0001Mask & 0x800) == 0 { // if not empty
+		if (zb0001Mask & 0x1000) == 0 { // if not empty
 			// string "lsig"
 			o = append(o, 0xa4, 0x6c, 0x73, 0x69, 0x67)
-			o = (*z).SignedTxnWithAD.SignedTxn.Lsig.MarshalMsg(o)
-		}
-		if (zb0001Mask & 0x1000) == 0 { // if not empty
-			// string "msig"
-			o = append(o, 0xa4, 0x6d, 0x73, 0x69, 0x67)
-			o = (*z).SignedTxnWithAD.SignedTxn.Msig.MarshalMsg(o)
+			o = (*z).SignedTxnWithAD.SignedTxn.SignatureFields.Lsig.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x2000) == 0 { // if not empty
+			// string "msig"
+			o = append(o, 0xa4, 0x6d, 0x73, 0x69, 0x67)
+			o = (*z).SignedTxnWithAD.SignedTxn.SignatureFields.Msig.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x4000) == 0 { // if not empty
 			// string "rc"
 			o = append(o, 0xa2, 0x72, 0x63)
 			o = (*z).SignedTxnWithAD.ApplyData.CloseRewards.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x4000) == 0 { // if not empty
+		if (zb0001Mask & 0x8000) == 0 { // if not empty
 			// string "rr"
 			o = append(o, 0xa2, 0x72, 0x72)
 			o = (*z).SignedTxnWithAD.ApplyData.ReceiverRewards.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x8000) == 0 { // if not empty
+		if (zb0001Mask & 0x10000) == 0 { // if not empty
 			// string "rs"
 			o = append(o, 0xa2, 0x72, 0x73)
 			o = (*z).SignedTxnWithAD.ApplyData.SenderRewards.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x10000) == 0 { // if not empty
+		if (zb0001Mask & 0x20000) == 0 { // if not empty
 			// string "sgnr"
 			o = append(o, 0xa4, 0x73, 0x67, 0x6e, 0x72)
-			o = (*z).SignedTxnWithAD.SignedTxn.AuthAddr.MarshalMsg(o)
-		}
-		if (zb0001Mask & 0x20000) == 0 { // if not empty
-			// string "sig"
-			o = append(o, 0xa3, 0x73, 0x69, 0x67)
-			o = (*z).SignedTxnWithAD.SignedTxn.Sig.MarshalMsg(o)
+			o = (*z).SignedTxnWithAD.SignedTxn.SignatureFields.AuthAddr.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x40000) == 0 { // if not empty
+			// string "sig"
+			o = append(o, 0xa3, 0x73, 0x69, 0x67)
+			o = (*z).SignedTxnWithAD.SignedTxn.SignatureFields.Sig.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x80000) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
 			o = (*z).SignedTxnWithAD.SignedTxn.Txn.MarshalMsg(o)
@@ -5536,7 +5735,7 @@ func (z *SignedTxnInBlock) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalSt
 		}
 		if zb0001 > 0 {
 			zb0001--
-			bts, err = (*z).SignedTxnWithAD.SignedTxn.Sig.UnmarshalMsgWithState(bts, st)
+			bts, err = (*z).SignedTxnWithAD.SignedTxn.SignatureFields.Sig.UnmarshalMsgWithState(bts, st)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Sig")
 				return
@@ -5544,7 +5743,7 @@ func (z *SignedTxnInBlock) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalSt
 		}
 		if zb0001 > 0 {
 			zb0001--
-			bts, err = (*z).SignedTxnWithAD.SignedTxn.Msig.UnmarshalMsgWithState(bts, st)
+			bts, err = (*z).SignedTxnWithAD.SignedTxn.SignatureFields.Msig.UnmarshalMsgWithState(bts, st)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Msig")
 				return
@@ -5552,9 +5751,17 @@ func (z *SignedTxnInBlock) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalSt
 		}
 		if zb0001 > 0 {
 			zb0001--
-			bts, err = (*z).SignedTxnWithAD.SignedTxn.Lsig.UnmarshalMsgWithState(bts, st)
+			bts, err = (*z).SignedTxnWithAD.SignedTxn.SignatureFields.Lsig.UnmarshalMsgWithState(bts, st)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Lsig")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).SignedTxnWithAD.SignedTxn.SignatureFields.AuthAddr.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "AuthAddr")
 				return
 			}
 		}
@@ -5563,14 +5770,6 @@ func (z *SignedTxnInBlock) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalSt
 			bts, err = (*z).SignedTxnWithAD.SignedTxn.Txn.UnmarshalMsgWithState(bts, st)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Txn")
-				return
-			}
-		}
-		if zb0001 > 0 {
-			zb0001--
-			bts, err = (*z).SignedTxnWithAD.SignedTxn.AuthAddr.UnmarshalMsgWithState(bts, st)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "AuthAddr")
 				return
 			}
 		}
@@ -5678,33 +5877,33 @@ func (z *SignedTxnInBlock) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalSt
 			}
 			switch string(field) {
 			case "sig":
-				bts, err = (*z).SignedTxnWithAD.SignedTxn.Sig.UnmarshalMsgWithState(bts, st)
+				bts, err = (*z).SignedTxnWithAD.SignedTxn.SignatureFields.Sig.UnmarshalMsgWithState(bts, st)
 				if err != nil {
 					err = msgp.WrapError(err, "Sig")
 					return
 				}
 			case "msig":
-				bts, err = (*z).SignedTxnWithAD.SignedTxn.Msig.UnmarshalMsgWithState(bts, st)
+				bts, err = (*z).SignedTxnWithAD.SignedTxn.SignatureFields.Msig.UnmarshalMsgWithState(bts, st)
 				if err != nil {
 					err = msgp.WrapError(err, "Msig")
 					return
 				}
 			case "lsig":
-				bts, err = (*z).SignedTxnWithAD.SignedTxn.Lsig.UnmarshalMsgWithState(bts, st)
+				bts, err = (*z).SignedTxnWithAD.SignedTxn.SignatureFields.Lsig.UnmarshalMsgWithState(bts, st)
 				if err != nil {
 					err = msgp.WrapError(err, "Lsig")
+					return
+				}
+			case "sgnr":
+				bts, err = (*z).SignedTxnWithAD.SignedTxn.SignatureFields.AuthAddr.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "AuthAddr")
 					return
 				}
 			case "txn":
 				bts, err = (*z).SignedTxnWithAD.SignedTxn.Txn.UnmarshalMsgWithState(bts, st)
 				if err != nil {
 					err = msgp.WrapError(err, "Txn")
-					return
-				}
-			case "sgnr":
-				bts, err = (*z).SignedTxnWithAD.SignedTxn.AuthAddr.UnmarshalMsgWithState(bts, st)
-				if err != nil {
-					err = msgp.WrapError(err, "AuthAddr")
 					return
 				}
 			case "ca":
@@ -5790,18 +5989,18 @@ func (_ *SignedTxnInBlock) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *SignedTxnInBlock) Msgsize() (s int) {
-	s = 1 + 4 + (*z).SignedTxnWithAD.SignedTxn.Sig.Msgsize() + 5 + (*z).SignedTxnWithAD.SignedTxn.Msig.Msgsize() + 5 + (*z).SignedTxnWithAD.SignedTxn.Lsig.Msgsize() + 4 + (*z).SignedTxnWithAD.SignedTxn.Txn.Msgsize() + 5 + (*z).SignedTxnWithAD.SignedTxn.AuthAddr.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.ClosingAmount.Msgsize() + 4 + msgp.Uint64Size + 3 + (*z).SignedTxnWithAD.ApplyData.SenderRewards.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.ReceiverRewards.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.CloseRewards.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.EvalDelta.Msgsize() + 5 + (*z).SignedTxnWithAD.ApplyData.ConfigAsset.Msgsize() + 5 + (*z).SignedTxnWithAD.ApplyData.ApplicationID.Msgsize() + 4 + msgp.BoolSize + 4 + msgp.BoolSize
+	s = 1 + 4 + (*z).SignedTxnWithAD.SignedTxn.SignatureFields.Sig.Msgsize() + 5 + (*z).SignedTxnWithAD.SignedTxn.SignatureFields.Msig.Msgsize() + 5 + (*z).SignedTxnWithAD.SignedTxn.SignatureFields.Lsig.Msgsize() + 5 + (*z).SignedTxnWithAD.SignedTxn.SignatureFields.AuthAddr.Msgsize() + 4 + (*z).SignedTxnWithAD.SignedTxn.Txn.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.ClosingAmount.Msgsize() + 4 + msgp.Uint64Size + 3 + (*z).SignedTxnWithAD.ApplyData.SenderRewards.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.ReceiverRewards.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.CloseRewards.Msgsize() + 3 + (*z).SignedTxnWithAD.ApplyData.EvalDelta.Msgsize() + 5 + (*z).SignedTxnWithAD.ApplyData.ConfigAsset.Msgsize() + 5 + (*z).SignedTxnWithAD.ApplyData.ApplicationID.Msgsize() + 4 + msgp.BoolSize + 4 + msgp.BoolSize
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *SignedTxnInBlock) MsgIsZero() bool {
-	return ((*z).SignedTxnWithAD.SignedTxn.Sig.MsgIsZero()) && ((*z).SignedTxnWithAD.SignedTxn.Msig.MsgIsZero()) && ((*z).SignedTxnWithAD.SignedTxn.Lsig.MsgIsZero()) && ((*z).SignedTxnWithAD.SignedTxn.Txn.MsgIsZero()) && ((*z).SignedTxnWithAD.SignedTxn.AuthAddr.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.ClosingAmount.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.AssetClosingAmount == 0) && ((*z).SignedTxnWithAD.ApplyData.SenderRewards.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.ReceiverRewards.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.CloseRewards.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.EvalDelta.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.ConfigAsset.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.ApplicationID.MsgIsZero()) && ((*z).HasGenesisID == false) && ((*z).HasGenesisHash == false)
+	return ((*z).SignedTxnWithAD.SignedTxn.SignatureFields.Sig.MsgIsZero()) && ((*z).SignedTxnWithAD.SignedTxn.SignatureFields.Msig.MsgIsZero()) && ((*z).SignedTxnWithAD.SignedTxn.SignatureFields.Lsig.MsgIsZero()) && ((*z).SignedTxnWithAD.SignedTxn.SignatureFields.AuthAddr.MsgIsZero()) && ((*z).SignedTxnWithAD.SignedTxn.Txn.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.ClosingAmount.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.AssetClosingAmount == 0) && ((*z).SignedTxnWithAD.ApplyData.SenderRewards.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.ReceiverRewards.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.CloseRewards.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.EvalDelta.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.ConfigAsset.MsgIsZero()) && ((*z).SignedTxnWithAD.ApplyData.ApplicationID.MsgIsZero()) && ((*z).HasGenesisID == false) && ((*z).HasGenesisHash == false)
 }
 
 // SignedTxnInBlockMaxSize returns a maximum valid message size for this message type
 func SignedTxnInBlockMaxSize() (s int) {
-	s = 1 + 4 + crypto.SignatureMaxSize() + 5 + crypto.MultisigSigMaxSize() + 5 + LogicSigMaxSize() + 4 + TransactionMaxSize() + 5 + basics.AddressMaxSize() + 3 + basics.MicroAlgosMaxSize() + 4 + msgp.Uint64Size + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + EvalDeltaMaxSize() + 5 + basics.AssetIndexMaxSize() + 5 + basics.AppIndexMaxSize() + 4 + msgp.BoolSize + 4 + msgp.BoolSize
+	s = 1 + 4 + crypto.SignatureMaxSize() + 5 + crypto.MultisigSigMaxSize() + 5 + LogicSigMaxSize() + 5 + basics.AddressMaxSize() + 4 + TransactionMaxSize() + 3 + basics.MicroAlgosMaxSize() + 4 + msgp.Uint64Size + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + EvalDeltaMaxSize() + 5 + basics.AssetIndexMaxSize() + 5 + basics.AppIndexMaxSize() + 4 + msgp.BoolSize + 4 + msgp.BoolSize
 	return
 }
 
@@ -5810,123 +6009,123 @@ func (z *SignedTxnWithAD) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
 	zb0001Len := uint32(13)
-	var zb0001Mask uint16 /* 16 bits */
+	var zb0001Mask uint32 /* 17 bits */
 	if (*z).ApplyData.AssetClosingAmount == 0 {
-		zb0001Len--
-		zb0001Mask |= 0x8
-	}
-	if (*z).ApplyData.ApplicationID.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x10
 	}
-	if (*z).ApplyData.ClosingAmount.MsgIsZero() {
+	if (*z).ApplyData.ApplicationID.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x20
 	}
-	if (*z).ApplyData.ConfigAsset.MsgIsZero() {
+	if (*z).ApplyData.ClosingAmount.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x40
 	}
-	if (*z).ApplyData.EvalDelta.MsgIsZero() {
+	if (*z).ApplyData.ConfigAsset.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x80
 	}
-	if (*z).SignedTxn.Lsig.MsgIsZero() {
+	if (*z).ApplyData.EvalDelta.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x100
 	}
-	if (*z).SignedTxn.Msig.MsgIsZero() {
+	if (*z).SignedTxn.SignatureFields.Lsig.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x200
 	}
-	if (*z).ApplyData.CloseRewards.MsgIsZero() {
+	if (*z).SignedTxn.SignatureFields.Msig.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x400
 	}
-	if (*z).ApplyData.ReceiverRewards.MsgIsZero() {
+	if (*z).ApplyData.CloseRewards.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x800
 	}
-	if (*z).ApplyData.SenderRewards.MsgIsZero() {
+	if (*z).ApplyData.ReceiverRewards.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x1000
 	}
-	if (*z).SignedTxn.AuthAddr.MsgIsZero() {
+	if (*z).ApplyData.SenderRewards.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x2000
 	}
-	if (*z).SignedTxn.Sig.MsgIsZero() {
+	if (*z).SignedTxn.SignatureFields.AuthAddr.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x4000
 	}
-	if (*z).SignedTxn.Txn.MsgIsZero() {
+	if (*z).SignedTxn.SignatureFields.Sig.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x8000
+	}
+	if (*z).SignedTxn.Txn.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x10000
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
 	if zb0001Len != 0 {
-		if (zb0001Mask & 0x8) == 0 { // if not empty
+		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "aca"
 			o = append(o, 0xa3, 0x61, 0x63, 0x61)
 			o = msgp.AppendUint64(o, (*z).ApplyData.AssetClosingAmount)
 		}
-		if (zb0001Mask & 0x10) == 0 { // if not empty
+		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "apid"
 			o = append(o, 0xa4, 0x61, 0x70, 0x69, 0x64)
 			o = (*z).ApplyData.ApplicationID.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x20) == 0 { // if not empty
+		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "ca"
 			o = append(o, 0xa2, 0x63, 0x61)
 			o = (*z).ApplyData.ClosingAmount.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x40) == 0 { // if not empty
+		if (zb0001Mask & 0x80) == 0 { // if not empty
 			// string "caid"
 			o = append(o, 0xa4, 0x63, 0x61, 0x69, 0x64)
 			o = (*z).ApplyData.ConfigAsset.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x80) == 0 { // if not empty
+		if (zb0001Mask & 0x100) == 0 { // if not empty
 			// string "dt"
 			o = append(o, 0xa2, 0x64, 0x74)
 			o = (*z).ApplyData.EvalDelta.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x100) == 0 { // if not empty
+		if (zb0001Mask & 0x200) == 0 { // if not empty
 			// string "lsig"
 			o = append(o, 0xa4, 0x6c, 0x73, 0x69, 0x67)
-			o = (*z).SignedTxn.Lsig.MarshalMsg(o)
-		}
-		if (zb0001Mask & 0x200) == 0 { // if not empty
-			// string "msig"
-			o = append(o, 0xa4, 0x6d, 0x73, 0x69, 0x67)
-			o = (*z).SignedTxn.Msig.MarshalMsg(o)
+			o = (*z).SignedTxn.SignatureFields.Lsig.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x400) == 0 { // if not empty
+			// string "msig"
+			o = append(o, 0xa4, 0x6d, 0x73, 0x69, 0x67)
+			o = (*z).SignedTxn.SignatureFields.Msig.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x800) == 0 { // if not empty
 			// string "rc"
 			o = append(o, 0xa2, 0x72, 0x63)
 			o = (*z).ApplyData.CloseRewards.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x800) == 0 { // if not empty
+		if (zb0001Mask & 0x1000) == 0 { // if not empty
 			// string "rr"
 			o = append(o, 0xa2, 0x72, 0x72)
 			o = (*z).ApplyData.ReceiverRewards.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x1000) == 0 { // if not empty
+		if (zb0001Mask & 0x2000) == 0 { // if not empty
 			// string "rs"
 			o = append(o, 0xa2, 0x72, 0x73)
 			o = (*z).ApplyData.SenderRewards.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x2000) == 0 { // if not empty
+		if (zb0001Mask & 0x4000) == 0 { // if not empty
 			// string "sgnr"
 			o = append(o, 0xa4, 0x73, 0x67, 0x6e, 0x72)
-			o = (*z).SignedTxn.AuthAddr.MarshalMsg(o)
-		}
-		if (zb0001Mask & 0x4000) == 0 { // if not empty
-			// string "sig"
-			o = append(o, 0xa3, 0x73, 0x69, 0x67)
-			o = (*z).SignedTxn.Sig.MarshalMsg(o)
+			o = (*z).SignedTxn.SignatureFields.AuthAddr.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x8000) == 0 { // if not empty
+			// string "sig"
+			o = append(o, 0xa3, 0x73, 0x69, 0x67)
+			o = (*z).SignedTxn.SignatureFields.Sig.MarshalMsg(o)
+		}
+		if (zb0001Mask & 0x10000) == 0 { // if not empty
 			// string "txn"
 			o = append(o, 0xa3, 0x74, 0x78, 0x6e)
 			o = (*z).SignedTxn.Txn.MarshalMsg(o)
@@ -5960,7 +6159,7 @@ func (z *SignedTxnWithAD) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalSta
 		}
 		if zb0001 > 0 {
 			zb0001--
-			bts, err = (*z).SignedTxn.Sig.UnmarshalMsgWithState(bts, st)
+			bts, err = (*z).SignedTxn.SignatureFields.Sig.UnmarshalMsgWithState(bts, st)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Sig")
 				return
@@ -5968,7 +6167,7 @@ func (z *SignedTxnWithAD) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalSta
 		}
 		if zb0001 > 0 {
 			zb0001--
-			bts, err = (*z).SignedTxn.Msig.UnmarshalMsgWithState(bts, st)
+			bts, err = (*z).SignedTxn.SignatureFields.Msig.UnmarshalMsgWithState(bts, st)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Msig")
 				return
@@ -5976,9 +6175,17 @@ func (z *SignedTxnWithAD) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalSta
 		}
 		if zb0001 > 0 {
 			zb0001--
-			bts, err = (*z).SignedTxn.Lsig.UnmarshalMsgWithState(bts, st)
+			bts, err = (*z).SignedTxn.SignatureFields.Lsig.UnmarshalMsgWithState(bts, st)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Lsig")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).SignedTxn.SignatureFields.AuthAddr.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "AuthAddr")
 				return
 			}
 		}
@@ -5987,14 +6194,6 @@ func (z *SignedTxnWithAD) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalSta
 			bts, err = (*z).SignedTxn.Txn.UnmarshalMsgWithState(bts, st)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array", "Txn")
-				return
-			}
-		}
-		if zb0001 > 0 {
-			zb0001--
-			bts, err = (*z).SignedTxn.AuthAddr.UnmarshalMsgWithState(bts, st)
-			if err != nil {
-				err = msgp.WrapError(err, "struct-from-array", "AuthAddr")
 				return
 			}
 		}
@@ -6086,33 +6285,33 @@ func (z *SignedTxnWithAD) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalSta
 			}
 			switch string(field) {
 			case "sig":
-				bts, err = (*z).SignedTxn.Sig.UnmarshalMsgWithState(bts, st)
+				bts, err = (*z).SignedTxn.SignatureFields.Sig.UnmarshalMsgWithState(bts, st)
 				if err != nil {
 					err = msgp.WrapError(err, "Sig")
 					return
 				}
 			case "msig":
-				bts, err = (*z).SignedTxn.Msig.UnmarshalMsgWithState(bts, st)
+				bts, err = (*z).SignedTxn.SignatureFields.Msig.UnmarshalMsgWithState(bts, st)
 				if err != nil {
 					err = msgp.WrapError(err, "Msig")
 					return
 				}
 			case "lsig":
-				bts, err = (*z).SignedTxn.Lsig.UnmarshalMsgWithState(bts, st)
+				bts, err = (*z).SignedTxn.SignatureFields.Lsig.UnmarshalMsgWithState(bts, st)
 				if err != nil {
 					err = msgp.WrapError(err, "Lsig")
+					return
+				}
+			case "sgnr":
+				bts, err = (*z).SignedTxn.SignatureFields.AuthAddr.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "AuthAddr")
 					return
 				}
 			case "txn":
 				bts, err = (*z).SignedTxn.Txn.UnmarshalMsgWithState(bts, st)
 				if err != nil {
 					err = msgp.WrapError(err, "Txn")
-					return
-				}
-			case "sgnr":
-				bts, err = (*z).SignedTxn.AuthAddr.UnmarshalMsgWithState(bts, st)
-				if err != nil {
-					err = msgp.WrapError(err, "AuthAddr")
 					return
 				}
 			case "ca":
@@ -6186,18 +6385,18 @@ func (_ *SignedTxnWithAD) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *SignedTxnWithAD) Msgsize() (s int) {
-	s = 1 + 4 + (*z).SignedTxn.Sig.Msgsize() + 5 + (*z).SignedTxn.Msig.Msgsize() + 5 + (*z).SignedTxn.Lsig.Msgsize() + 4 + (*z).SignedTxn.Txn.Msgsize() + 5 + (*z).SignedTxn.AuthAddr.Msgsize() + 3 + (*z).ApplyData.ClosingAmount.Msgsize() + 4 + msgp.Uint64Size + 3 + (*z).ApplyData.SenderRewards.Msgsize() + 3 + (*z).ApplyData.ReceiverRewards.Msgsize() + 3 + (*z).ApplyData.CloseRewards.Msgsize() + 3 + (*z).ApplyData.EvalDelta.Msgsize() + 5 + (*z).ApplyData.ConfigAsset.Msgsize() + 5 + (*z).ApplyData.ApplicationID.Msgsize()
+	s = 1 + 4 + (*z).SignedTxn.SignatureFields.Sig.Msgsize() + 5 + (*z).SignedTxn.SignatureFields.Msig.Msgsize() + 5 + (*z).SignedTxn.SignatureFields.Lsig.Msgsize() + 5 + (*z).SignedTxn.SignatureFields.AuthAddr.Msgsize() + 4 + (*z).SignedTxn.Txn.Msgsize() + 3 + (*z).ApplyData.ClosingAmount.Msgsize() + 4 + msgp.Uint64Size + 3 + (*z).ApplyData.SenderRewards.Msgsize() + 3 + (*z).ApplyData.ReceiverRewards.Msgsize() + 3 + (*z).ApplyData.CloseRewards.Msgsize() + 3 + (*z).ApplyData.EvalDelta.Msgsize() + 5 + (*z).ApplyData.ConfigAsset.Msgsize() + 5 + (*z).ApplyData.ApplicationID.Msgsize()
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *SignedTxnWithAD) MsgIsZero() bool {
-	return ((*z).SignedTxn.Sig.MsgIsZero()) && ((*z).SignedTxn.Msig.MsgIsZero()) && ((*z).SignedTxn.Lsig.MsgIsZero()) && ((*z).SignedTxn.Txn.MsgIsZero()) && ((*z).SignedTxn.AuthAddr.MsgIsZero()) && ((*z).ApplyData.ClosingAmount.MsgIsZero()) && ((*z).ApplyData.AssetClosingAmount == 0) && ((*z).ApplyData.SenderRewards.MsgIsZero()) && ((*z).ApplyData.ReceiverRewards.MsgIsZero()) && ((*z).ApplyData.CloseRewards.MsgIsZero()) && ((*z).ApplyData.EvalDelta.MsgIsZero()) && ((*z).ApplyData.ConfigAsset.MsgIsZero()) && ((*z).ApplyData.ApplicationID.MsgIsZero())
+	return ((*z).SignedTxn.SignatureFields.Sig.MsgIsZero()) && ((*z).SignedTxn.SignatureFields.Msig.MsgIsZero()) && ((*z).SignedTxn.SignatureFields.Lsig.MsgIsZero()) && ((*z).SignedTxn.SignatureFields.AuthAddr.MsgIsZero()) && ((*z).SignedTxn.Txn.MsgIsZero()) && ((*z).ApplyData.ClosingAmount.MsgIsZero()) && ((*z).ApplyData.AssetClosingAmount == 0) && ((*z).ApplyData.SenderRewards.MsgIsZero()) && ((*z).ApplyData.ReceiverRewards.MsgIsZero()) && ((*z).ApplyData.CloseRewards.MsgIsZero()) && ((*z).ApplyData.EvalDelta.MsgIsZero()) && ((*z).ApplyData.ConfigAsset.MsgIsZero()) && ((*z).ApplyData.ApplicationID.MsgIsZero())
 }
 
 // SignedTxnWithADMaxSize returns a maximum valid message size for this message type
 func SignedTxnWithADMaxSize() (s int) {
-	s = 1 + 4 + crypto.SignatureMaxSize() + 5 + crypto.MultisigSigMaxSize() + 5 + LogicSigMaxSize() + 4 + TransactionMaxSize() + 5 + basics.AddressMaxSize() + 3 + basics.MicroAlgosMaxSize() + 4 + msgp.Uint64Size + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + EvalDeltaMaxSize() + 5 + basics.AssetIndexMaxSize() + 5 + basics.AppIndexMaxSize()
+	s = 1 + 4 + crypto.SignatureMaxSize() + 5 + crypto.MultisigSigMaxSize() + 5 + LogicSigMaxSize() + 5 + basics.AddressMaxSize() + 4 + TransactionMaxSize() + 3 + basics.MicroAlgosMaxSize() + 4 + msgp.Uint64Size + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + basics.MicroAlgosMaxSize() + 3 + EvalDeltaMaxSize() + 5 + basics.AssetIndexMaxSize() + 5 + basics.AppIndexMaxSize()
 	return
 }
 

--- a/data/transactions/msgp_gen_test.go
+++ b/data/transactions/msgp_gen_test.go
@@ -973,6 +973,66 @@ func BenchmarkUnmarshalResourceRef(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalSignatureFields(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	v := SignatureFields{}
+	bts := v.MarshalMsg(nil)
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func TestRandomizedEncodingSignatureFields(t *testing.T) {
+	protocol.RunEncodingTest(t, &SignatureFields{})
+}
+
+func BenchmarkMarshalMsgSignatureFields(b *testing.B) {
+	v := SignatureFields{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgSignatureFields(b *testing.B) {
+	v := SignatureFields{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalSignatureFields(b *testing.B) {
+	v := SignatureFields{}
+	bts := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalSignedTxn(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	v := SignedTxn{}

--- a/data/transactions/signedtxn.go
+++ b/data/transactions/signedtxn.go
@@ -32,10 +32,17 @@ import (
 type SignedTxn struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
+	SignatureFields
+	Txn Transaction `codec:"txn"`
+}
+
+// SignatureFields contain the different type of signatures
+type SignatureFields struct {
+	_struct struct{} `codec:",omitempty,omitemptyarray"`
+
 	Sig      crypto.Signature   `codec:"sig"`
 	Msig     crypto.MultisigSig `codec:"msig"`
 	Lsig     LogicSig           `codec:"lsig"`
-	Txn      Transaction        `codec:"txn"`
 	AuthAddr basics.Address     `codec:"sgnr"`
 }
 
@@ -116,9 +123,11 @@ func AssembleSignedTxn(txn Transaction, sig crypto.Signature, msig crypto.Multis
 		return SignedTxn{}, errors.New("signed txn can only have one of sig or msig")
 	}
 	s := SignedTxn{
-		Txn:  txn,
-		Sig:  sig,
-		Msig: msig,
+		Txn: txn,
+		SignatureFields: SignatureFields{
+			Sig:  sig,
+			Msig: msig,
+		},
 	}
 	return s, nil
 }

--- a/data/transactions/teal_test.go
+++ b/data/transactions/teal_test.go
@@ -140,8 +140,10 @@ func TestEvalDeltaEqual(t *testing.T) {
 	d1 = EvalDelta{
 		InnerTxns: []SignedTxnWithAD{{
 			SignedTxn: SignedTxn{
-				Lsig: LogicSig{
-					Logic: []byte{0x01},
+				SignatureFields: SignatureFields{
+					Lsig: LogicSig{
+						Logic: []byte{0x01},
+					},
 				},
 			},
 		}},
@@ -149,8 +151,10 @@ func TestEvalDeltaEqual(t *testing.T) {
 	d2 = EvalDelta{
 		InnerTxns: []SignedTxnWithAD{{
 			SignedTxn: SignedTxn{
-				Lsig: LogicSig{
-					Logic: []byte{0x01},
+				SignatureFields: SignatureFields{
+					Lsig: LogicSig{
+						Logic: []byte{0x01},
+					},
 				},
 			},
 		}},
@@ -159,9 +163,11 @@ func TestEvalDeltaEqual(t *testing.T) {
 	d2 = EvalDelta{
 		InnerTxns: []SignedTxnWithAD{{
 			SignedTxn: SignedTxn{
-				Lsig: LogicSig{
-					Logic: []byte{0x02},
-					Args:  [][]byte{},
+				SignatureFields: SignatureFields{
+					Lsig: LogicSig{
+						Logic: []byte{0x02},
+						Args:  [][]byte{},
+					},
 				},
 			},
 		}},

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -266,7 +266,9 @@ func (tx Transaction) Sign(secrets *crypto.SignatureSecrets) SignedTxn {
 
 	s := SignedTxn{
 		Txn: tx,
-		Sig: sig,
+		SignatureFields: SignatureFields{
+			Sig: sig,
+		},
 	}
 	// Set the AuthAddr if the signing key doesn't match the transaction sender
 	if basics.Address(secrets.SignatureVerifier) != tx.Sender {
@@ -506,7 +508,9 @@ func (tx Transaction) EstimateEncodedSize() int {
 	// Make a signedtxn with a nonzero signature and encode it
 	stx := SignedTxn{
 		Txn: tx,
-		Sig: crypto.Signature{1},
+		SignatureFields: SignatureFields{
+			Sig: crypto.Signature{1},
+		},
 	}
 	return stx.GetEncodedLength()
 }

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -124,7 +124,9 @@ func createHeartbeatTxn(fv basics.Round, t *testing.T) transactions.SignedTxn {
 	}
 
 	hb := transactions.SignedTxn{
-		Sig: secrets[0].Sign(txn),
+		SignatureFields: transactions.SignatureFields{
+			Sig: secrets[0].Sign(txn),
+		},
 		Txn: txn,
 	}
 	return hb
@@ -562,15 +564,19 @@ pushint 1`,
 
 			txgroup := []transactions.SignedTxn{
 				{
-					Lsig: transactions.LogicSig{
-						Logic: program1Bytes,
+					SignatureFields: transactions.SignatureFields{
+						Lsig: transactions.LogicSig{
+							Logic: program1Bytes,
+						},
 					},
 					Txn: lsigPay.Txn(),
 				},
 				normalSigAppCall.Txn().Sign(account),
 				{
-					Lsig: transactions.LogicSig{
-						Logic: program2Bytes,
+					SignatureFields: transactions.SignatureFields{
+						Lsig: transactions.LogicSig{
+							Logic: program2Bytes,
+						},
 					},
 					Txn: lsigAppCall.Txn(),
 				},

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -214,8 +214,10 @@ func makeRandomTransactions(num int) ([]transactions.SignedTxn, []byte) {
 		var addr basics.Address
 		crypto.RandBytes(addr[:])
 		stxns[i] = transactions.SignedTxn{
-			Sig:      sig,
-			AuthAddr: addr,
+			SignatureFields: transactions.SignatureFields{
+				Sig:      sig,
+				AuthAddr: addr,
+			},
 			Txn: transactions.Transaction{
 				Header: transactions.Header{
 					Sender: addr,
@@ -652,9 +654,9 @@ func craftNonCanonical(t *testing.T, stxn *transactions.SignedTxn, blobStxn []by
 	// make non-canonical encoding and ensure it is not accepted
 	stxnNonCanTxn := transactions.SignedTxn{Txn: stxn.Txn}
 	blobTxn := protocol.Encode(&stxnNonCanTxn)
-	stxnNonCanAuthAddr := transactions.SignedTxn{AuthAddr: stxn.AuthAddr}
+	stxnNonCanAuthAddr := transactions.SignedTxn{SignatureFields: transactions.SignatureFields{AuthAddr: stxn.AuthAddr}}
 	blobAuthAddr := protocol.Encode(&stxnNonCanAuthAddr)
-	stxnNonCanAuthSig := transactions.SignedTxn{Sig: stxn.Sig}
+	stxnNonCanAuthSig := transactions.SignedTxn{SignatureFields: transactions.SignatureFields{Sig: stxn.Sig}}
 	blobSig := protocol.Encode(&stxnNonCanAuthSig)
 
 	if blobStxn == nil {

--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -1331,8 +1331,10 @@ int 1
 		},
 	}
 	signedLsigPayment := transactions.SignedTxn{
-		Lsig: transactions.LogicSig{Logic: program},
-		Txn:  lsigPayment,
+		SignatureFields: transactions.SignatureFields{
+			Lsig: transactions.LogicSig{Logic: program},
+		},
+		Txn: lsigPayment,
 	}
 	err = l.appendUnvalidatedSignedTx(t, genesisInitState.Accounts, signedLsigPayment, transactions.ApplyData{})
 	a.NoError(err)

--- a/ledger/eval_simple_test.go
+++ b/ledger/eval_simple_test.go
@@ -1276,7 +1276,7 @@ func TestRekeying(t *testing.T) {
 			},
 		}
 		sig := signer.Sign(txn)
-		return transactions.SignedTxn{Txn: txn, Sig: sig, AuthAddr: authaddr}
+		return transactions.SignedTxn{Txn: txn, SignatureFields: transactions.SignatureFields{Sig: sig, AuthAddr: authaddr}}
 	}
 
 	tryBlock := func(stxns []transactions.SignedTxn) error {

--- a/ledger/fullblock_perf_test.go
+++ b/ledger/fullblock_perf_test.go
@@ -251,7 +251,7 @@ func payTo(bc *benchConfig, from, to basics.Address, amt uint64) {
 
 func createAssetForAcct(bc *benchConfig, acct basics.Address) (aidx basics.AssetIndex) {
 	tx := createAssetTransaction(bc.txnCount, bc.round, acct)
-	stxn := transactions.SignedTxn{Txn: tx, Sig: crypto.Signature{1}}
+	stxn := transactions.SignedTxn{Txn: tx, SignatureFields: transactions.SignatureFields{Sig: crypto.Signature{1}}}
 	aIdx := basics.AssetIndex(addTransaction(bc, stxn))
 	if len(bc.acctToAst[acct]) == 0 {
 		bc.acctToAst[acct] = make(map[basics.AssetIndex]uint64)
@@ -264,7 +264,7 @@ func createAssetForAcct(bc *benchConfig, acct basics.Address) (aidx basics.Asset
 func createAppForAcct(bc *benchConfig, acct basics.Address) (appIdx basics.AppIndex) {
 	tx, err := makeAppTransaction(bc.txnCount, bc.round, acct)
 	require.NoError(bc.b, err)
-	stxn := transactions.SignedTxn{Txn: tx, Sig: crypto.Signature{1}}
+	stxn := transactions.SignedTxn{Txn: tx, SignatureFields: transactions.SignatureFields{Sig: crypto.Signature{1}}}
 	appIdx = basics.AppIndex(addTransaction(bc, stxn))
 	if len(bc.acctToApp[acct]) == 0 {
 		bc.acctToApp[acct] = make(map[basics.AppIndex]struct{})

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -65,7 +65,9 @@ func sign(secrets map[basics.Address]*crypto.SignatureSecrets, t transactions.Tr
 	}
 	return transactions.SignedTxn{
 		Txn: t,
-		Sig: sig,
+		SignatureFields: transactions.SignatureFields{
+			Sig: sig,
+		},
 	}
 }
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1316,7 +1316,9 @@ func TestNodeHybridP2PGossipSend(t *testing.T) {
 	}
 	signature := secrets2.Sign(txn)
 	stxn := transactions.SignedTxn{
-		Sig: signature,
+		SignatureFields: transactions.SignatureFields{
+			Sig: signature,
+		},
 		Txn: txn,
 	}
 

--- a/test/e2e-go/features/transactions/logicsig_test.go
+++ b/test/e2e-go/features/transactions/logicsig_test.go
@@ -101,7 +101,7 @@ func testLogicSize(t *testing.T, tealOK, tealTooLong []byte,
 	a.NoError(err)
 
 	txn1Success.Group = gidSuccess
-	stxn1Success := transactions.SignedTxn{Txn: txn1Success, Lsig: lsigOK}
+	stxn1Success := transactions.SignedTxn{Txn: txn1Success, SignatureFields: transactions.SignatureFields{Lsig: lsigOK}}
 
 	txn2Success.Group = gidSuccess
 	stxn2Success, err := client.SignTransactionWithWallet(walletHandler, nil, txn2Success)
@@ -115,7 +115,7 @@ func testLogicSize(t *testing.T, tealOK, tealTooLong []byte,
 	a.NoError(err)
 
 	txn1Fail.Group = gidFail
-	stxn1Fail := transactions.SignedTxn{Txn: txn1Fail, Lsig: lsigTooLong}
+	stxn1Fail := transactions.SignedTxn{Txn: txn1Fail, SignatureFields: transactions.SignatureFields{Lsig: lsigTooLong}}
 
 	txn2Fail.Group = gidFail
 	stxn2Fail, err := client.SignTransactionWithWallet(walletHandler, nil, txn2Fail)

--- a/tools/block-generator/generator/generate.go
+++ b/tools/block-generator/generator/generate.go
@@ -826,10 +826,12 @@ func (g *generator) recordData(id TxTypeID, start time.Time) {
 
 func signTxn(transaction txn.Transaction) txn.SignedTxn {
 	stxn := txn.SignedTxn{
-		Msig:     crypto.MultisigSig{},
-		Lsig:     txn.LogicSig{},
-		Txn:      transaction,
-		AuthAddr: basics.Address{},
+		SignatureFields: txn.SignatureFields{
+			Msig:     crypto.MultisigSig{},
+			Lsig:     txn.LogicSig{},
+			AuthAddr: basics.Address{},
+		},
+		Txn: transaction,
 	}
 
 	addSignature(&stxn)


### PR DESCRIPTION
Extracts `Sig`, `Msig`, `Lsig`, `AuthAddr` from `SignedTxn` into a new embedded `SignatureFields` struct. Groups the authorisation material as a first-class type while preserving existing field access via Go's embedded-struct promotion (`s.Sig` etc. still work).

**What changed**

 - New `SignatureFields` struct, embedded in `SignedTxn`.
 - Struct literals updated across `cmd/goal`, `daemon/kmd`, `tools/block-generator`, and `tests`.
 - `msgp_gen.go` regenerated; new roundtrip + randomized encoding tests added.

**Wire format**

Canonical (map) encoding is byte-for-byte identical - same keys, same alphabetical order. Checked via `TestRandomizedEncoding*` on `SignedTxn`, `SignedTxnWithAD`, `SignedTxnInBlock`.

**Notes**

 - Array decode order changes. msgp's non-canonical array fallback now expects [`Sig`, `Msig`, `Lsig`, `AuthAddr`, `Txn`] instead of [`Sig`, `Msig`, `Lsig`, `Txn`, `AuthAddr`] because embedded fields precede `Txn` in declaration order. Canonical (map) encoding is what algod, indexer, conduit, and the SDKs actually use, and that's byte-identical. Worth flagging, but not something we owe stability on.
 - `AuthAddr` being the rekey authoriser isn't exactly a signature - So maybe the struct should be `AuthorisationFields` rather than `SignatureFields`? Open to renaming.
 - Verbose literals. Writes now require nesting (`SignatureFields: transactions.SignatureFields{Sig: ...}`); reads are unaffected.