### PR TITLE
network: avoid panic on invalid fallback DNS resolver

### DIFF
--- a/tools/network/resolveController.go
+++ b/tools/network/resolveController.go
@@ -62,12 +62,15 @@ func (c *ResolveController) SystemResolver() ResolverIf {
 	return net.DefaultResolver
 }
 
-// FallbackResolver returns a resolver that uses fallback DNS address
+// FallbackResolver returns a resolver that uses the fallback DNS address. If that address
+// cannot be resolved to an IP (e.g. a misconfigured FallbackDNSResolverAddress), it returns
+// the default resolver instead of an unusable one; the non-secure path previously
+// dereferenced a nil *net.IPAddr and panicked.
 func (c *ResolveController) FallbackResolver() ResolverIf {
-	var dnsIPAddr *net.IPAddr
-	var err error
-	if dnsIPAddr, err = net.ResolveIPAddr("ip", c.fallback); err != nil {
-		c.log.Debugf("resolving fallback '%s' failed with %s", c.fallback, err.Error())
+	dnsIPAddr, err := net.ResolveIPAddr("ip", c.fallback)
+	if err != nil || dnsIPAddr == nil {
+		c.log.Warnf("resolving fallback DNS address '%s' failed (%v); using default resolver instead", c.fallback, err)
+		return c.DefaultResolver()
 	}
 
 	if c.secure {

--- a/tools/network/resolveController_test.go
+++ b/tools/network/resolveController_test.go
@@ -62,6 +62,28 @@ func TestFallbackResolver(t *testing.T) {
 	a.Equal(r.(*dnssec.Resolver).EffectiveResolverDNS(), []dnssec.ResolverAddress{dnssec.MakeResolverAddress("127.0.0.1", "53")})
 }
 
+func TestFallbackResolverInvalidAddress(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	a := require.New(t)
+	log := logging.Base()
+
+	// An unresolvable fallback address (consecutive dots form an empty, syntactically
+	// invalid label, so this fails locally without a network lookup) must degrade to the
+	// default resolver rather than panic on a nil *net.IPAddr.
+	const badAddr = "invalid..fallback..address"
+
+	c := NewResolveController(false, badAddr, log)
+	r := c.FallbackResolver()
+	a.IsType(&Resolver{}, r)
+	a.Equal(defaultDNSAddress, r.(*Resolver).EffectiveResolverDNS())
+
+	c = NewResolveController(true, badAddr, log)
+	r = c.FallbackResolver()
+	a.IsType(&dnssec.Resolver{}, r)
+	a.Equal(dnssec.DefaultDnssecAwareNSServers, r.(*dnssec.Resolver).EffectiveResolverDNS())
+}
+
 func TestDefaultResolver(t *testing.T) {
 	partitiontest.PartitionTest(t)
 


### PR DESCRIPTION
So this isn't actually something I've ever used or even knew about. But whilst working on #6652 this flagged up, so thought I'd give it a separate PR.

## Summary

- Handle invalid or unresolvable fallback DNS resolver addresses in `ResolveController.FallbackResolver`
- Fall back to the default resolver instead of dereferencing a nil `*net.IPAddr`
- Add coverage for invalid fallback addresses in both secure and non-secure resolver modes

## Testing
- `go test ./tools/network -run 'Test(FallbackResolver|DefaultResolver|SystemResolver)$'`
- `go test ./tools/network -run TestFallbackResolverInvalidAddress -count=1`