### PR TITLE
network: harden DNS bootstrap resolution and surface failures

### DIFF
--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -1659,7 +1659,7 @@ func (wn *WebsocketNetwork) updatePhonebookAddresses(relayAddrs []string, archiv
 		wn.log.Debugf("got %d relay dns addrs, %#v", len(relayAddrs), relayAddrs[:min(5, len(relayAddrs))])
 		wn.phonebook.ReplacePeerList(relayAddrs, string(wn.genesisInfo.NetworkID), phonebook.RelayRole)
 	} else {
-		wn.log.Infof("got no relay DNS addrs for network %s", wn.genesisInfo.NetworkID)
+		wn.log.Warnf("got no relay DNS addrs for network %s; the node may be unable to find peers and sync", wn.genesisInfo.NetworkID)
 	}
 	if len(archiveAddrs) > 0 {
 		wn.phonebook.ReplacePeerList(archiveAddrs, string(wn.genesisInfo.NetworkID), phonebook.ArchivalRole)
@@ -1858,19 +1858,15 @@ func (wn *WebsocketNetwork) getDNSAddrs(dnsBootstrap string) (relaysAddresses []
 	var err error
 	relaysAddresses, err = wn.resolveSRVRecords(wn.ctx, "algobootstrap", "tcp", dnsBootstrap, wn.config.FallbackDNSResolverAddress, wn.config.DNSSecuritySRVEnforced())
 	if err != nil {
-		// only log this warning on testnet or devnet
-		if wn.genesisInfo.NetworkID == config.Devnet || wn.genesisInfo.NetworkID == config.Testnet {
-			wn.log.Warnf("Cannot lookup algobootstrap SRV record for %s: %v", dnsBootstrap, err)
-		}
+		// Log on all networks: with no relays resolved the node may be unable to find peers.
+		wn.log.Warnf("Cannot lookup algobootstrap SRV record for %s: %v", dnsBootstrap, err)
 		relaysAddresses = nil
 	}
 
 	archivalAddresses, err = wn.resolveSRVRecords(wn.ctx, "archive", "tcp", dnsBootstrap, wn.config.FallbackDNSResolverAddress, wn.config.DNSSecuritySRVEnforced())
 	if err != nil {
-		// only log this warning on testnet or devnet
-		if wn.genesisInfo.NetworkID == config.Devnet || wn.genesisInfo.NetworkID == config.Testnet {
-			wn.log.Warnf("Cannot lookup archive SRV record for %s: %v", dnsBootstrap, err)
-		}
+		// Archival peers are optional for most nodes, so this is informational.
+		wn.log.Infof("Cannot lookup archive SRV record for %s: %v", dnsBootstrap, err)
 		archivalAddresses = nil
 	}
 	return

--- a/tools/network/dnssec/client.go
+++ b/tools/network/dnssec/client.go
@@ -75,7 +75,9 @@ func (r *dnsClient) query(ctx context.Context, name string, qtype uint16) (resp 
 	msg := new(dns.Msg)
 	msg.RecursionDesired = true
 	msg.SetQuestion(name, qtype)
-	msg.SetEdns0(4096, true) // high enough value prevents truncation and retries with TCP
+	// Conservative EDNS0 UDP buffer (DNS Flag Day 2020): larger sizes invite
+	// fragmented responses that get dropped, defeating the truncation/TCP retry.
+	msg.SetEdns0(1232, true)
 
 	for _, server := range r.servers {
 		resp, err := r.transport.queryServer(ctx, server, msg, r.readTimeout)

--- a/tools/network/dnssec/client.go
+++ b/tools/network/dnssec/client.go
@@ -52,14 +52,26 @@ type qsi struct {
 
 // queryServer performs DNS query against provided server with respect of both context and timeout restrictions.
 // If UDP fails then retries with TCP client
-func (t qsi) queryServer(ctx context.Context, server ResolverAddress, msg *dns.Msg, timeout time.Duration) (resp *dns.Msg, err error) {
+func (t qsi) queryServer(ctx context.Context, server ResolverAddress, msg *dns.Msg, timeout time.Duration) (*dns.Msg, error) {
+	var lastErr error
 	for _, netType := range []string{"udp", "tcp"} {
-		if resp, _, err = (&dns.Client{Net: netType, ReadTimeout: timeout}).ExchangeContext(ctx, msg, string(server)); err != nil {
-			return nil, err
+		// Timeout bounds dial+write+read; without it dial/write use miekg's 2s default.
+		resp, _, err := (&dns.Client{Net: netType, Timeout: timeout}).ExchangeContext(ctx, msg, string(server))
+		if err != nil {
+			// Fall through to TCP on a UDP error too (dropped response, or UDP/53
+			// filtered); only a finished context is fatal.
+			if ctx.Err() != nil {
+				return nil, err
+			}
+			lastErr = err
+			continue
 		}
 		if !resp.Truncated {
-			return
+			return resp, nil
 		}
+	}
+	if lastErr != nil {
+		return nil, lastErr
 	}
 	var name string
 	if len(msg.Question) > 0 {

--- a/tools/network/dnssec/client.go
+++ b/tools/network/dnssec/client.go
@@ -18,6 +18,7 @@ package dnssec
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -91,12 +92,18 @@ func (r *dnsClient) query(ctx context.Context, name string, qtype uint16) (resp 
 	// fragmented responses that get dropped, defeating the truncation/TCP retry.
 	msg.SetEdns0(1232, true)
 
+	var errs []error
 	for _, server := range r.servers {
-		resp, err := r.transport.queryServer(ctx, server, msg, r.readTimeout)
+		resp, err = r.transport.queryServer(ctx, server, msg, r.readTimeout)
 		if err != nil {
+			// Keep each server's error so the eventual failure explains itself.
+			errs = append(errs, fmt.Errorf("%s: %w", server, err))
 			continue
 		}
-		return resp, err
+		return resp, nil
+	}
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("no answer for (%s, %d) from DNS servers %v: %w", name, qtype, r.servers, errors.Join(errs...))
 	}
 	return nil, fmt.Errorf("no answer for (%s, %d) from DNS servers %v", name, qtype, r.servers)
 }

--- a/tools/network/dnssec/client.go
+++ b/tools/network/dnssec/client.go
@@ -25,6 +25,11 @@ import (
 	"github.com/miekg/dns"
 )
 
+// ednsUDPBufferSize is the EDNS0 UDP payload size advertised to DNS servers. Per DNS Flag
+// Day 2020, 1232 bytes keeps responses below the common path MTU to avoid IP fragmentation;
+// larger responses come back truncated (or are dropped) and are retried over TCP by queryServer.
+const ednsUDPBufferSize = 1232
+
 // Querier provides a method for getting RRSet and RRSig from DNSSEC-aware server
 type Querier interface {
 	QueryRRSet(ctx context.Context, domain string, qtype uint16) ([]dns.RR, []dns.RRSIG, error)
@@ -88,9 +93,7 @@ func (r *dnsClient) query(ctx context.Context, name string, qtype uint16) (resp 
 	msg := new(dns.Msg)
 	msg.RecursionDesired = true
 	msg.SetQuestion(name, qtype)
-	// Conservative EDNS0 UDP buffer (DNS Flag Day 2020): larger sizes invite
-	// fragmented responses that get dropped, defeating the truncation/TCP retry.
-	msg.SetEdns0(1232, true)
+	msg.SetEdns0(ednsUDPBufferSize, true)
 
 	var errs []error
 	for _, server := range r.servers {

--- a/tools/network/dnssec/client_test.go
+++ b/tools/network/dnssec/client_test.go
@@ -18,6 +18,8 @@ package dnssec
 
 import (
 	"context"
+	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -86,4 +88,112 @@ func TestMockedClient(t *testing.T) {
 	a.NoError(err)
 	a.Equal(1, len(rr))
 	a.Equal(1, len(rsig))
+}
+
+// startTestDNSServer starts a miekg/dns server with handler on network ("udp"
+// or "tcp"), bound to addr ("127.0.0.1:0" for an ephemeral port). It blocks
+// until the server is ready and returns the bound address and a shutdown func.
+func startTestDNSServer(t *testing.T, network, addr string, handler dns.HandlerFunc) (string, func()) {
+	t.Helper()
+	srv := &dns.Server{Net: network, Handler: handler}
+	var bound string
+	switch network {
+	case "udp":
+		pc, err := net.ListenPacket("udp", addr)
+		require.NoError(t, err)
+		srv.PacketConn = pc
+		bound = pc.LocalAddr().String()
+	case "tcp":
+		l, err := net.Listen("tcp", addr)
+		require.NoError(t, err)
+		srv.Listener = l
+		bound = l.Addr().String()
+	default:
+		t.Fatalf("unsupported network %q", network)
+	}
+	started := make(chan struct{})
+	srv.NotifyStartedFunc = func() { close(started) }
+	go func() { _ = srv.ActivateAndServe() }()
+	<-started
+	return bound, func() { _ = srv.Shutdown() }
+}
+
+func replyWithA(w dns.ResponseWriter, r *dns.Msg) {
+	m := new(dns.Msg)
+	m.SetReply(r)
+	m.Answer = append(m.Answer, &dns.A{
+		Hdr: dns.RR_Header{Name: r.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 1},
+		A:   net.IPv4(1, 2, 3, 4),
+	})
+	_ = w.WriteMsg(m)
+}
+
+// A UDP error (nothing answering on UDP) must still retry over TCP.
+func TestQueryServerFallsBackToTCPOnUDPError(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	addr, shutdown := startTestDNSServer(t, "tcp", "127.0.0.1:0", replyWithA)
+	defer shutdown()
+
+	c := &dnsClient{servers: []ResolverAddress{ResolverAddress(addr)}, readTimeout: 2 * time.Second, transport: qsi{}}
+	resp, err := c.query(context.Background(), "example.com", dns.TypeA)
+	a.NoError(err)
+	a.NotNil(resp)
+	a.Len(resp.Answer, 1)
+}
+
+// A truncated UDP response must trigger a TCP retry that returns the full answer.
+func TestQueryServerFallsBackToTCPOnTruncation(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	addr, shutdownTCP := startTestDNSServer(t, "tcp", "127.0.0.1:0", replyWithA)
+	defer shutdownTCP()
+	_, shutdownUDP := startTestDNSServer(t, "udp", addr, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Truncated = true
+		_ = w.WriteMsg(m)
+	})
+	defer shutdownUDP()
+
+	c := &dnsClient{servers: []ResolverAddress{ResolverAddress(addr)}, readTimeout: 2 * time.Second, transport: qsi{}}
+	resp, err := c.query(context.Background(), "example.com", dns.TypeA)
+	a.NoError(err)
+	a.False(resp.Truncated)
+	a.Len(resp.Answer, 1)
+}
+
+// Queries must advertise the reduced EDNS0 UDP buffer size (DNS Flag Day 2020).
+func TestQueryAdvertisesReducedEDNSBuffer(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	var got atomic.Uint32
+	addr, shutdown := startTestDNSServer(t, "udp", "127.0.0.1:0", func(w dns.ResponseWriter, r *dns.Msg) {
+		if o := r.IsEdns0(); o != nil {
+			got.Store(uint32(o.UDPSize()))
+		}
+		replyWithA(w, r)
+	})
+	defer shutdown()
+
+	c := &dnsClient{servers: []ResolverAddress{ResolverAddress(addr)}, readTimeout: 2 * time.Second, transport: qsi{}}
+	_, err := c.query(context.Background(), "example.com", dns.TypeA)
+	a.NoError(err)
+	a.Equal(uint32(1232), got.Load())
+}
+
+// When every server attempt errors, the failure surfaces the underlying cause.
+func TestQueryReportsUnderlyingErrors(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	// Nothing listens on 127.0.0.1:1, so both the UDP and TCP attempts fail.
+	c := &dnsClient{servers: []ResolverAddress{"127.0.0.1:1"}, readTimeout: 500 * time.Millisecond, transport: qsi{}}
+	resp, err := c.query(context.Background(), "example.com", dns.TypeA)
+	a.Error(err)
+	a.Nil(resp)
+	a.Contains(err.Error(), "127.0.0.1:1")
 }

--- a/tools/network/dnssec/client_test.go
+++ b/tools/network/dnssec/client_test.go
@@ -182,7 +182,7 @@ func TestQueryAdvertisesReducedEDNSBuffer(t *testing.T) {
 	c := &dnsClient{servers: []ResolverAddress{ResolverAddress(addr)}, readTimeout: 2 * time.Second, transport: qsi{}}
 	_, err := c.query(context.Background(), "example.com", dns.TypeA)
 	a.NoError(err)
-	a.Equal(uint32(1232), got.Load())
+	a.Equal(uint32(ednsUDPBufferSize), got.Load())
 }
 
 // When every server attempt errors, the failure surfaces the underlying cause.


### PR DESCRIPTION
## Summary

Mainnet nodes can currently fail relay SRV resolution silently: the phonebook stays empty, the node connects to no peers, and it may appear caught up at a stale round without an actionable log.

This PR hardens the DNSSEC SRV bootstrap path (`tools/network/dnssec`, the default resolver path when `DNSSecurityFlags=9`) and makes bootstrap failures visible in `network/wsNetwork.go`. The non-DNSSEC stdlib resolver path is unchanged.

## Changes

- Advertise a 1232-byte EDNS0 UDP buffer, per DNS Flag Day 2020 guidance, to avoid fragmented DNSSEC UDP responses that are commonly dropped.
- Retry over TCP when a UDP DNS query errors, not only when the UDP response has the truncated bit set.
- Apply the configured DNS timeout to the full DNS exchange via `Client.Timeout`.
- Return joined per-server errors so failed lookups include the real cause, such as timeout or blocked TCP.
- Log relay SRV lookup failures on all networks, and warn when no relay addresses are resolved because the node may be unable to find peers.
- Log archive SRV lookup failures at INFO, since archival peers are optional for most nodes.
- Add loopback DNS transport tests covering UDP errors, truncation fallback, EDNS buffer size, and underlying error reporting.

## Behavioural note

Reducing the advertised UDP buffer to 1232 means larger DNSSEC answers intentionally truncate and retry over TCP/53 instead of relying on fragmented UDP delivery.

This is likely already the effective behaviour on mainnet today: as today, the mainnet bootstrap SRV response is 3615 bytes with DNSSEC, larger than both the new 1232-byte buffer and a typical 1500-byte path MTU. Resolvers such as 1.1.1.1 already return it truncated and complete the lookup over TCP. This change makes that path explicit and reliable instead of depending on whether an oversized UDP response happens to survive fragmentation.

If TCP/53 to the configured resolver is blocked, the lookup can still fail, but the returned/logged error now exposes that cause.

## Testing

- `go test -race ./tools/network/dnssec/`
- `go build ./network/`