### PR TITLE
logic: add autosalt pragma

### DIFF
--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -1186,7 +1186,7 @@ func legacyOnCurveLogicSigProgram(t *testing.T) []byte {
 func offCurveLogicSigProgram(t *testing.T) []byte {
 	t.Helper()
 
-	ops, err := logic.AssembleStringWithVersion("#pragma version 13\npushint 12", logic.LogicSigOffCurveVersion)
+	ops, err := logic.AssembleStringWithVersion("pushint 12", logic.LogicSigOffCurveVersion)
 	require.NoError(t, err)
 	require.False(t, logic.ProgramHashIsEdwards25519Point(ops.Program))
 	return ops.Program

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -268,12 +268,22 @@ type OpStream struct {
 	OffsetToSource map[int]SourceLocation
 
 	HasStatefulOps bool
+	autoSalt       autoSaltMode
+	autoSaltToken  token
 
 	// Need new copy for each opstream
 	versionedPseudoOps map[string]map[int]OpSpec
 
 	macros map[string][]token
 }
+
+type autoSaltMode int
+
+const (
+	autoSaltDefault autoSaltMode = iota
+	autoSaltOn
+	autoSaltOff
+)
 
 // newOpStream constructs OpStream instances ready to invoke assemble. A new
 // OpStream must be used for each call to assemble().
@@ -2223,12 +2233,14 @@ func (ops *OpStream) parseText(text string) error {
 const assemblerSaltSearchLimit = 128
 
 // finalizeProgram constructs final program bytes. For v13+ stateless programs
-// that would hash on-curve, it adds salt to make the hash off-curve. If the
-// program has an automatic intcblock, it appends the salt there; otherwise it
-// adds a trailing intcblock at the end of the program.
+// that would hash on-curve, it adds salt to make the hash off-curve. The
+// #pragma autosalt directive can force this behavior on for older versions, or
+// disable it for v13+ programs. If the program has an automatic intcblock, it
+// appends the salt there; otherwise it adds a trailing intcblock at the end of
+// the program.
 func (ops *OpStream) finalizeProgram() ([]byte, int, *sourceError) {
 	program, prefixLen := ops.prependCBlocks()
-	if ops.Version < LogicSigOffCurveVersion || ops.HasStatefulOps || !ProgramHashIsEdwards25519Point(program) {
+	if !ops.shouldAutoSalt(program) {
 		return program, prefixLen, nil
 	}
 
@@ -2236,6 +2248,22 @@ func (ops *OpStream) finalizeProgram() ([]byte, int, *sourceError) {
 		return ops.finalizeProgramWithAutoIntcSalt()
 	}
 	return ops.finalizeProgramWithTrailingIntcSalt(program, prefixLen)
+}
+
+func (ops *OpStream) shouldAutoSalt(program []byte) bool {
+	if ops.autoSalt == autoSaltOff {
+		return false
+	}
+	if ops.autoSalt == autoSaltOn {
+		if ops.HasStatefulOps {
+			ops.warn(ops.autoSaltToken, "#pragma autosalt true used with stateful opcodes")
+		}
+		return ProgramHashIsEdwards25519Point(program)
+	}
+	if ops.HasStatefulOps {
+		return false
+	}
+	return ops.Version >= LogicSigOffCurveVersion && ProgramHashIsEdwards25519Point(program)
 }
 
 // TODO: should ops.intc reflect the salted intcblock that ends up
@@ -2449,6 +2477,29 @@ func pragma(ops *OpStream, tokens []token) *sourceError {
 			ops.known.reset()
 		}
 		ops.typeTracking = on
+
+		return nil
+	case "autosalt":
+		if len(tokens) < 3 {
+			return tokens[1].errorf("no autosalt value")
+		}
+		if len(tokens) > 3 {
+			return tokens[3].errorf("unexpected extra tokens:%s", reJoin("", tokens[3:]))
+		}
+		if ops.pending.Len() > 0 {
+			return tokens[0].errorf("#pragma autosalt is only allowed before instructions")
+		}
+		value := tokens[2].str
+		on, err := strconv.ParseBool(value)
+		if err != nil {
+			return tokens[2].errorf("bad #pragma autosalt: %#v", value)
+		}
+		if on {
+			ops.autoSalt = autoSaltOn
+		} else {
+			ops.autoSalt = autoSaltOff
+		}
+		ops.autoSaltToken = tokens[0]
 
 		return nil
 	default:
@@ -3273,20 +3324,19 @@ type disInfo struct {
 // disassembly. If the labels names are known, they may be passed in.
 // When doing so, labels for all jump targets must be provided.
 func disassembleInstrumented(program []byte, labels map[int]string) (text string, ds disInfo, err error) {
-	out := strings.Builder{}
-	dis := disassembleState{program: program, out: &out, pendingLabels: labels}
+	body := strings.Builder{}
+	dis := disassembleState{program: program, out: &body, pendingLabels: labels}
 	version, vlen := binary.Uvarint(program)
 	if vlen <= 0 {
 		fmt.Fprintf(dis.out, "// invalid version\n")
-		text = out.String()
+		text = body.String()
 		return
 	}
 	if version > LogicVersion {
 		fmt.Fprintf(dis.out, "// unsupported version %d\n", version)
-		text = out.String()
+		text = body.String()
 		return
 	}
-	fmt.Fprintf(dis.out, "#pragma version %d\n", version)
 	dis.pc = vlen
 	for dis.pc < len(program) {
 		err = dis.outputLabelIfNeeded()
@@ -3298,11 +3348,11 @@ func disassembleInstrumented(program []byte, labels map[int]string) (text string
 			ds.hasStatefulOps = true
 		}
 		if op.Name == "" {
-			ds.pcOffset = append(ds.pcOffset, PCOffset{dis.pc, out.Len()})
+			ds.pcOffset = append(ds.pcOffset, PCOffset{dis.pc, body.Len()})
 			msg := fmt.Sprintf("invalid opcode %02x at pc=%d", program[dis.pc], dis.pc)
-			out.WriteString(msg)
-			out.WriteRune('\n')
-			text = out.String()
+			body.WriteString(msg)
+			body.WriteRune('\n')
+			text = finalizeDisassemblyWithPragmas(version, program, body.String(), &ds)
 			err = errors.New(msg)
 			return
 		}
@@ -3321,7 +3371,7 @@ func disassembleInstrumented(program []byte, labels map[int]string) (text string
 		}
 
 		// ds.pcOffset tracks where in the output each opcode maps to assembly
-		ds.pcOffset = append(ds.pcOffset, PCOffset{dis.pc, out.Len()})
+		ds.pcOffset = append(ds.pcOffset, PCOffset{dis.pc, body.Len()})
 
 		// Actually do the disassembly
 		var instruction string
@@ -3329,16 +3379,14 @@ func disassembleInstrumented(program []byte, labels map[int]string) (text string
 		if err != nil {
 			return
 		}
-		out.WriteString(instruction)
-		out.WriteRune('\n')
+		body.WriteString(instruction)
+		body.WriteRune('\n')
 		dis.pc = dis.nextpc
 	}
 	err = dis.outputLabelIfNeeded()
 	if err != nil {
 		return
 	}
-
-	text = out.String()
 
 	if dis.rerun {
 		if labels != nil {
@@ -3347,7 +3395,22 @@ func disassembleInstrumented(program []byte, labels map[int]string) (text string
 		}
 		return disassembleInstrumented(program, dis.pendingLabels)
 	}
+	text = finalizeDisassemblyWithPragmas(version, program, body.String(), &ds)
 	return
+}
+
+func finalizeDisassemblyWithPragmas(version uint64, program []byte, body string, ds *disInfo) string {
+	header := strings.Builder{}
+	fmt.Fprintf(&header, "#pragma version %d\n", version)
+	if version >= LogicSigOffCurveVersion && !ds.hasStatefulOps && ProgramHashIsEdwards25519Point(program) {
+		fmt.Fprintf(&header, "#pragma autosalt false\n")
+	}
+	headerLen := header.Len()
+	for i := range ds.pcOffset {
+		ds.pcOffset[i].Offset += headerLen
+	}
+	header.WriteString(body)
+	return header.String()
 }
 
 // Disassemble produces a text form of program bytes.

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -2252,6 +2252,9 @@ func (ops *OpStream) finalizeProgram() ([]byte, int, *sourceError) {
 
 func (ops *OpStream) shouldAutoSalt(program []byte) bool {
 	if ops.autoSalt == autoSaltOff {
+		if !ops.HasStatefulOps && ProgramHashIsEdwards25519Point(program) {
+			ops.warn(ops.autoSaltToken, "#pragma autosalt false leaves program hash on curve")
+		}
 		return false
 	}
 	if ops.autoSalt == autoSaltOn {
@@ -2260,10 +2263,11 @@ func (ops *OpStream) shouldAutoSalt(program []byte) bool {
 		}
 		return ProgramHashIsEdwards25519Point(program)
 	}
-	if ops.HasStatefulOps {
-		return false
-	}
-	return ops.Version >= LogicSigOffCurveVersion && ProgramHashIsEdwards25519Point(program)
+	return defaultAutoSaltApplies(ops.Version, ops.HasStatefulOps, program)
+}
+
+func defaultAutoSaltApplies(version uint64, hasStatefulOps bool, program []byte) bool {
+	return version >= LogicSigOffCurveVersion && !hasStatefulOps && ProgramHashIsEdwards25519Point(program)
 }
 
 // TODO: should ops.intc reflect the salted intcblock that ends up
@@ -3402,7 +3406,7 @@ func disassembleInstrumented(program []byte, labels map[int]string) (text string
 func finalizeDisassemblyWithPragmas(version uint64, program []byte, body string, ds *disInfo) string {
 	header := strings.Builder{}
 	fmt.Fprintf(&header, "#pragma version %d\n", version)
-	if version >= LogicSigOffCurveVersion && !ds.hasStatefulOps && ProgramHashIsEdwards25519Point(program) {
+	if defaultAutoSaltApplies(version, ds.hasStatefulOps, program) {
 		fmt.Fprintf(&header, "#pragma autosalt false\n")
 	}
 	headerLen := header.Len()

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -898,6 +898,10 @@ const onCurveStatelessAutosaltTrueV12Source = `#pragma version 12
 #pragma autosalt true
 pushint 1`
 
+const onCurveStatelessAutosaltFalseV12Source = `#pragma version 12
+#pragma autosalt false
+pushint 1`
+
 const onCurveStatelessAutosaltFalseV13Source = `#pragma version 13
 #pragma autosalt false
 pushint 12`
@@ -916,10 +920,18 @@ app_global_get
 pop
 pushint 1`
 
+const onCurveStatefulAutosaltFalseV13Source = `#pragma version 13
+#pragma autosalt false
+byte 0x01
+app_global_get
+pop
+pushint 0`
+
 func TestPragmaAutosalt(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	const statefulAutosaltWarning = "#pragma autosalt true used with stateful opcodes"
+	const onCurveLogicSigWarning = "#pragma autosalt false leaves program hash on curve"
 
 	tests := []struct {
 		name                         string
@@ -942,10 +954,18 @@ func TestPragmaAutosalt(t *testing.T) {
 			wantSaltAdded:              true,
 		},
 		{
+			name:                       "false warns older versions on curve logicsig",
+			source:                     onCurveStatelessAutosaltFalseV12Source,
+			wantUnsaltedProgramOnCurve: true,
+			wantSaltAdded:              false,
+			wantWarning:                onCurveLogicSigWarning,
+		},
+		{
 			name:                         "false opts v13 out",
 			source:                       onCurveStatelessAutosaltFalseV13Source,
 			wantUnsaltedProgramOnCurve:   true,
 			wantSaltAdded:                false,
+			wantWarning:                  onCurveLogicSigWarning,
 			wantDisassemblyAutosaltFalse: true,
 		},
 		{
@@ -960,6 +980,12 @@ func TestPragmaAutosalt(t *testing.T) {
 			source:        offCurveStatefulAutosaltTrueV13Source,
 			wantSaltAdded: false,
 			wantWarning:   statefulAutosaltWarning,
+		},
+		{
+			name:                       "false does not warn on stateful program",
+			source:                     onCurveStatefulAutosaltFalseV13Source,
+			wantUnsaltedProgramOnCurve: true,
+			wantSaltAdded:              false,
 		},
 	}
 

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -891,6 +891,104 @@ func TestAssemblerIntcblockSalt(t *testing.T) {
 	})
 }
 
+const onCurveStatelessV12Source = `#pragma version 12
+pushint 1`
+
+const onCurveStatelessAutosaltTrueV12Source = `#pragma version 12
+#pragma autosalt true
+pushint 1`
+
+const onCurveStatelessAutosaltFalseV13Source = `#pragma version 13
+#pragma autosalt false
+pushint 12`
+
+const onCurveStatefulAutosaltTrueV13Source = `#pragma version 13
+#pragma autosalt true
+byte 0x01
+app_global_get
+pop
+pushint 0`
+
+const offCurveStatefulAutosaltTrueV13Source = `#pragma version 13
+#pragma autosalt true
+byte 0x01
+app_global_get
+pop
+pushint 1`
+
+func TestPragmaAutosalt(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	const statefulAutosaltWarning = "#pragma autosalt true used with stateful opcodes"
+
+	tests := []struct {
+		name                         string
+		source                       string
+		wantUnsaltedProgramOnCurve   bool
+		wantSaltAdded                bool
+		wantWarning                  string
+		wantDisassemblyAutosaltFalse bool
+	}{
+		{
+			name:                       "default v12 does not autosalt",
+			source:                     onCurveStatelessV12Source,
+			wantUnsaltedProgramOnCurve: true,
+			wantSaltAdded:              false,
+		},
+		{
+			name:                       "true opts older versions in",
+			source:                     onCurveStatelessAutosaltTrueV12Source,
+			wantUnsaltedProgramOnCurve: true,
+			wantSaltAdded:              true,
+		},
+		{
+			name:                         "false opts v13 out",
+			source:                       onCurveStatelessAutosaltFalseV13Source,
+			wantUnsaltedProgramOnCurve:   true,
+			wantSaltAdded:                false,
+			wantDisassemblyAutosaltFalse: true,
+		},
+		{
+			name:                       "true salts stateful program with warning",
+			source:                     onCurveStatefulAutosaltTrueV13Source,
+			wantUnsaltedProgramOnCurve: true,
+			wantSaltAdded:              true,
+			wantWarning:                statefulAutosaltWarning,
+		},
+		{
+			name:          "true warns stateful program even when already off curve",
+			source:        offCurveStatefulAutosaltTrueV13Source,
+			wantSaltAdded: false,
+			wantWarning:   statefulAutosaltWarning,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			unsaltedProgram := assembleProgramWithoutAutomaticSalt(t, test.source, assemblerNoVersion)
+			require.Equal(t, test.wantUnsaltedProgramOnCurve, ProgramHashIsEdwards25519Point(unsaltedProgram))
+
+			ops := testProg(t, test.source, assemblerNoVersion)
+			saltAdded := !bytes.Equal(unsaltedProgram, ops.Program)
+			require.Equal(t, test.wantSaltAdded, saltAdded)
+			require.Equal(t, test.wantUnsaltedProgramOnCurve && !saltAdded, ProgramHashIsEdwards25519Point(ops.Program))
+
+			if test.wantWarning == "" {
+				require.Empty(t, ops.Warnings)
+			} else {
+				require.Len(t, ops.Warnings, 1)
+				require.ErrorContains(t, ops.Warnings[0], test.wantWarning)
+			}
+
+			if test.wantDisassemblyAutosaltFalse {
+				dis, err := Disassemble(ops.Program)
+				require.NoError(t, err)
+				require.Contains(t, dis, "#pragma autosalt false\n")
+			}
+		})
+	}
+}
+
 func testLine(t *testing.T, line string, ver uint64, expected string, col ...int) {
 	t.Helper()
 	// By embedding the source line between two other lines, the
@@ -2800,12 +2898,27 @@ func TestPragmas(t *testing.T) {
 	testProg(t, "#pragma typetrack false blah", assemblerNoVersion,
 		exp(1, "unexpected extra tokens: blah"))
 
+	testProg(t, "#pragma autosalt", assemblerNoVersion,
+		exp(1, "no autosalt value"))
+
+	testProg(t, "#pragma autosalt blah", assemblerNoVersion,
+		exp(1, `bad #pragma autosalt: "blah"`))
+
+	testProg(t, "#pragma autosalt false blah", assemblerNoVersion,
+		exp(1, "unexpected extra tokens: blah"))
+
+	testProg(t, "\nint 1\n#pragma autosalt false", assemblerNoVersion,
+		exp(3, "#pragma autosalt is only allowed before instructions"))
+
 	// Currently pragmas don't treat semicolons as newlines. It would probably
 	// be nice to fix this.
 	testProg(t, "#pragma version 5; int 1", assemblerNoVersion,
 		exp(1, "unexpected extra tokens: ; int 1"))
 
 	testProg(t, "#pragma typetrack false; int 1", assemblerNoVersion,
+		exp(1, "unexpected extra tokens: ; int 1"))
+
+	testProg(t, "#pragma autosalt false; int 1", assemblerNoVersion,
 		exp(1, "unexpected extra tokens: ; int 1"))
 }
 

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -695,7 +695,7 @@ func TestLsigSize(t *testing.T) {
 	for _, test := range testCases {
 		blkHdr.UpgradeState.CurrentProtocol = test.consensusVersion
 
-		lsig, err := txntest.GenerateProgramOfSize(test.lsigSize, pragma)
+		lsig, err := txntest.GenerateUnsaltedProgramOfSize(test.lsigSize, pragma)
 		require.NoError(t, err)
 
 		lsigPay := txntest.Txn{

--- a/data/txntest/program.go
+++ b/data/txntest/program.go
@@ -22,22 +22,22 @@ import (
 	"github.com/algorand/go-algorand/data/transactions/logic"
 )
 
-// GenerateProgramOfSize return a TEAL bytecode of `size` bytes which always succeeds.
-// `size` must be at least 9 bytes
-func GenerateProgramOfSize(size uint, pragma uint) ([]byte, error) {
-	if size < 9 {
-		return nil, fmt.Errorf("size must be at least 9 bytes; got %d", size)
+// GenerateUnsaltedProgramOfSize returns a TEAL bytecode of `size` bytes which always succeeds.
+// `size` must be at least 5 bytes.
+func GenerateUnsaltedProgramOfSize(size uint, pragma uint) ([]byte, error) {
+	if size < 5 {
+		return nil, fmt.Errorf("size must be at least 5 bytes; got %d", size)
 	}
-	ls := fmt.Sprintf("#pragma version %d\n", pragma)
+	ls := fmt.Sprintf("#pragma version %d\n#pragma autosalt false\n", pragma)
 	if size%2 == 0 {
-		ls += "int 10\npop\nint 1\npop\n"
+		ls += "intcblock 1 1\n"
 	} else {
-		ls += "int 1\npop\nint 1\npop\n"
+		ls += "intcblock 1\n"
 	}
-	for i := uint(11); i <= size; i += 2 {
-		ls = ls + "int 1\npop\n"
+	for i := uint(7); i <= size; i += 2 {
+		ls += "intc_0\npop\n"
 	}
-	ls = ls + "int 1"
+	ls += "intc_0"
 	code, err := logic.AssembleString(ls)
 	if err != nil {
 		return nil, err

--- a/data/txntest/program_test.go
+++ b/data/txntest/program_test.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2019-2026 Algorand Foundation Ltd.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package txntest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/data/transactions/logic"
+	"github.com/algorand/go-algorand/test/partitiontest"
+)
+
+func TestGenerateUnsaltedProgramOfSize(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	for _, version := range []uint{1, logic.LogicSigOffCurveVersion} {
+		t.Run(fmt.Sprintf("v%d", version), func(t *testing.T) {
+			for size := uint(5); size < 80; size++ {
+				program, err := GenerateUnsaltedProgramOfSize(size, version)
+				require.NoError(t, err)
+				require.Len(t, program, int(size))
+			}
+		})
+	}
+}

--- a/test/e2e-go/features/transactions/logicsig_test.go
+++ b/test/e2e-go/features/transactions/logicsig_test.go
@@ -36,9 +36,9 @@ func TestLogicSigSizeBeforePooling(t *testing.T) {
 	// From consensus version 18, we have lsigs with a maximum size of 1000 bytes.
 	// We need to use pragma 1 for teal in v18
 	pragma := uint(1)
-	tealOK, err := txntest.GenerateProgramOfSize(1000, pragma)
+	tealOK, err := txntest.GenerateUnsaltedProgramOfSize(1000, pragma)
 	a.NoError(err)
-	tealTooLong, err := txntest.GenerateProgramOfSize(1001, pragma)
+	tealTooLong, err := txntest.GenerateUnsaltedProgramOfSize(1001, pragma)
 	a.NoError(err)
 
 	testLogicSize(t, tealOK, tealTooLong, filepath.Join("nettemplates", "TwoNodes50EachV18.json"))
@@ -50,9 +50,9 @@ func TestLogicSigSizeAfterPooling(t *testing.T) {
 	a := require.New(fixtures.SynchronizedTest(t))
 
 	pragma := uint(1)
-	tealOK, err := txntest.GenerateProgramOfSize(2000, pragma)
+	tealOK, err := txntest.GenerateUnsaltedProgramOfSize(2000, pragma)
 	a.NoError(err)
-	tealTooLong, err := txntest.GenerateProgramOfSize(2001, pragma)
+	tealTooLong, err := txntest.GenerateUnsaltedProgramOfSize(2001, pragma)
 	a.NoError(err)
 
 	// TODO: Update this when lsig pooling graduates from vFuture


### PR DESCRIPTION
# Summary

This PR adds `#pragma autosalt` to control the assembler's off-curve autosalt behavior introduced for AVM v13+ programs.

The directive accepts a boolean value:

- `#pragma autosalt true` forces autosalt behavior for any TEAL version.
- `#pragma autosalt false` disables autosalt behavior, including for v13+ programs.
- Omitting the pragma preserves the current default: autosalt v13+ programs that do not contain detected stateful opcodes.

Autosalt only mutates bytecode when the unsalted program hash is an Edwards25519 curve point. If the hash is already off-curve, no salt is added.

If `#pragma autosalt true` is used on a program where the assembler detects stateful opcodes, the assembler still honors the directive and emits a warning.

If `#pragma autosalt false` is used on a program that appears to be a LogicSig and the resulting program hash is on-curve, the assembler emits a warning for any TEAL version.

# Behavior Matrix

In this table, "stateful" means the assembler detected at least one app-only opcode. "Salt if on-curve" means the assembler only adds salt when the unsalted program hash is on-curve.

| TEAL version | `#pragma autosalt` | Detected mode | Behavior | Warning |
|---|---:|---|---|---|
| v12- | absent | stateless | No autosalt | No |
| v12- | absent | stateful | No autosalt | No |
| v12- | `true` | stateless | Salt if on-curve | No |
| v12- | `true` | stateful | Salt if on-curve | Yes |
| v12- | `false` | stateless | No autosalt | If on-curve |
| v12- | `false` | stateful | No autosalt | No |
| v13+ | absent | stateless | Salt if on-curve | No |
| v13+ | absent | stateful | No autosalt | No |
| v13+ | `true` | stateless | Salt if on-curve | No |
| v13+ | `true` | stateful | Salt if on-curve | Yes |
| v13+ | `false` | stateless | No autosalt | If on-curve |
| v13+ | `false` | stateful | No autosalt | No |

# Disassembly

Disassembly preserves round trips for on-curve v13+ stateless programs by emitting `#pragma autosalt false` when needed.

# Tests

- `TestPragmaAutosalt`
  - default v12 behavior
  - v12 opt-in with `#pragma autosalt true`
  - v12/v13 opt-out with `#pragma autosalt false`, including on-curve LogicSig warning behavior
  - explicit autosalt on detected stateful programs, including warning behavior
- `TestPragmas`
  - parser validation for missing, invalid, extra-token, and after-instruction `#pragma autosalt` forms
