### PR TITLE
transactions: reject heartbeat transactions with missing fields

### DIFF
--- a/data/transactions/heartbeat_test.go
+++ b/data/transactions/heartbeat_test.go
@@ -58,6 +58,16 @@ func TestWellFormedHeartbeatErrors(t *testing.T) {
 			expectedError: fmt.Errorf("heartbeat transaction not supported"),
 		},
 		{
+			// A "hb" txn with the hb field omitted decodes to a nil
+			// *HeartbeatTxnFields. WellFormed must reject it, not panic.
+			tx: Transaction{
+				Type:   protocol.HeartbeatTx,
+				Header: okHeader,
+			},
+			proto:         futureProto,
+			expectedError: fmt.Errorf("heartbeat transaction has no heartbeat fields"),
+		},
+		{
 			tx: Transaction{
 				Type:   protocol.HeartbeatTx,
 				Header: okHeader,

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -348,7 +348,7 @@ func (tx Transaction) MatchAddress(addr basics.Address) bool {
 			return true
 		}
 	case protocol.HeartbeatTx:
-		if addr == tx.HeartbeatTxnFields.HbAddress {
+		if tx.HeartbeatTxnFields != nil && addr == tx.HeartbeatTxnFields.HbAddress {
 			return true
 		}
 	}
@@ -423,6 +423,13 @@ func (tx Transaction) WellFormed(spec SpecialAddresses, proto config.ConsensusPa
 	case protocol.HeartbeatTx:
 		if !proto.Heartbeat {
 			return fmt.Errorf("heartbeat transaction not supported")
+		}
+
+		// HeartbeatTxnFields is a pointer; a "hb" transaction whose hb field was
+		// omitted decodes to a nil pointer. Reject it here rather than
+		// dereferencing nil (wellFormed has a value receiver) and panicking.
+		if tx.HeartbeatTxnFields == nil {
+			return errors.New("heartbeat transaction has no heartbeat fields")
 		}
 
 		err := tx.HeartbeatTxnFields.wellFormed(tx.Header, proto)


### PR DESCRIPTION
## Summary

`HeartbeatTxnFields` is an embedded pointer on `Transaction`, so a transaction of type `"hb"` whose `hb` field is omitted decodes to a nil `*HeartbeatTxnFields`. `WellFormed` then invoked the value-receiver `wellFormed()` through that nil pointer, causing a nil-pointer dereference during stateless validation. This adds a nil check that rejects such a transaction with a well-formedness error, and hardens `MatchAddress` with the same guard.

## Test Plan

Added a regression case to `TestWellFormedHeartbeatErrors` covering a `HeartbeatTx` with nil `HeartbeatTxnFields`, asserting it returns `"heartbeat transaction has no heartbeat fields"` rather than panicking.

```
go test -run TestWellFormedHeartbeatErrors ./data/transactions/
go build ./...
```

Also ran `gofmt` and `go vet` — clean.
