### PR TITLE
tests: fix flaky TestPeeringWithIdentityChallenge

### DIFF
--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -1537,13 +1537,18 @@ func TestPeeringWithIdentityChallenge(t *testing.T) {
 		return len(netA.GetPeers(PeersConnectedOut)) == 2
 	}, time.Second, 50*time.Millisecond)
 
+	// let netC's addPeer to add the inbound connection
+	assert.Eventually(t, func() bool {
+		return len(netC.GetPeers(PeersConnectedIn)) == 1
+	}, time.Second, 50*time.Millisecond)
+
 	// A->B and A->C both open
 	assert.Equal(t, 0, len(netA.GetPeers(PeersConnectedIn)))
 	assert.Equal(t, 2, len(netA.GetPeers(PeersConnectedOut)))
 	assert.Equal(t, 1, len(netB.GetPeers(PeersConnectedIn)))
 	assert.Equal(t, 0, len(netB.GetPeers(PeersConnectedOut)))
 	assert.Equal(t, 1, len(netC.GetPeers(PeersConnectedIn)))
-	assert.Equal(t, 0, len(netB.GetPeers(PeersConnectedOut)))
+	assert.Equal(t, 0, len(netC.GetPeers(PeersConnectedOut)))
 
 	// confirm identity map was added to for both hosts
 	assert.Equal(t, 3, netA.identityTracker.(*mockIdentityTracker).getSetCount())


### PR DESCRIPTION
## Summary

Fix flaky test as seen [here](https://github.com/algorand/go-algorand/actions/runs/27627578512/job/81693374049?pr=6648#step:5:7499) that appears to be a race between netA and netC connection counting so added `assert.Eventually` similarly to what the test does for netA.

## Test Plan

`TestPeeringWithIdentityChallenge` not reproducible locally even with cpu hammering in background so it is a best guess.