### PR TITLE
Build: locate e2e test binaries via `go env`, not $GOPATH

### DIFF
--- a/test/framework/fixtures/baseFixture.go
+++ b/test/framework/fixtures/baseFixture.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/algorand/go-algorand/config"
@@ -51,8 +52,9 @@ func getTestDir() string {
 // goInstallBinDir reports where `go install` (and thus `make install`) places
 // binaries, asking `go env` rather than trusting an exported $GOPATH. This
 // mirrors the GOBIN/GOPATH resolution in the Makefile so a plain `go test`
-// finds algod without requiring NODEBINDIR or an exported GOPATH.
-func goInstallBinDir() string {
+// finds algod without requiring NODEBINDIR or an exported GOPATH. The result
+// is cached, since every fixture initialize() would otherwise re-run `go env`.
+var goInstallBinDir = sync.OnceValue(func() string {
 	if out, err := exec.Command("go", "env", "GOBIN").Output(); err == nil {
 		if dir := strings.TrimSpace(string(out)); dir != "" {
 			return dir
@@ -68,7 +70,7 @@ func goInstallBinDir() string {
 		return ""
 	}
 	return filepath.Join(gopath[0], "bin")
-}
+})
 
 func (f *baseFixture) initialize(instance Fixture) {
 	f.instance = instance

--- a/test/framework/fixtures/baseFixture.go
+++ b/test/framework/fixtures/baseFixture.go
@@ -19,8 +19,11 @@ package fixtures
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/algorand/go-algorand/config"
@@ -45,12 +48,34 @@ func getTestDir() string {
 	return os.ExpandEnv("${GOPATH}/src/github.com/algorand/go-algorand/test/")
 }
 
+// goInstallBinDir reports where `go install` (and thus `make install`) places
+// binaries, asking `go env` rather than trusting an exported $GOPATH. This
+// mirrors the GOBIN/GOPATH resolution in the Makefile so a plain `go test`
+// finds algod without requiring NODEBINDIR or an exported GOPATH.
+func goInstallBinDir() string {
+	if out, err := exec.Command("go", "env", "GOBIN").Output(); err == nil {
+		if dir := strings.TrimSpace(string(out)); dir != "" {
+			return dir
+		}
+	}
+	out, err := exec.Command("go", "env", "GOPATH").Output()
+	if err != nil {
+		return ""
+	}
+	// GOPATH may be a list; go install uses the first entry.
+	gopath := filepath.SplitList(strings.TrimSpace(string(out)))
+	if len(gopath) == 0 || gopath[0] == "" {
+		return ""
+	}
+	return filepath.Join(gopath[0], "bin")
+}
+
 func (f *baseFixture) initialize(instance Fixture) {
 	f.instance = instance
 	f.Config = config.Protocol
 	f.binDir = os.Getenv("NODEBINDIR")
 	if f.binDir == "" {
-		f.binDir = os.ExpandEnv("$GOPATH/bin")
+		f.binDir = goInstallBinDir()
 	}
 	f.testDir = os.Getenv("TESTDIR")
 	if f.testDir == "" {


### PR DESCRIPTION
## Summary

The e2e test fixture (`test/framework/fixtures/baseFixture.go`) resolved the directory containing `algod`/`goal` as `os.ExpandEnv("$GOPATH/bin")` when `NODEBINDIR` was unset. This relies on `$GOPATH` being present in the environment.

Since Go modules, `$GOPATH` no longer needs to be exported — `go` itself defaults it to `~/go`, but a raw `os.ExpandEnv("$GOPATH/bin")` does not. On a typical modern setup `$GOPATH` is empty in the environment, so the fixture expands the path to `/bin` and panics when starting a network:

```
panic: error starting network: fork/exec /bin/algod: no such file or directory
```

even though `make install` placed the binaries correctly.

## Fix

Ask `go env` for `GOBIN`/`GOPATH` instead, mirroring the resolution the Makefile already uses to decide where `make install` puts binaries:

```makefile
GOBIN := $(if $(shell go env GOBIN),$(shell go env GOBIN),$(GOPATH1)/bin)
```

This makes a plain `go test ./test/e2e-go/...` find the installed binaries without requiring `NODEBINDIR` or an exported `GOPATH`. `NODEBINDIR` still takes precedence as an explicit override (e.g. for CI or cross-compiled binaries).

## Testing

`go test -run TestSimulateWithFixSigners ./test/e2e-go/restAPI/simulate/` now starts `algod` successfully with both `NODEBINDIR` and `GOPATH` unset (`env -u NODEBINDIR -u GOPATH`), where it previously panicked.