### PR TITLE
eval: handle error in gload of a txn that didn't run a program

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -4017,6 +4017,12 @@ func opGloadImpl(cx *EvalContext, gi int, scratchIdx byte, opName string) (stack
 		return none, fmt.Errorf("%s can't get future scratch space from txn with index %d", opName, gi)
 	}
 
+	// An app call that never executed its program leaves pastScratch[gi] nil even
+	// though its Type is still appl (e.g., a ClearState against a deleted app).
+	if cx.pastScratch[gi] == nil {
+		return none, fmt.Errorf("%s lookup of txn %d that did not run a program", opName, gi)
+	}
+
 	return cx.pastScratch[gi][scratchIdx], nil
 }
 

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -2987,6 +2987,20 @@ func TestGload(t *testing.T) {
 	}
 }
 
+// TestGloadNoProgram covers gload reading a sibling app-call txn that never ran a program.
+func TestGloadNoProgram(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	appcall := transactions.SignedTxn{Txn: transactions.Transaction{Type: protocol.ApplicationCallTx}}
+	ep := defaultAppParams(appcall, appcall)
+	// Evaluate gi=1 while gi=0's program was never run, so pastScratch[0] is nil.
+	cx := &EvalContext{EvalParams: ep, groupIndex: 1}
+
+	_, err := opGloadImpl(cx, 0, 0, "gload")
+	require.ErrorContains(t, err, "gload lookup of txn 0 that did not run a program")
+}
+
 // TestGloads tests gloads and gloadss
 func TestGloads(t *testing.T) {
 	partitiontest.PartitionTest(t)


### PR DESCRIPTION
## Summary

This is already caught by the AVM's recovery, but adding this check provides better error-handling coverage.

## Test Plan

Added new test to exercise this error.