### PR TITLE
catchup: log early exit reason at Info level

### DIFF
--- a/catchup/service.go
+++ b/catchup/service.go
@@ -234,6 +234,16 @@ func (s *Service) SynchronizingTime() time.Duration {
 // errLedgerAlreadyHasBlock is returned by innerFetch in case the local ledger already has the requested block.
 var errLedgerAlreadyHasBlock = errors.New("ledger already has block")
 
+// Exit reasons returned by fetchAndWrite and pipelinedFetch.
+var (
+	errFetchRetryLimit          = errors.New("block retrieval exceeded retry limit")
+	errFetchNoBlock             = errors.New("remote peers do not have the block")
+	errCatchupNoPeer            = errors.New("no peer available to fetch from")
+	errCatchupWritingCatchpoint = errors.New("stopping to write catchpoint file")
+	errCatchupBehindDeltas      = errors.New("stopping: ledger behind committing deltas")
+	errCatchupStopping          = errors.New("catchup service stopping or round unsupported")
+)
+
 // function scope to make a bunch of defer statements better
 func (s *Service) innerFetch(ctx context.Context, r basics.Round, peer network.Peer) (blk *bookkeeping.Block, cert *agreement.Certificate, ddur time.Duration, err error) {
 	ledgerWaitCh := s.ledger.WaitMem(r)
@@ -276,15 +286,18 @@ const errNoBlockForRoundThreshold = 5
 //   - If the block is already in the ledger (e.g. if agreement service has already written it)
 //   - If the retrieval of the previous block was unsuccessful
 //   - If block evaluation panicked and was recovered (an unrecoverable defect; see ledgercore.EvalPanicError)
-func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCompleteChan chan struct{}, lookbackComplete chan struct{}, peerSelector peerSelector) bool {
+func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCompleteChan chan struct{}, lookbackComplete chan struct{}, peerSelector peerSelector) error {
 	// If sync-ing this round is not intended, don't fetch it
 	if dontSyncRound := s.GetDisableSyncRound(); dontSyncRound != 0 && r >= basics.Round(dontSyncRound) {
-		return false
+		return fmt.Errorf("fetchAndWrite(%d): syncing disabled at/after round %d", r, dontSyncRound)
 	}
 
 	// peerErrors tracks occurrences of errNoBlockForRound in order to quit earlier without making
 	// repeated requests for a block that most likely does not exist yet
 	peerErrors := map[network.Peer]int{}
+
+	// lastErr holds the most recent fetch error, surfaced if we exceed the retry limit.
+	var lastErr error
 
 	i := 0
 	for {
@@ -292,7 +305,7 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 		select {
 		case <-ctx.Done():
 			s.log.Debugf("fetchAndWrite(%d): Aborted", r)
-			return false
+			return ctx.Err()
 		default:
 		}
 
@@ -314,13 +327,16 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 					s.log.Warn(loggedMessage)
 				}
 			}
-			return false
+			if lastErr != nil {
+				return fmt.Errorf("%w: last error %v", errFetchRetryLimit, lastErr)
+			}
+			return errFetchRetryLimit
 		}
 
 		psp, getPeerErr := peerSelector.getNextPeer()
 		if getPeerErr != nil {
 			s.log.Debugf("fetchAndWrite(%d): was unable to obtain a peer to retrieve the block from: %v", r, getPeerErr)
-			return false
+			return fmt.Errorf("fetchAndWrite(%d): no peer available: %w", r, getPeerErr)
 		}
 		peer := psp.Peer
 		s.log.Debugf("fetchAndWrite(%d): got %s peer: %s", r, psp.peerClass, peerAddress(peer))
@@ -329,11 +345,12 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 		block, cert, blockDownloadDuration, err := s.innerFetch(ctx, r, peer)
 
 		if err != nil {
+			lastErr = err
 			if errors.Is(err, errLedgerAlreadyHasBlock) {
 				// ledger already has the block, no need to request this block.
 				// only the agreement could have added this block into the ledger, catchup is complete
 				s.log.Infof("fetchAndWrite(%d): the block is already in the ledger. The catchup is complete", r)
-				return false
+				return errLedgerAlreadyHasBlock
 			}
 			failureRank := peerRankDownloadFailed
 			var nbfe noBlockForRoundError
@@ -349,7 +366,7 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 				} else {
 					if count := peerErrors[peer]; count > errNoBlockForRoundThreshold {
 						s.log.Infof("fetchAndWrite(%d): remote peers do not have the block. Quitting", r)
-						return false
+						return errFetchNoBlock
 					}
 					peerErrors[peer]++
 				}
@@ -364,13 +381,13 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 			select {
 			case <-ctx.Done():
 				s.log.Infof("fetchAndWrite(%d): Aborted while waiting for lookback block to ledger", r)
-				return false
+				return ctx.Err()
 			case <-lookbackComplete:
 			}
 			continue // retry the fetch
 		} else if block == nil || cert == nil {
 			// someone already wrote the block to the ledger, we should stop syncing
-			return false
+			return errLedgerAlreadyHasBlock
 		}
 		s.log.Debugf("fetchAndWrite(%d): Got block and cert contents: %v %v", r, block, cert)
 
@@ -381,7 +398,7 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 				// Check if this mismatch is due to an unsupported protocol version
 				if _, ok := config.Consensus[block.BlockHeader.CurrentProtocol]; !ok {
 					s.log.Errorf("fetchAndWrite(%d): unsupported protocol version detected: '%v'", r, block.BlockHeader.CurrentProtocol)
-					return false
+					return fmt.Errorf("fetchAndWrite(%d): unsupported protocol version %v", r, block.BlockHeader.CurrentProtocol)
 				}
 
 				s.log.Warnf("fetchAndWrite(%d): block contents do not match header (attempt %d)", r, i)
@@ -393,7 +410,7 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 		select {
 		case <-ctx.Done():
 			s.log.Debugf("fetchAndWrite(%d): Aborted while waiting for lookback block to ledger", r)
-			return false
+			return ctx.Err()
 		case <-lookbackComplete:
 		}
 
@@ -414,13 +431,13 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 		select {
 		case <-ctx.Done():
 			s.log.Debugf("fetchAndWrite(%d): Aborted while waiting to write to ledger", r)
-			return false
+			return ctx.Err()
 		case <-prevFetchCompleteChan:
 			// make sure the ledger wrote enough of the account data to disk, since we don't want the ledger to hold a large amount of data in memory.
 			proto, err := s.ledger.ConsensusParams(r.SubSaturate(1))
 			if err != nil {
 				s.log.Errorf("fetchAndWrite(%d): Unable to determine consensus params for round %d: %v", r, r-1, err)
-				return false
+				return fmt.Errorf("fetchAndWrite(%d): consensus params for round %d: %w", r, r-1, err)
 			}
 			ledgerBacklogRound := r.SubSaturate(basics.Round(proto.MaxBalLookback))
 			select {
@@ -428,7 +445,7 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 				// i.e. round r-320 is no longer in the blockqueue, so it's account data is either being currently written, or it was already written.
 			case <-s.ctx.Done():
 				s.log.Debugf("fetchAndWrite(%d): Aborted while waiting for ledger to complete writing up to round %d", r, ledgerBacklogRound)
-				return false
+				return s.ctx.Err()
 			}
 
 			if s.cfg.CatchupVerifyTransactionSignatures() || s.cfg.CatchupVerifyApplyData() {
@@ -437,24 +454,24 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 				if err != nil {
 					if s.ctx.Err() != nil {
 						// if the context expired, just exit.
-						return false
+						return s.ctx.Err()
 					}
 					var errNSBE ledgercore.ErrNonSequentialBlockEval
 					if errors.As(err, &errNSBE) && errNSBE.EvaluatorRound <= errNSBE.LatestRound {
 						// the block was added to the ledger from elsewhere after fetching it here
 						// only the agreement could have added this block into the ledger, catchup is complete
 						s.log.Infof("fetchAndWrite(%d): after fetching the block, it is already in the ledger. The catchup is complete", r)
-						return false
+						return errLedgerAlreadyHasBlock
 					}
 					var evalPanicErr ledgercore.EvalPanicError
 					if errors.As(err, &evalPanicErr) {
 						// Validating the cert-authenticated block panicked; same unrecoverable
 						// handling as the ledger-write error switch below.
 						s.logEvalPanicOnce(r, err)
-						return false
+						return fmt.Errorf("fetchAndWrite(%d): block validation panicked: %w", r, err)
 					}
 					s.log.Warnf("fetchAndWrite(%d): failed to validate block : %v", r, err)
-					return false
+					return fmt.Errorf("fetchAndWrite(%d): failed to validate block: %w", r, err)
 				}
 				err = s.ledger.AddValidatedBlock(*vb, *cert)
 			} else {
@@ -469,12 +486,12 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 				switch {
 				case errors.As(err, &errNonSequentialBlockEval):
 					s.log.Infof("fetchAndWrite(%d): no need to re-evaluate historical block", r)
-					return true
+					return nil
 				case errors.As(err, &blockInLedgerError):
 					// the block was added to the ledger from elsewhere after fetching it here
 					// only the agreement could have added this block into the ledger, catchup is complete
 					s.log.Infof("fetchAndWrite(%d): after fetching the block, it is already in the ledger. The catchup is complete", r)
-					return false
+					return errLedgerAlreadyHasBlock
 				case errors.As(err, &protocolErr):
 					s.protocolErrorOnce.Do(func() {
 						logging.Base().Errorf("fetchAndWrite(%d): unrecoverable protocol error detected: %v", r, err)
@@ -489,23 +506,23 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 					s.log.Errorf("fetchAndWrite(%d): ledger write failed: %v", r, err)
 				}
 
-				return false
+				return fmt.Errorf("fetchAndWrite(%d): ledger write failed: %w", r, err)
 			}
 			s.log.Debugf("fetchAndWrite(%d): Wrote block to ledger", r)
-			return true
+			return nil
 		}
 	}
 }
 
 // TODO the following code does not handle the following case: seedLookback upgrades during fetch
-func (s *Service) pipelinedFetch(seedLookback uint64) {
+func (s *Service) pipelinedFetch(seedLookback uint64) error {
 	maxParallelRequests := max(s.parallelBlocks, seedLookback)
 	minParallelRequests := seedLookback
 
 	// Start the limited requests at max(1, 'seedLookback')
 	limitedParallelRequests := max(1, seedLookback)
 
-	completed := make(map[basics.Round]chan bool)
+	completed := make(map[basics.Round]chan error)
 	var wg sync.WaitGroup
 	defer func() {
 		wg.Wait()
@@ -517,7 +534,7 @@ func (s *Service) pipelinedFetch(seedLookback uint64) {
 	ps := createPeerSelector(s.net)
 	if _, err := ps.getNextPeer(); err != nil {
 		s.log.Debugf("pipelinedFetch: was unable to obtain a peer to retrieve the block from: %v", err)
-		return
+		return fmt.Errorf("%w: %v", errCatchupNoPeer, err)
 	}
 
 	// Create a new context for canceling the pipeline if some block
@@ -543,7 +560,7 @@ func (s *Service) pipelinedFetch(seedLookback uint64) {
 				break
 			}
 
-			done := make(chan bool, 1)
+			done := make(chan error, 1)
 			completed[nextRound] = done
 
 			wg.Add(1)
@@ -559,14 +576,14 @@ func (s *Service) pipelinedFetch(seedLookback uint64) {
 
 		// wait for the first round to complete before starting the next download.
 		select {
-		case completedOK := <-completed[firstRound]:
+		case fetchErr := <-completed[firstRound]:
 			delete(completed, firstRound)
 			firstRound++
 
-			if !completedOK {
-				// there was an error; defer will cancel the pipeline
-				s.log.Debugf("pipelinedFetch: quitting on fetchAndWrite error (firstRound=%d, nextRound=%d)", firstRound-1, nextRound)
-				return
+			if fetchErr != nil {
+				// this round stopped the pipeline; the deferred cancel will abort in-flight fetches
+				s.log.Debugf("pipelinedFetch: quitting on fetchAndWrite (firstRound=%d, nextRound=%d): %v", firstRound-1, nextRound, fetchErr)
+				return fmt.Errorf("stopped at round %d: %w", firstRound-1, fetchErr)
 			}
 
 			fetchTime := time.Now()
@@ -591,19 +608,19 @@ func (s *Service) pipelinedFetch(seedLookback uint64) {
 			if s.ledger.IsWritingCatchpointDataFile() {
 				s.log.Info("Catchup is stopping due to catchpoint file being written")
 				s.suspendForLedgerOps = true
-				return
+				return errCatchupWritingCatchpoint
 			}
 
 			// if the ledger has too many non-flushed account changes, stop catching up to reduce the memory pressure.
 			if s.ledger.IsBehindCommittingDeltas() {
 				s.log.Info("Catchup is stopping due to too many non-flushed account changes")
 				s.suspendForLedgerOps = true
-				return
+				return errCatchupBehindDeltas
 			}
 
 		case <-s.ctx.Done():
 			s.log.Debugf("pipelinedFetch: Aborted (firstRound=%d, nextRound=%d)", firstRound, nextRound)
-			return
+			return errCatchupStopping
 		}
 	}
 }
@@ -730,7 +747,7 @@ func (s *Service) sync() {
 	} else {
 		seedLookback = proto.SeedLookback
 	}
-	s.pipelinedFetch(seedLookback)
+	exitReason := s.pipelinedFetch(seedLookback)
 
 	initSync := false
 
@@ -753,7 +770,7 @@ func (s *Service) sync() {
 		Time:       elapsedTime,
 		InitSync:   initSync,
 	})
-	s.log.Infof("Catchup Service: finished catching up, now at round %v (previously %v). Total time catching up %v.", s.ledger.LastRound(), pr, elapsedTime)
+	s.log.Infof("Catchup Service: finished catching up, now at round %v (previously %v). Total time catching up %v (exit: %v).", s.ledger.LastRound(), pr, elapsedTime, exitReason)
 }
 
 // syncCert retrieving a single round identified by the provided certificate and adds it to the ledger.

--- a/catchup/service.go
+++ b/catchup/service.go
@@ -241,7 +241,7 @@ var (
 	errCatchupNoPeer            = errors.New("no peer available to fetch from")
 	errCatchupWritingCatchpoint = errors.New("stopping to write catchpoint file")
 	errCatchupBehindDeltas      = errors.New("stopping: ledger behind committing deltas")
-	errCatchupStopping          = errors.New("catchup service stopping or round unsupported")
+	errCatchupStopping          = errors.New("catchup service stopping")
 )
 
 // function scope to make a bunch of defer statements better
@@ -280,12 +280,13 @@ func (s *Service) innerFetch(ctx context.Context, r basics.Round, peer network.P
 const errNoBlockForRoundThreshold = 5
 
 // fetchAndWrite fetches a block, checks the cert, and writes it to the ledger. Cert checking and ledger writing both wait for the ledger to advance if necessary.
-// Returns false if we should stop trying to catch up.  This may occur for several reasons:
-//   - If the context is canceled (e.g. if the node is shutting down)
-//   - If we couldn't fetch the block (e.g. if there are no peers available, or we've reached the catchupRetryLimit)
-//   - If the block is already in the ledger (e.g. if agreement service has already written it)
-//   - If the retrieval of the previous block was unsuccessful
-//   - If block evaluation panicked and was recovered (an unrecoverable defect; see ledgercore.EvalPanicError)
+// It returns nil when catchup should continue: the block was written, or a historical block was already present and needed no re-evaluation.
+// It returns a non-nil exit reason when catchup should stop for this round. This may occur for several reasons:
+//   - The context was canceled (e.g. the node is shutting down): the context error.
+//   - The block could not be fetched, e.g. no peers are available or we reached catchupRetryLimit: errCatchupNoPeer, errFetchNoBlock, or errFetchRetryLimit.
+//   - The block is already in the ledger (e.g. agreement service wrote it first), so catchup is complete: errLedgerAlreadyHasBlock.
+//   - Block evaluation panicked and was recovered (an unrecoverable defect; see ledgercore.EvalPanicError).
+//   - The block failed validation, or the ledger write otherwise failed: a wrapped error describing the failure.
 func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCompleteChan chan struct{}, lookbackComplete chan struct{}, peerSelector peerSelector) error {
 	// If sync-ing this round is not intended, don't fetch it
 	if dontSyncRound := s.GetDisableSyncRound(); dontSyncRound != 0 && r >= basics.Round(dontSyncRound) {
@@ -328,7 +329,7 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 				}
 			}
 			if lastErr != nil {
-				return fmt.Errorf("%w: last error %v", errFetchRetryLimit, lastErr)
+				return fmt.Errorf("%w: last error %w", errFetchRetryLimit, lastErr)
 			}
 			return errFetchRetryLimit
 		}
@@ -336,7 +337,7 @@ func (s *Service) fetchAndWrite(ctx context.Context, r basics.Round, prevFetchCo
 		psp, getPeerErr := peerSelector.getNextPeer()
 		if getPeerErr != nil {
 			s.log.Debugf("fetchAndWrite(%d): was unable to obtain a peer to retrieve the block from: %v", r, getPeerErr)
-			return fmt.Errorf("fetchAndWrite(%d): no peer available: %w", r, getPeerErr)
+			return fmt.Errorf("fetchAndWrite(%d): %w: %w", r, errCatchupNoPeer, getPeerErr)
 		}
 		peer := psp.Peer
 		s.log.Debugf("fetchAndWrite(%d): got %s peer: %s", r, psp.peerClass, peerAddress(peer))
@@ -534,7 +535,7 @@ func (s *Service) pipelinedFetch(seedLookback uint64) error {
 	ps := createPeerSelector(s.net)
 	if _, err := ps.getNextPeer(); err != nil {
 		s.log.Debugf("pipelinedFetch: was unable to obtain a peer to retrieve the block from: %v", err)
-		return fmt.Errorf("%w: %v", errCatchupNoPeer, err)
+		return fmt.Errorf("%w: %w", errCatchupNoPeer, err)
 	}
 
 	// Create a new context for canceling the pipeline if some block
@@ -620,7 +621,9 @@ func (s *Service) pipelinedFetch(seedLookback uint64) error {
 
 		case <-s.ctx.Done():
 			s.log.Debugf("pipelinedFetch: Aborted (firstRound=%d, nextRound=%d)", firstRound, nextRound)
-			return errCatchupStopping
+			// Wrap ctx.Err() so the specific cause (cancellation vs deadline) is
+			// preserved alongside the errCatchupStopping category in the exit log.
+			return fmt.Errorf("%w: %w", errCatchupStopping, s.ctx.Err())
 		}
 	}
 }
@@ -770,6 +773,9 @@ func (s *Service) sync() {
 		Time:       elapsedTime,
 		InitSync:   initSync,
 	})
+	// exitReason is informational. The common, healthy terminus of a catchup span is the
+	// leading-edge fetch finding no block once we reach the tip (errFetchNoBlock /
+	// errFetchRetryLimit), so a fetch-stall reason here is expected and does not indicate a fault.
 	s.log.Infof("Catchup Service: finished catching up, now at round %v (previously %v). Total time catching up %v (exit: %v).", s.ledger.LastRound(), pr, elapsedTime, exitReason)
 }
 

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -732,6 +732,9 @@ type mockedLedger struct {
 	mu     deadlock.Mutex
 	blocks []bookkeeping.Block
 	chans  map[basics.Round]chan struct{}
+
+	writingCatchpoint bool
+	behindDeltas      bool
 }
 
 func (m *mockedLedger) NextRound() basics.Round {
@@ -849,19 +852,11 @@ func (m *mockedLedger) LookupAgreement(basics.Round, basics.Address) (basics.Onl
 }
 
 func (m *mockedLedger) IsWritingCatchpointDataFile() bool {
-	return false
+	return m.writingCatchpoint
 }
 
 func (m *mockedLedger) IsBehindCommittingDeltas() bool {
-	return false
-}
-
-type mockedBehindDeltasLedger struct {
-	mockedLedger
-}
-
-func (m *mockedBehindDeltasLedger) IsBehindCommittingDeltas() bool {
-	return true
+	return m.behindDeltas
 }
 
 func testingenvWithUpgrade(
@@ -1047,9 +1042,11 @@ func TestDownloadBlocksToSupportStateProofs(t *testing.T) {
 func TestServiceLedgerUnavailable(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	// Make Ledger
-	local := new(mockedBehindDeltasLedger)
+	// Make Ledger that is always behind committing deltas, so catchup cannot
+	// keep up with the remote.
+	local := new(mockedLedger)
 	local.blocks = append(local.blocks, bookkeeping.Block{})
+	local.behindDeltas = true
 
 	remote, _, blk, err := buildTestLedger(t, bookkeeping.Block{})
 	if err != nil {
@@ -1136,4 +1133,139 @@ func TestServiceNoBlockForRound(t *testing.T) {
 	// without the fix there are about 2k messages (4x catchupRetryLimit)
 	// with the fix expect less than catchupRetryLimit
 	require.Less(t, int(pl.debugMsgs.Load()), catchupRetryLimit)
+}
+
+// TestPipelinedFetchExitReason checks the exit-reason error returned by pipelinedFetch
+// (and fetchAndWrite), which sync() surfaces in the "finished catching up" log line,
+// so the cause of a catchup termination is visible at Info level.
+func TestPipelinedFetchExitReason(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	// newLocal returns a mockedLedger holding a single (genesis) block.
+	newLocal := func() *mockedLedger {
+		local := new(mockedLedger)
+		local.blocks = append(local.blocks, bookkeeping.Block{})
+		return local
+	}
+
+	// startService builds a started catchup.Service backed by the given local
+	// ledger, fetching from a remote ledger of numBlocks blocks served over HTTP by
+	// nodeA. Every subtest shares this wiring even when it never fetches a block; a
+	// subtest calls net.addPeer(peerURL) when it wants fetches to find the remote,
+	// and noPeer leaves net empty to exercise the no-peer path.
+	const numBlocks = 10
+	startService := func(t *testing.T, local Ledger) (s *Service, remote *data.Ledger, net *httpTestPeerSource, peerURL string) {
+		remote, _, blk, err := buildTestLedger(t, bookkeeping.Block{})
+		require.NoError(t, err)
+		addBlocks(t, remote, blk, numBlocks)
+
+		net = &httpTestPeerSource{}
+		ls := rpcs.MakeBlockService(logging.Base(), config.GetDefaultLocal(), remote, net, "test genesisID")
+		nodeA := &basicRPCNode{}
+		ls.RegisterHandlers(nodeA)
+		nodeA.start()
+		t.Cleanup(nodeA.stop)
+
+		s = MakeService(logging.Base(), defaultConfig, net, local, &mockedAuthenticator{errorRound: -1}, nil, nil)
+		s.testStart()
+		return s, remote, net, nodeA.rootURL()
+	}
+
+	// noPeer: with no peers available, pipelinedFetch returns errCatchupNoPeer
+	// before touching the ledger.
+	t.Run("noPeer", func(t *testing.T) {
+		s, _, _, _ := startService(t, newLocal()) // peer not added
+
+		err := s.pipelinedFetch(2)
+		require.ErrorIs(t, err, errCatchupNoPeer)
+	})
+
+	// stalled: once the local ledger has caught up to the remote tip, the
+	// leading-edge fetch can no longer find a block, and pipelinedFetch returns a
+	// reason that wraps the fetch-stall cause (no block from peers, or the retry
+	// limit).
+	t.Run("stalled", func(t *testing.T) {
+		local := newLocal()
+		s, remote, net, peerURL := startService(t, local)
+		net.addPeer(peerURL)
+
+		// One pipelinedFetch invocation catches local up to the remote tip and then
+		// stalls trying to fetch the next (nonexistent) round.
+		err := s.pipelinedFetch(2)
+		require.Equal(t, remote.LastRound(), local.LastRound(), "should have caught up to the remote tip")
+		require.True(t,
+			errors.Is(err, errFetchNoBlock) || errors.Is(err, errFetchRetryLimit),
+			"expected a fetch-stall exit reason, got: %v", err)
+	})
+
+	// contextCanceled: a cancelled service context terminates the pipeline with a
+	// context-related reason (either errCatchupStopping from the ctx.Done select
+	// branch, or a wrapped context.Canceled from the in-flight fetch that observed
+	// the cancellation first -- both are valid, the select races).
+	t.Run("contextCanceled", func(t *testing.T) {
+		s, _, net, peerURL := startService(t, newLocal())
+		net.addPeer(peerURL) // a real peer, but never contacted: the cancelled ctx returns from fetchAndWrite's first select
+
+		s.cancel() // cancel the service context before fetching
+
+		err := s.pipelinedFetch(2)
+		require.Error(t, err)
+		require.True(t,
+			errors.Is(err, errCatchupStopping) || errors.Is(err, context.Canceled),
+			"expected a context-cancellation exit reason, got: %v", err)
+	})
+
+	// behindDeltas: after a successful fetch, pipelinedFetch checks the ledger's
+	// commit backpressure; a ledger that is behind committing deltas stops catchup
+	// with errCatchupBehindDeltas. roundTimeEstimate is shrunk so the busy-wait that
+	// precedes the check returns immediately instead of pausing for real.
+	t.Run("behindDeltas", func(t *testing.T) {
+		local := newLocal()
+		local.behindDeltas = true
+		s, _, net, peerURL := startService(t, local)
+		net.addPeer(peerURL)
+		s.roundTimeEstimate = time.Nanosecond
+
+		err := s.pipelinedFetch(2)
+		require.ErrorIs(t, err, errCatchupBehindDeltas)
+		require.NotZero(t, local.LastRound(), "should have written a block before stopping on backpressure")
+	})
+
+	// writingCatchpoint: same post-fetch backpressure check, but for a ledger that
+	// is writing a catchpoint file, which stops catchup with errCatchupWritingCatchpoint.
+	t.Run("writingCatchpoint", func(t *testing.T) {
+		local := newLocal()
+		local.writingCatchpoint = true
+		s, _, net, peerURL := startService(t, local)
+		net.addPeer(peerURL)
+		s.roundTimeEstimate = time.Nanosecond
+
+		err := s.pipelinedFetch(2)
+		require.ErrorIs(t, err, errCatchupWritingCatchpoint)
+		require.NotZero(t, local.LastRound(), "should have written a block before stopping on backpressure")
+	})
+
+	// syncDisabled: when a disable-sync round is set, fetchAndWrite refuses to fetch
+	// rounds at or beyond it, returning an error naming the cutoff rather than fetching.
+	t.Run("syncDisabled", func(t *testing.T) {
+		s, _, _, _ := startService(t, newLocal())
+		require.NoError(t, s.SetDisableSyncRound(1))
+
+		// no peer needed: the disable-sync check is the first thing fetchAndWrite does.
+		err := s.fetchAndWrite(s.ctx, basics.Round(1), nil, nil, nil)
+		require.ErrorContains(t, err, "syncing disabled")
+	})
+
+	// fetchAndWriteContextCanceled: fetchAndWrite returns the context error (not
+	// nil) when its context is already cancelled, so the cancellation propagates up
+	// as a real reason rather than a silent stop.
+	t.Run("fetchAndWriteContextCanceled", func(t *testing.T) {
+		s, _, _, _ := startService(t, newLocal())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		// peerSelector/channels are not reached: the first select returns on ctx.Done.
+		err := s.fetchAndWrite(ctx, basics.Round(1), nil, nil, nil)
+		require.ErrorIs(t, err, context.Canceled)
+	})
 }

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -852,10 +852,14 @@ func (m *mockedLedger) LookupAgreement(basics.Round, basics.Address) (basics.Onl
 }
 
 func (m *mockedLedger) IsWritingCatchpointDataFile() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.writingCatchpoint
 }
 
 func (m *mockedLedger) IsBehindCommittingDeltas() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.behindDeltas
 }
 


### PR DESCRIPTION
## Summary

When catchup stops unexpectedly (with the message "Catchup Service: finished catching up, now at round X (previously Y)") it can be impossible to know why, because many of the reasons causing the catchup service to give up are logged at debug level (connection errors, etc). This logs the error causing catchup to fail in the "finished catching up" line by returning errors from `fetchAndWrite`/`pipelinedFetch`.

## Test Plan

New test added to assert reasons are covered.