### PR TITLE
crypto: use batch verification for OneTimeSignature (votes, heartbeats)

### DIFF
--- a/crypto/batchverifier_bench_test.go
+++ b/crypto/batchverifier_bench_test.go
@@ -61,10 +61,11 @@ func BenchmarkBatchVerifierImpls(b *testing.B) {
 	}
 
 	b.Log("running with", b.N, "iterations using", len(msgs), "batches of", batchSize, "signatures")
-	runImpl := func(b *testing.B, bv BatchVerifier,
+	runImpl := func(b *testing.B, makeBV func() BatchVerifier,
 		msgs [][]Hashable, pks [][]SignatureVerifier, sigs [][]Signature) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
+			bv := makeBV()
 			batchIdx := i % numBatches
 			for j := range msgs[batchIdx] {
 				bv.EnqueueSignature(pks[batchIdx][j], msgs[batchIdx][j], sigs[batchIdx][j])
@@ -74,18 +75,21 @@ func BenchmarkBatchVerifierImpls(b *testing.B) {
 	}
 
 	b.Run("libsodium_single", func(b *testing.B) {
-		bv := makeLibsodiumBatchVerifier(batchSize)
-		bv.(*cgoBatchVerifier).useSingle = true
-		runImpl(b, bv, msgs, pks, sigs)
+		runImpl(b, func() BatchVerifier {
+			bv := makeLibsodiumBatchVerifier(batchSize)
+			bv.(*cgoBatchVerifier).useSingle = true
+			return bv
+		}, msgs, pks, sigs)
 	})
 	b.Run("libsodium_batch", func(b *testing.B) {
-		bv := makeLibsodiumBatchVerifier(batchSize)
-		bv.(*cgoBatchVerifier).useSingle = false
-		runImpl(b, bv, msgs, pks, sigs)
+		runImpl(b, func() BatchVerifier {
+			bv := makeLibsodiumBatchVerifier(batchSize)
+			bv.(*cgoBatchVerifier).useSingle = false
+			return bv
+		}, msgs, pks, sigs)
 	})
 	b.Run("ed25519consensus", func(b *testing.B) {
-		bv := makeEd25519ConsensusBatchVerifier(batchSize)
-		runImpl(b, bv, msgs, pks, sigs)
+		runImpl(b, func() BatchVerifier { return makeEd25519ConsensusBatchVerifier(batchSize) }, msgs, pks, sigs)
 	})
 }
 

--- a/crypto/curve25519_test.go
+++ b/crypto/curve25519_test.go
@@ -18,6 +18,7 @@ package crypto
 
 import (
 	"bytes"
+	"crypto/ed25519"
 	"testing"
 
 	"github.com/algorand/go-algorand/test/partitiontest"
@@ -89,15 +90,42 @@ func BenchmarkSignVerify(b *testing.B) {
 }
 
 func BenchmarkSign(b *testing.B) {
+	b.Run("libsodium", func(b *testing.B) {
+		benchmarkSign(b, func(sk ed25519PrivateKey, msg []byte) Signature {
+			return Signature(ed25519Sign(sk, msg))
+		})
+	})
+	b.Run("ed25519stdlib", func(b *testing.B) {
+		benchmarkSign(b, func(sk ed25519PrivateKey, msg []byte) Signature {
+			return Signature(ed25519.Sign(ed25519.PrivateKey(sk[:]), msg))
+		})
+	})
+}
+
+func benchmarkSign(b *testing.B, sign func(ed25519PrivateKey, []byte) Signature) {
 	c := makeCurve25519Secret()
 	s := randString()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = c.Sign(s)
+		_ = sign(c.SK, HashRep(s))
 	}
 }
+
 func BenchmarkVerify25519(b *testing.B) {
+	b.Run("libsodium", func(b *testing.B) {
+		benchmarkVerify25519(b, func(pk SignatureVerifier, msg []byte, sig Signature) bool {
+			return ed25519Verify(ed25519PublicKey(pk), msg, ed25519Signature(sig))
+		})
+	})
+	b.Run("ed25519consensus", func(b *testing.B) {
+		benchmarkVerify25519(b, func(pk SignatureVerifier, msg []byte, sig Signature) bool {
+			return ed25519ConsensusVerifySingle(pk, msg, sig)
+		})
+	})
+}
+
+func benchmarkVerify25519(b *testing.B, verify func(SignatureVerifier, []byte, Signature) bool) {
 	c := makeCurve25519Secret()
 	strs := make([]TestingHashable, b.N)
 	sigs := make([]Signature, b.N)
@@ -108,6 +136,8 @@ func BenchmarkVerify25519(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = c.Verify(strs[i], sigs[i])
+		if !verify(c.SignatureVerifier, HashRep(strs[i]), sigs[i]) {
+			b.Error("BAD: valid signature not valid")
+		}
 	}
 }

--- a/crypto/onetimesig.go
+++ b/crypto/onetimesig.go
@@ -374,24 +374,6 @@ func (v OneTimeSignatureVerifier) Verify(id OneTimeSignatureIdentifier, message 
 		SubKeyPK: sig.PK2,
 		Batch:    id.Batch,
 	}
-
-	if !useSingleVerifierDefault {
-		return v.batchVerify(batchID, offsetID, message, sig)
-	}
-
-	if !ed25519Verify(ed25519PublicKey(v), HashRep(batchID), sig.PK2Sig) {
-		return false
-	}
-	if !ed25519Verify(batchID.SubKeyPK, HashRep(offsetID), sig.PK1Sig) {
-		return false
-	}
-	if !ed25519Verify(offsetID.SubKeyPK, HashRep(message), sig.Sig) {
-		return false
-	}
-	return true
-}
-
-func (v OneTimeSignatureVerifier) batchVerify(batchID OneTimeSignatureSubkeyBatchID, offsetID OneTimeSignatureSubkeyOffsetID, message Hashable, sig OneTimeSignature) bool {
 	bv := MakeBatchVerifierWithHint(3)
 	bv.EnqueueSignature(PublicKey(v), batchID, Signature(sig.PK2Sig))
 	bv.EnqueueSignature(PublicKey(batchID.SubKeyPK), offsetID, Signature(sig.PK1Sig))

--- a/crypto/onetimesig_test.go
+++ b/crypto/onetimesig_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/stretchr/testify/assert"
 )
 
 func randID() OneTimeSignatureIdentifier {
@@ -185,7 +186,7 @@ func BenchmarkOneTimeSigBatchVerification(b *testing.B) {
 			// verify them
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				v.Verify(ids[i], msg, sigs[i])
+				assert.True(b, v.Verify(ids[i], msg, sigs[i]), "BAD: valid signature not valid")
 			}
 		})
 	}

--- a/crypto/onetimesig_test.go
+++ b/crypto/onetimesig_test.go
@@ -17,7 +17,6 @@
 package crypto
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/algorand/go-algorand/test/partitiontest"
@@ -141,8 +140,36 @@ func testOneTimeSignVerifyNewStyle(t *testing.T, c *OneTimeSignatureSecrets, c2 
 }
 
 func BenchmarkOneTimeSigBatchVerification(b *testing.B) {
-	for _, enabled := range []bool{false, true} {
-		b.Run(fmt.Sprintf("batch=%v", enabled), func(b *testing.B) {
+	// A OneTimeSignature carries 3 ed25519 sigs (PK2Sig, PK1Sig, Sig). Compare
+	// the configured BatchVerifier factories on the 3-sig OneTimeSig batch:
+	//   - libsodium with useSingle=true (loops over libsodium single-verify;
+	//     the historical vote path before PR #3759)
+	//   - libsodium with useSingle=false (calls into the libsodium fork's
+	//     batch.c batch routine)
+	//   - ed25519consensus (pure-Go batch verifier)
+	libsodiumWith := func(useSingle bool) func(int) BatchVerifier {
+		return func(hint int) BatchVerifier {
+			bv := makeLibsodiumBatchVerifier(hint)
+			bv.(*cgoBatchVerifier).useSingle = useSingle
+			return bv
+		}
+	}
+
+	cases := []struct {
+		name    string
+		factory func(int) BatchVerifier
+	}{
+		{"libsodium_singles", libsodiumWith(true)},
+		{"libsodium_batch", libsodiumWith(false)},
+		{"ed25519consensus_batch", makeEd25519ConsensusBatchVerifier},
+	}
+
+	origFactory := ed25519BatchVerifierFactory
+	defer func() { ed25519BatchVerifierFactory = origFactory }()
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			ed25519BatchVerifierFactory = tc.factory
 			// generate a bunch of signatures
 			c := GenerateOneTimeSignatureSecrets(0, 1000)
 			sigs := make([]OneTimeSignature, b.N)

--- a/crypto/onetimesig_test.go
+++ b/crypto/onetimesig_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/algorand/go-algorand/test/partitiontest"
-	"github.com/stretchr/testify/assert"
 )
 
 func randID() OneTimeSignatureIdentifier {
@@ -186,7 +185,9 @@ func BenchmarkOneTimeSigBatchVerification(b *testing.B) {
 			// verify them
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				assert.True(b, v.Verify(ids[i], msg, sigs[i]), "BAD: valid signature not valid")
+				if !v.Verify(ids[i], msg, sigs[i]) {
+					b.Error("BAD: valid signature not valid")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

This repeats the change from #3759 while undoing the change in #5988 to check a `useSingleVerifierDefault` const in `OneTimeSignatureVerifier.Verify` allowing it to use the Go-based batch verifier introduced in #6440.

Benchmarks on a MBP, plus a ~10-year-old Intel Ivy Bridge server:
```
$ go test -run=^$ -bench=BenchmarkOneTimeSigBatchVerification -benchtime=2s ./crypto/
goos: darwin
goarch: arm64
pkg: github.com/algorand/go-algorand/crypto
cpu: Apple M2 Max
BenchmarkOneTimeSigBatchVerification/libsodium_singles-12             19286            124967 ns/op
BenchmarkOneTimeSigBatchVerification/libsodium_batch-12               23778            101276 ns/op
BenchmarkOneTimeSigBatchVerification/ed25519consensus_batch-12        26347             91827 ns/op

goos: linux
goarch: amd64
pkg: github.com/algorand/go-algorand/crypto
cpu: Intel(R) Xeon(R) CPU E5-1650 v2 @ 3.50GHz
BenchmarkOneTimeSigBatchVerification/libsodium_singles-12         	    5827	    648960 ns/op
BenchmarkOneTimeSigBatchVerification/libsodium_batch-12           	   10000	    423498 ns/op
BenchmarkOneTimeSigBatchVerification/ed25519consensus_batch-12    	   10000	    298023 ns/op
```

## Test Plan

Existing tests pass, including agreement tests like vote_test.go.