### PR TITLE
tools: Remove more uses of reflection-based msgp encoding

### DIFF
--- a/agreement/actions.go
+++ b/agreement/actions.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/algorand/msgp/msgp"
+
 	"github.com/algorand/go-algorand/logging/logspec"
 	"github.com/algorand/go-algorand/logging/telemetryspec"
 	"github.com/algorand/go-algorand/protocol"
-	"github.com/algorand/msgp/msgp"
 )
 
 //go:generate go tool -modfile=../tool.mod stringer -type=actionType

--- a/agreement/actions.go
+++ b/agreement/actions.go
@@ -24,6 +24,7 @@ import (
 	"github.com/algorand/go-algorand/logging/logspec"
 	"github.com/algorand/go-algorand/logging/telemetryspec"
 	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/msgp/msgp"
 )
 
 //go:generate go tool -modfile=../tool.mod stringer -type=actionType
@@ -76,6 +77,7 @@ func (nonpersistent) persistent() bool {
 }
 
 type noopAction struct {
+	_struct struct{} `codec:","`
 	nonpersistent
 }
 
@@ -92,6 +94,7 @@ func (a noopAction) String() string {
 func (a noopAction) ComparableStr() string { return a.String() }
 
 type networkAction struct {
+	_struct struct{} `codec:","`
 	nonpersistent
 
 	// ignore, broadcast, broadcastVotes, relay, disconnect
@@ -104,7 +107,11 @@ type networkAction struct {
 	UnauthenticatedBundle unauthenticatedBundle
 	CompoundMessage       compoundMessage
 
-	UnauthenticatedVotes []unauthenticatedVote
+	// UnauthenticatedVotes is a concatenation of per-step vote dumps, so no
+	// single consensus bound applies; these bytes come only from the local
+	// crash database, so decoding is unbounded like the reflection codec it
+	// replaced.
+	UnauthenticatedVotes []unauthenticatedVote `codec:",allocbound=-"`
 
 	Err *serializableError
 }
@@ -180,6 +187,7 @@ func (a networkAction) do(ctx context.Context, s *Service) {
 }
 
 type cryptoAction struct {
+	_struct struct{} `codec:","`
 	nonpersistent
 
 	// verify{Vote,Payload,Bundle}
@@ -226,6 +234,7 @@ func (a cryptoAction) do(ctx context.Context, s *Service) {
 }
 
 type ensureAction struct {
+	_struct struct{} `codec:","`
 	nonpersistent
 
 	// the payload that we will give to the ledger
@@ -298,6 +307,7 @@ func (a ensureAction) do(ctx context.Context, s *Service) {
 }
 
 type stageDigestAction struct {
+	_struct struct{} `codec:","`
 	nonpersistent
 	// Certificate identifies a block and is a proof commitment
 	Certificate Certificate // a block digest is probably sufficient; keep certificate for now to match ledger interface
@@ -326,6 +336,7 @@ func (a stageDigestAction) do(ctx context.Context, service *Service) {
 }
 
 type rezeroAction struct {
+	_struct struct{} `codec:","`
 	nonpersistent
 
 	Round round
@@ -361,6 +372,8 @@ func (a rezeroAction) do(ctx context.Context, s *Service) {
 }
 
 type pseudonodeAction struct {
+	_struct struct{} `codec:","`
+
 	// assemble, repropose, attest
 	T actionType
 
@@ -510,6 +523,8 @@ func zeroAction(t actionType) action {
 		return cryptoAction{}
 	case ensure:
 		return ensureAction{}
+	case stageDigest:
+		return stageDigestAction{}
 	case rezero:
 		return rezeroAction{}
 	case attest, assemble, repropose:
@@ -522,7 +537,78 @@ func zeroAction(t actionType) action {
 	}
 }
 
+// encodeAction serializes an action using its generated msgp marshaler. The
+// type switch is unavoidable: action is an interface, so the concrete type
+// must be recovered before its pointer methods are available. Keep the cases
+// in sync with decodeAction.
+func encodeAction(a action) []byte {
+	switch v := a.(type) {
+	case noopAction:
+		return protocol.Encode(&v)
+	case networkAction:
+		return protocol.Encode(&v)
+	case cryptoAction:
+		return protocol.Encode(&v)
+	case ensureAction:
+		return protocol.Encode(&v)
+	case stageDigestAction:
+		return protocol.Encode(&v)
+	case rezeroAction:
+		return protocol.Encode(&v)
+	case pseudonodeAction:
+		return protocol.Encode(&v)
+	case checkpointAction:
+		return protocol.Encode(&v)
+	default:
+		// matches the panic in protocol.Encode for a non-marshalable object
+		panic(fmt.Errorf("encodeAction: unsupported action type %T", a))
+	}
+}
+
+// unmarshalAction decodes data into a fresh value of concrete action type T.
+// The PT constraint binds T to its pointer type, which is where the generated
+// msgp unmarshaler lives, so listing a type here only compiles if the type is
+// covered by msgp code generation.
+func unmarshalAction[T action, PT interface {
+	*T
+	msgp.Unmarshaler
+}](data []byte) (action, error) {
+	var a T
+	if err := protocol.Decode(data, PT(&a)); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// decodeAction reconstructs the concrete action identified by t from its
+// msgp encoding. It returns an error rather than panicking on an unknown
+// actionType because t is read from the crash recovery database.
+func decodeAction(t actionType, data []byte) (action, error) {
+	switch t {
+	case noop:
+		return unmarshalAction[noopAction](data)
+	case ignore, broadcast, relay, disconnect, broadcastVotes:
+		return unmarshalAction[networkAction](data)
+	case verifyVote, verifyPayload, verifyBundle:
+		return unmarshalAction[cryptoAction](data)
+	case ensure:
+		return unmarshalAction[ensureAction](data)
+	case stageDigest:
+		return unmarshalAction[stageDigestAction](data)
+	case rezero:
+		return unmarshalAction[rezeroAction](data)
+	case attest, assemble, repropose:
+		return unmarshalAction[pseudonodeAction](data)
+	case checkpoint:
+		return unmarshalAction[checkpointAction](data)
+	default:
+		return nil, fmt.Errorf("decodeAction: bad action type: %v", t)
+	}
+}
+
 type checkpointAction struct {
+	_struct struct{} `codec:","`
+
 	Round  round
 	Period period
 	Step   step

--- a/agreement/actions.go
+++ b/agreement/actions.go
@@ -108,10 +108,6 @@ type networkAction struct {
 	UnauthenticatedBundle unauthenticatedBundle
 	CompoundMessage       compoundMessage
 
-	// UnauthenticatedVotes is a concatenation of per-step vote dumps, so no
-	// single consensus bound applies; these bytes come only from the local
-	// crash database, so decoding is unbounded like the reflection codec it
-	// replaced.
 	UnauthenticatedVotes []unauthenticatedVote `codec:",allocbound=-"`
 
 	Err *serializableError
@@ -538,10 +534,7 @@ func zeroAction(t actionType) action {
 	}
 }
 
-// encodeAction serializes an action using its generated msgp marshaler. The
-// type switch is unavoidable: action is an interface, so the concrete type
-// must be recovered before its pointer methods are available. Keep the cases
-// in sync with decodeAction.
+// encodeAction serializes an action using its generated msgp marshaler.
 func encodeAction(a action) []byte {
 	switch v := a.(type) {
 	case noopAction:
@@ -567,9 +560,6 @@ func encodeAction(a action) []byte {
 }
 
 // unmarshalAction decodes data into a fresh value of concrete action type T.
-// The PT constraint binds T to its pointer type, which is where the generated
-// msgp unmarshaler lives, so listing a type here only compiles if the type is
-// covered by msgp code generation.
 func unmarshalAction[T action, PT interface {
 	*T
 	msgp.Unmarshaler

--- a/agreement/msgp_gen.go
+++ b/agreement/msgp_gen.go
@@ -96,6 +96,16 @@ import (
 //    |-----> (*) MsgIsZero
 //    |-----> BundleMaxSize()
 //
+// checkpointAction
+//         |-----> (*) MarshalMsg
+//         |-----> (*) CanMarshalMsg
+//         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalMsgWithState
+//         |-----> (*) CanUnmarshalMsg
+//         |-----> (*) Msgsize
+//         |-----> (*) MsgIsZero
+//         |-----> CheckpointActionMaxSize()
+//
 // compoundMessage
 //        |-----> (*) MarshalMsg
 //        |-----> (*) CanMarshalMsg
@@ -106,6 +116,16 @@ import (
 //        |-----> (*) MsgIsZero
 //        |-----> CompoundMessageMaxSize()
 //
+// cryptoAction
+//       |-----> (*) MarshalMsg
+//       |-----> (*) CanMarshalMsg
+//       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalMsgWithState
+//       |-----> (*) CanUnmarshalMsg
+//       |-----> (*) Msgsize
+//       |-----> (*) MsgIsZero
+//       |-----> CryptoActionMaxSize()
+//
 // diskState
 //     |-----> (*) MarshalMsg
 //     |-----> (*) CanMarshalMsg
@@ -115,6 +135,16 @@ import (
 //     |-----> (*) Msgsize
 //     |-----> (*) MsgIsZero
 //     |-----> DiskStateMaxSize()
+//
+// ensureAction
+//       |-----> (*) MarshalMsg
+//       |-----> (*) CanMarshalMsg
+//       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalMsgWithState
+//       |-----> (*) CanUnmarshalMsg
+//       |-----> (*) Msgsize
+//       |-----> (*) MsgIsZero
+//       |-----> EnsureActionMaxSize()
 //
 // equivocationVote
 //         |-----> (*) MarshalMsg
@@ -176,6 +206,16 @@ import (
 //       |-----> (*) MsgIsZero
 //       |-----> MessageEventMaxSize()
 //
+// networkAction
+//       |-----> (*) MarshalMsg
+//       |-----> (*) CanMarshalMsg
+//       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalMsgWithState
+//       |-----> (*) CanUnmarshalMsg
+//       |-----> (*) Msgsize
+//       |-----> (*) MsgIsZero
+//       |-----> NetworkActionMaxSize()
+//
 // nextThresholdStatusEvent
 //             |-----> (*) MarshalMsg
 //             |-----> (*) CanMarshalMsg
@@ -185,6 +225,16 @@ import (
 //             |-----> (*) Msgsize
 //             |-----> (*) MsgIsZero
 //             |-----> NextThresholdStatusEventMaxSize()
+//
+// noopAction
+//      |-----> (*) MarshalMsg
+//      |-----> (*) CanMarshalMsg
+//      |-----> (*) UnmarshalMsg
+//      |-----> (*) UnmarshalMsgWithState
+//      |-----> (*) CanUnmarshalMsg
+//      |-----> (*) Msgsize
+//      |-----> (*) MsgIsZero
+//      |-----> NoopActionMaxSize()
 //
 // period
 //    |-----> MarshalMsg
@@ -316,6 +366,16 @@ import (
 //       |-----> (*) MsgIsZero
 //       |-----> ProposerSeedMaxSize()
 //
+// pseudonodeAction
+//         |-----> (*) MarshalMsg
+//         |-----> (*) CanMarshalMsg
+//         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalMsgWithState
+//         |-----> (*) CanUnmarshalMsg
+//         |-----> (*) Msgsize
+//         |-----> (*) MsgIsZero
+//         |-----> PseudonodeActionMaxSize()
+//
 // rawVote
 //    |-----> (*) MarshalMsg
 //    |-----> (*) CanMarshalMsg
@@ -325,6 +385,16 @@ import (
 //    |-----> (*) Msgsize
 //    |-----> (*) MsgIsZero
 //    |-----> RawVoteMaxSize()
+//
+// rezeroAction
+//       |-----> (*) MarshalMsg
+//       |-----> (*) CanMarshalMsg
+//       |-----> (*) UnmarshalMsg
+//       |-----> (*) UnmarshalMsgWithState
+//       |-----> (*) CanUnmarshalMsg
+//       |-----> (*) Msgsize
+//       |-----> (*) MsgIsZero
+//       |-----> RezeroActionMaxSize()
 //
 // rootRouter
 //      |-----> (*) MarshalMsg
@@ -375,6 +445,16 @@ import (
 //         |-----> Msgsize
 //         |-----> MsgIsZero
 //         |-----> SerializableErrorMaxSize()
+//
+// stageDigestAction
+//         |-----> (*) MarshalMsg
+//         |-----> (*) CanMarshalMsg
+//         |-----> (*) UnmarshalMsg
+//         |-----> (*) UnmarshalMsgWithState
+//         |-----> (*) CanUnmarshalMsg
+//         |-----> (*) Msgsize
+//         |-----> (*) MsgIsZero
+//         |-----> StageDigestActionMaxSize()
 //
 // step
 //   |-----> MarshalMsg
@@ -1862,6 +1942,220 @@ func BundleMaxSize() (s int) {
 }
 
 // MarshalMsg implements msgp.Marshaler
+func (z *checkpointAction) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 4
+	// string "Err"
+	o = append(o, 0x84, 0xa3, 0x45, 0x72, 0x72)
+	if (*z).Err == nil {
+		o = msgp.AppendNil(o)
+	} else {
+		o = msgp.AppendString(o, string(*(*z).Err))
+	}
+	// string "Period"
+	o = append(o, 0xa6, 0x50, 0x65, 0x72, 0x69, 0x6f, 0x64)
+	o = msgp.AppendUint64(o, uint64((*z).Period))
+	// string "Round"
+	o = append(o, 0xa5, 0x52, 0x6f, 0x75, 0x6e, 0x64)
+	o = (*z).Round.MarshalMsg(o)
+	// string "Step"
+	o = append(o, 0xa4, 0x53, 0x74, 0x65, 0x70)
+	o = msgp.AppendUint64(o, uint64((*z).Step))
+	return
+}
+
+func (_ *checkpointAction) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(*checkpointAction)
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *checkpointAction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []byte, err error) {
+	if st.AllowableDepth == 0 {
+		err = msgp.ErrMaxDepthExceeded{}
+		return
+	}
+	st.AllowableDepth--
+	var field []byte
+	_ = field
+	var zb0001 int
+	var zb0002 bool
+	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if _, ok := err.(msgp.TypeError); ok {
+		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Round.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Round")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			{
+				var zb0003 uint64
+				zb0003, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "struct-from-array", "Period")
+					return
+				}
+				(*z).Period = period(zb0003)
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			{
+				var zb0004 uint64
+				zb0004, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "struct-from-array", "Step")
+					return
+				}
+				(*z).Step = step(zb0004)
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				(*z).Err = nil
+			} else {
+				if (*z).Err == nil {
+					(*z).Err = new(serializableError)
+				}
+				{
+					var zb0005 string
+					zb0005, bts, err = msgp.ReadStringBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "struct-from-array", "Err")
+						return
+					}
+					*(*z).Err = serializableError(zb0005)
+				}
+			}
+		}
+		if zb0001 > 0 {
+			err = msgp.ErrTooManyArrayFields(zb0001)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array")
+				return
+			}
+		}
+	} else {
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0002 {
+			(*z) = checkpointAction{}
+		}
+		for zb0001 > 0 {
+			zb0001--
+			field, bts, err = msgp.ReadMapKeyZC(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+			switch string(field) {
+			case "Round":
+				bts, err = (*z).Round.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Round")
+					return
+				}
+			case "Period":
+				{
+					var zb0006 uint64
+					zb0006, bts, err = msgp.ReadUint64Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Period")
+						return
+					}
+					(*z).Period = period(zb0006)
+				}
+			case "Step":
+				{
+					var zb0007 uint64
+					zb0007, bts, err = msgp.ReadUint64Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Step")
+						return
+					}
+					(*z).Step = step(zb0007)
+				}
+			case "Err":
+				if msgp.IsNil(bts) {
+					bts, err = msgp.ReadNilBytes(bts)
+					if err != nil {
+						return
+					}
+					(*z).Err = nil
+				} else {
+					if (*z).Err == nil {
+						(*z).Err = new(serializableError)
+					}
+					{
+						var zb0008 string
+						zb0008, bts, err = msgp.ReadStringBytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "Err")
+							return
+						}
+						*(*z).Err = serializableError(zb0008)
+					}
+				}
+			default:
+				err = msgp.ErrNoField(string(field))
+				if err != nil {
+					err = msgp.WrapError(err)
+					return
+				}
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *checkpointAction) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.UnmarshalMsgWithState(bts, msgp.DefaultUnmarshalState)
+}
+func (_ *checkpointAction) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*checkpointAction)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *checkpointAction) Msgsize() (s int) {
+	s = 1 + 6 + (*z).Round.Msgsize() + 7 + msgp.Uint64Size + 5 + msgp.Uint64Size + 4
+	if (*z).Err == nil {
+		s += msgp.NilSize
+	} else {
+		s += msgp.StringPrefixSize + len(string(*(*z).Err))
+	}
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z *checkpointAction) MsgIsZero() bool {
+	return ((*z).Round.MsgIsZero()) && ((*z).Period == 0) && ((*z).Step == 0) && ((*z).Err == nil)
+}
+
+// CheckpointActionMaxSize returns a maximum valid message size for this message type
+func CheckpointActionMaxSize() (s int) {
+	s = 1 + 6 + basics.RoundMaxSize() + 7 + msgp.Uint64Size + 5 + msgp.Uint64Size + 4
+	panic("Unable to determine max size: String type string(*z.Err) is unbounded")
+}
+
+// MarshalMsg implements msgp.Marshaler
 func (z *compoundMessage) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 2
@@ -1983,6 +2277,257 @@ func (z *compoundMessage) MsgIsZero() bool {
 // CompoundMessageMaxSize returns a maximum valid message size for this message type
 func CompoundMessageMaxSize() (s int) {
 	s = 1 + 5 + UnauthenticatedVoteMaxSize() + 9 + UnauthenticatedProposalMaxSize()
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *cryptoAction) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 8
+	// string "M"
+	o = append(o, 0x88, 0xa1, 0x4d)
+	o = (*z).M.MarshalMsg(o)
+	// string "Period"
+	o = append(o, 0xa6, 0x50, 0x65, 0x72, 0x69, 0x6f, 0x64)
+	o = msgp.AppendUint64(o, uint64((*z).Period))
+	// string "Pinned"
+	o = append(o, 0xa6, 0x50, 0x69, 0x6e, 0x6e, 0x65, 0x64)
+	o = msgp.AppendBool(o, (*z).Pinned)
+	// string "Proposal"
+	o = append(o, 0xa8, 0x50, 0x72, 0x6f, 0x70, 0x6f, 0x73, 0x61, 0x6c)
+	o = (*z).Proposal.MarshalMsg(o)
+	// string "Round"
+	o = append(o, 0xa5, 0x52, 0x6f, 0x75, 0x6e, 0x64)
+	o = (*z).Round.MarshalMsg(o)
+	// string "Step"
+	o = append(o, 0xa4, 0x53, 0x74, 0x65, 0x70)
+	o = msgp.AppendUint64(o, uint64((*z).Step))
+	// string "T"
+	o = append(o, 0xa1, 0x54)
+	o = msgp.AppendUint8(o, uint8((*z).T))
+	// string "TaskIndex"
+	o = append(o, 0xa9, 0x54, 0x61, 0x73, 0x6b, 0x49, 0x6e, 0x64, 0x65, 0x78)
+	o = msgp.AppendUint64(o, (*z).TaskIndex)
+	return
+}
+
+func (_ *cryptoAction) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(*cryptoAction)
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *cryptoAction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []byte, err error) {
+	if st.AllowableDepth == 0 {
+		err = msgp.ErrMaxDepthExceeded{}
+		return
+	}
+	st.AllowableDepth--
+	var field []byte
+	_ = field
+	var zb0001 int
+	var zb0002 bool
+	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if _, ok := err.(msgp.TypeError); ok {
+		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0001 > 0 {
+			zb0001--
+			{
+				var zb0003 uint8
+				zb0003, bts, err = msgp.ReadUint8Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "struct-from-array", "T")
+					return
+				}
+				(*z).T = actionType(zb0003)
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).M.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "M")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Proposal.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Proposal")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Round.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Round")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			{
+				var zb0004 uint64
+				zb0004, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "struct-from-array", "Period")
+					return
+				}
+				(*z).Period = period(zb0004)
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			{
+				var zb0005 uint64
+				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "struct-from-array", "Step")
+					return
+				}
+				(*z).Step = step(zb0005)
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).Pinned, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Pinned")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			(*z).TaskIndex, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "TaskIndex")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			err = msgp.ErrTooManyArrayFields(zb0001)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array")
+				return
+			}
+		}
+	} else {
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0002 {
+			(*z) = cryptoAction{}
+		}
+		for zb0001 > 0 {
+			zb0001--
+			field, bts, err = msgp.ReadMapKeyZC(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+			switch string(field) {
+			case "T":
+				{
+					var zb0006 uint8
+					zb0006, bts, err = msgp.ReadUint8Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "T")
+						return
+					}
+					(*z).T = actionType(zb0006)
+				}
+			case "M":
+				bts, err = (*z).M.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "M")
+					return
+				}
+			case "Proposal":
+				bts, err = (*z).Proposal.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Proposal")
+					return
+				}
+			case "Round":
+				bts, err = (*z).Round.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Round")
+					return
+				}
+			case "Period":
+				{
+					var zb0007 uint64
+					zb0007, bts, err = msgp.ReadUint64Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Period")
+						return
+					}
+					(*z).Period = period(zb0007)
+				}
+			case "Step":
+				{
+					var zb0008 uint64
+					zb0008, bts, err = msgp.ReadUint64Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Step")
+						return
+					}
+					(*z).Step = step(zb0008)
+				}
+			case "Pinned":
+				(*z).Pinned, bts, err = msgp.ReadBoolBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Pinned")
+					return
+				}
+			case "TaskIndex":
+				(*z).TaskIndex, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "TaskIndex")
+					return
+				}
+			default:
+				err = msgp.ErrNoField(string(field))
+				if err != nil {
+					err = msgp.WrapError(err)
+					return
+				}
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *cryptoAction) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.UnmarshalMsgWithState(bts, msgp.DefaultUnmarshalState)
+}
+func (_ *cryptoAction) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*cryptoAction)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *cryptoAction) Msgsize() (s int) {
+	s = 1 + 2 + msgp.Uint8Size + 2 + (*z).M.Msgsize() + 9 + (*z).Proposal.Msgsize() + 6 + (*z).Round.Msgsize() + 7 + msgp.Uint64Size + 5 + msgp.Uint64Size + 7 + msgp.BoolSize + 10 + msgp.Uint64Size
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z *cryptoAction) MsgIsZero() bool {
+	return ((*z).T == 0) && ((*z).M.MsgIsZero()) && ((*z).Proposal.MsgIsZero()) && ((*z).Round.MsgIsZero()) && ((*z).Period == 0) && ((*z).Step == 0) && ((*z).Pinned == false) && ((*z).TaskIndex == 0)
+}
+
+// CryptoActionMaxSize returns a maximum valid message size for this message type
+func CryptoActionMaxSize() (s int) {
+	s = 1 + 2 + msgp.Uint8Size + 2 + MessageMaxSize() + 9 + ProposalValueMaxSize() + 6 + basics.RoundMaxSize() + 7 + msgp.Uint64Size + 5 + msgp.Uint64Size + 7 + msgp.BoolSize + 10 + msgp.Uint64Size
 	return
 }
 
@@ -2249,6 +2794,131 @@ func (z *diskState) MsgIsZero() bool {
 func DiskStateMaxSize() (s int) {
 	s = 1 + 7
 	panic("Unable to determine max size: Byteslice type z.Router is unbounded")
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *ensureAction) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "Certificate"
+	o = append(o, 0x82, 0xab, 0x43, 0x65, 0x72, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x65)
+	o = (*z).Certificate.MarshalMsg(o)
+	// string "Payload"
+	o = append(o, 0xa7, 0x50, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64)
+	o = (*z).Payload.MarshalMsg(o)
+	return
+}
+
+func (_ *ensureAction) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(*ensureAction)
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *ensureAction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []byte, err error) {
+	if st.AllowableDepth == 0 {
+		err = msgp.ErrMaxDepthExceeded{}
+		return
+	}
+	st.AllowableDepth--
+	var field []byte
+	_ = field
+	var zb0001 int
+	var zb0002 bool
+	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if _, ok := err.(msgp.TypeError); ok {
+		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Payload.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Payload")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Certificate.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Certificate")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			err = msgp.ErrTooManyArrayFields(zb0001)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array")
+				return
+			}
+		}
+	} else {
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0002 {
+			(*z) = ensureAction{}
+		}
+		for zb0001 > 0 {
+			zb0001--
+			field, bts, err = msgp.ReadMapKeyZC(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+			switch string(field) {
+			case "Payload":
+				bts, err = (*z).Payload.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Payload")
+					return
+				}
+			case "Certificate":
+				bts, err = (*z).Certificate.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Certificate")
+					return
+				}
+			default:
+				err = msgp.ErrNoField(string(field))
+				if err != nil {
+					err = msgp.WrapError(err)
+					return
+				}
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *ensureAction) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.UnmarshalMsgWithState(bts, msgp.DefaultUnmarshalState)
+}
+func (_ *ensureAction) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*ensureAction)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *ensureAction) Msgsize() (s int) {
+	s = 1 + 8 + (*z).Payload.Msgsize() + 12 + (*z).Certificate.Msgsize()
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z *ensureAction) MsgIsZero() bool {
+	return ((*z).Payload.MsgIsZero()) && ((*z).Certificate.MsgIsZero())
+}
+
+// EnsureActionMaxSize returns a maximum valid message size for this message type
+func EnsureActionMaxSize() (s int) {
+	s = 1 + 8 + ProposalMaxSize() + 12 + CertificateMaxSize()
+	return
 }
 
 // MarshalMsg implements msgp.Marshaler
@@ -3716,6 +4386,441 @@ func MessageEventMaxSize() (s int) {
 }
 
 // MarshalMsg implements msgp.Marshaler
+func (z *networkAction) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 7
+	// string "CompoundMessage"
+	o = append(o, 0x87, 0xaf, 0x43, 0x6f, 0x6d, 0x70, 0x6f, 0x75, 0x6e, 0x64, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65)
+	// map header, size 2
+	// string "Proposal"
+	o = append(o, 0x82, 0xa8, 0x50, 0x72, 0x6f, 0x70, 0x6f, 0x73, 0x61, 0x6c)
+	o = (*z).CompoundMessage.Proposal.MarshalMsg(o)
+	// string "Vote"
+	o = append(o, 0xa4, 0x56, 0x6f, 0x74, 0x65)
+	o = (*z).CompoundMessage.Vote.MarshalMsg(o)
+	// string "Err"
+	o = append(o, 0xa3, 0x45, 0x72, 0x72)
+	if (*z).Err == nil {
+		o = msgp.AppendNil(o)
+	} else {
+		o = msgp.AppendString(o, string(*(*z).Err))
+	}
+	// string "T"
+	o = append(o, 0xa1, 0x54)
+	o = msgp.AppendUint8(o, uint8((*z).T))
+	// string "Tag"
+	o = append(o, 0xa3, 0x54, 0x61, 0x67)
+	o = (*z).Tag.MarshalMsg(o)
+	// string "UnauthenticatedBundle"
+	o = append(o, 0xb5, 0x55, 0x6e, 0x61, 0x75, 0x74, 0x68, 0x65, 0x6e, 0x74, 0x69, 0x63, 0x61, 0x74, 0x65, 0x64, 0x42, 0x75, 0x6e, 0x64, 0x6c, 0x65)
+	o = (*z).UnauthenticatedBundle.MarshalMsg(o)
+	// string "UnauthenticatedVote"
+	o = append(o, 0xb3, 0x55, 0x6e, 0x61, 0x75, 0x74, 0x68, 0x65, 0x6e, 0x74, 0x69, 0x63, 0x61, 0x74, 0x65, 0x64, 0x56, 0x6f, 0x74, 0x65)
+	o = (*z).UnauthenticatedVote.MarshalMsg(o)
+	// string "UnauthenticatedVotes"
+	o = append(o, 0xb4, 0x55, 0x6e, 0x61, 0x75, 0x74, 0x68, 0x65, 0x6e, 0x74, 0x69, 0x63, 0x61, 0x74, 0x65, 0x64, 0x56, 0x6f, 0x74, 0x65, 0x73)
+	if (*z).UnauthenticatedVotes == nil {
+		o = msgp.AppendNil(o)
+	} else {
+		o = msgp.AppendArrayHeader(o, uint32(len((*z).UnauthenticatedVotes)))
+	}
+	for zb0001 := range (*z).UnauthenticatedVotes {
+		o = (*z).UnauthenticatedVotes[zb0001].MarshalMsg(o)
+	}
+	return
+}
+
+func (_ *networkAction) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(*networkAction)
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *networkAction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []byte, err error) {
+	if st.AllowableDepth == 0 {
+		err = msgp.ErrMaxDepthExceeded{}
+		return
+	}
+	st.AllowableDepth--
+	var field []byte
+	_ = field
+	var zb0002 int
+	var zb0003 bool
+	zb0002, zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if _, ok := err.(msgp.TypeError); ok {
+		zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0002 > 0 {
+			zb0002--
+			{
+				var zb0004 uint8
+				zb0004, bts, err = msgp.ReadUint8Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "struct-from-array", "T")
+					return
+				}
+				(*z).T = actionType(zb0004)
+			}
+		}
+		if zb0002 > 0 {
+			zb0002--
+			bts, err = (*z).Tag.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Tag")
+				return
+			}
+		}
+		if zb0002 > 0 {
+			zb0002--
+			bts, err = (*z).UnauthenticatedVote.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "UnauthenticatedVote")
+				return
+			}
+		}
+		if zb0002 > 0 {
+			zb0002--
+			bts, err = (*z).UnauthenticatedBundle.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "UnauthenticatedBundle")
+				return
+			}
+		}
+		if zb0002 > 0 {
+			zb0002--
+			var zb0005 int
+			var zb0006 bool
+			zb0005, zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if _, ok := err.(msgp.TypeError); ok {
+				zb0005, zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "struct-from-array", "CompoundMessage")
+					return
+				}
+				if zb0005 > 0 {
+					zb0005--
+					bts, err = (*z).CompoundMessage.Vote.UnmarshalMsgWithState(bts, st)
+					if err != nil {
+						err = msgp.WrapError(err, "struct-from-array", "CompoundMessage", "struct-from-array", "Vote")
+						return
+					}
+				}
+				if zb0005 > 0 {
+					zb0005--
+					bts, err = (*z).CompoundMessage.Proposal.UnmarshalMsgWithState(bts, st)
+					if err != nil {
+						err = msgp.WrapError(err, "struct-from-array", "CompoundMessage", "struct-from-array", "Proposal")
+						return
+					}
+				}
+				if zb0005 > 0 {
+					err = msgp.ErrTooManyArrayFields(zb0005)
+					if err != nil {
+						err = msgp.WrapError(err, "struct-from-array", "CompoundMessage", "struct-from-array")
+						return
+					}
+				}
+			} else {
+				if err != nil {
+					err = msgp.WrapError(err, "struct-from-array", "CompoundMessage")
+					return
+				}
+				if zb0006 {
+					(*z).CompoundMessage = compoundMessage{}
+				}
+				for zb0005 > 0 {
+					zb0005--
+					field, bts, err = msgp.ReadMapKeyZC(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "struct-from-array", "CompoundMessage")
+						return
+					}
+					switch string(field) {
+					case "Vote":
+						bts, err = (*z).CompoundMessage.Vote.UnmarshalMsgWithState(bts, st)
+						if err != nil {
+							err = msgp.WrapError(err, "struct-from-array", "CompoundMessage", "Vote")
+							return
+						}
+					case "Proposal":
+						bts, err = (*z).CompoundMessage.Proposal.UnmarshalMsgWithState(bts, st)
+						if err != nil {
+							err = msgp.WrapError(err, "struct-from-array", "CompoundMessage", "Proposal")
+							return
+						}
+					default:
+						err = msgp.ErrNoField(string(field))
+						if err != nil {
+							err = msgp.WrapError(err, "struct-from-array", "CompoundMessage")
+							return
+						}
+					}
+				}
+			}
+		}
+		if zb0002 > 0 {
+			zb0002--
+			var zb0007 int
+			var zb0008 bool
+			zb0007, zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "UnauthenticatedVotes")
+				return
+			}
+			if zb0008 {
+				(*z).UnauthenticatedVotes = nil
+			} else if (*z).UnauthenticatedVotes != nil && cap((*z).UnauthenticatedVotes) >= zb0007 {
+				(*z).UnauthenticatedVotes = ((*z).UnauthenticatedVotes)[:zb0007]
+			} else {
+				(*z).UnauthenticatedVotes = make([]unauthenticatedVote, zb0007)
+			}
+			for zb0001 := range (*z).UnauthenticatedVotes {
+				bts, err = (*z).UnauthenticatedVotes[zb0001].UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "struct-from-array", "UnauthenticatedVotes", zb0001)
+					return
+				}
+			}
+		}
+		if zb0002 > 0 {
+			zb0002--
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				(*z).Err = nil
+			} else {
+				if (*z).Err == nil {
+					(*z).Err = new(serializableError)
+				}
+				{
+					var zb0009 string
+					zb0009, bts, err = msgp.ReadStringBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "struct-from-array", "Err")
+						return
+					}
+					*(*z).Err = serializableError(zb0009)
+				}
+			}
+		}
+		if zb0002 > 0 {
+			err = msgp.ErrTooManyArrayFields(zb0002)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array")
+				return
+			}
+		}
+	} else {
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0003 {
+			(*z) = networkAction{}
+		}
+		for zb0002 > 0 {
+			zb0002--
+			field, bts, err = msgp.ReadMapKeyZC(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+			switch string(field) {
+			case "T":
+				{
+					var zb0010 uint8
+					zb0010, bts, err = msgp.ReadUint8Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "T")
+						return
+					}
+					(*z).T = actionType(zb0010)
+				}
+			case "Tag":
+				bts, err = (*z).Tag.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Tag")
+					return
+				}
+			case "UnauthenticatedVote":
+				bts, err = (*z).UnauthenticatedVote.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "UnauthenticatedVote")
+					return
+				}
+			case "UnauthenticatedBundle":
+				bts, err = (*z).UnauthenticatedBundle.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "UnauthenticatedBundle")
+					return
+				}
+			case "CompoundMessage":
+				var zb0011 int
+				var zb0012 bool
+				zb0011, zb0012, bts, err = msgp.ReadMapHeaderBytes(bts)
+				if _, ok := err.(msgp.TypeError); ok {
+					zb0011, zb0012, bts, err = msgp.ReadArrayHeaderBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "CompoundMessage")
+						return
+					}
+					if zb0011 > 0 {
+						zb0011--
+						bts, err = (*z).CompoundMessage.Vote.UnmarshalMsgWithState(bts, st)
+						if err != nil {
+							err = msgp.WrapError(err, "CompoundMessage", "struct-from-array", "Vote")
+							return
+						}
+					}
+					if zb0011 > 0 {
+						zb0011--
+						bts, err = (*z).CompoundMessage.Proposal.UnmarshalMsgWithState(bts, st)
+						if err != nil {
+							err = msgp.WrapError(err, "CompoundMessage", "struct-from-array", "Proposal")
+							return
+						}
+					}
+					if zb0011 > 0 {
+						err = msgp.ErrTooManyArrayFields(zb0011)
+						if err != nil {
+							err = msgp.WrapError(err, "CompoundMessage", "struct-from-array")
+							return
+						}
+					}
+				} else {
+					if err != nil {
+						err = msgp.WrapError(err, "CompoundMessage")
+						return
+					}
+					if zb0012 {
+						(*z).CompoundMessage = compoundMessage{}
+					}
+					for zb0011 > 0 {
+						zb0011--
+						field, bts, err = msgp.ReadMapKeyZC(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "CompoundMessage")
+							return
+						}
+						switch string(field) {
+						case "Vote":
+							bts, err = (*z).CompoundMessage.Vote.UnmarshalMsgWithState(bts, st)
+							if err != nil {
+								err = msgp.WrapError(err, "CompoundMessage", "Vote")
+								return
+							}
+						case "Proposal":
+							bts, err = (*z).CompoundMessage.Proposal.UnmarshalMsgWithState(bts, st)
+							if err != nil {
+								err = msgp.WrapError(err, "CompoundMessage", "Proposal")
+								return
+							}
+						default:
+							err = msgp.ErrNoField(string(field))
+							if err != nil {
+								err = msgp.WrapError(err, "CompoundMessage")
+								return
+							}
+						}
+					}
+				}
+			case "UnauthenticatedVotes":
+				var zb0013 int
+				var zb0014 bool
+				zb0013, zb0014, bts, err = msgp.ReadArrayHeaderBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "UnauthenticatedVotes")
+					return
+				}
+				if zb0014 {
+					(*z).UnauthenticatedVotes = nil
+				} else if (*z).UnauthenticatedVotes != nil && cap((*z).UnauthenticatedVotes) >= zb0013 {
+					(*z).UnauthenticatedVotes = ((*z).UnauthenticatedVotes)[:zb0013]
+				} else {
+					(*z).UnauthenticatedVotes = make([]unauthenticatedVote, zb0013)
+				}
+				for zb0001 := range (*z).UnauthenticatedVotes {
+					bts, err = (*z).UnauthenticatedVotes[zb0001].UnmarshalMsgWithState(bts, st)
+					if err != nil {
+						err = msgp.WrapError(err, "UnauthenticatedVotes", zb0001)
+						return
+					}
+				}
+			case "Err":
+				if msgp.IsNil(bts) {
+					bts, err = msgp.ReadNilBytes(bts)
+					if err != nil {
+						return
+					}
+					(*z).Err = nil
+				} else {
+					if (*z).Err == nil {
+						(*z).Err = new(serializableError)
+					}
+					{
+						var zb0015 string
+						zb0015, bts, err = msgp.ReadStringBytes(bts)
+						if err != nil {
+							err = msgp.WrapError(err, "Err")
+							return
+						}
+						*(*z).Err = serializableError(zb0015)
+					}
+				}
+			default:
+				err = msgp.ErrNoField(string(field))
+				if err != nil {
+					err = msgp.WrapError(err)
+					return
+				}
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *networkAction) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.UnmarshalMsgWithState(bts, msgp.DefaultUnmarshalState)
+}
+func (_ *networkAction) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*networkAction)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *networkAction) Msgsize() (s int) {
+	s = 1 + 2 + msgp.Uint8Size + 4 + (*z).Tag.Msgsize() + 20 + (*z).UnauthenticatedVote.Msgsize() + 22 + (*z).UnauthenticatedBundle.Msgsize() + 16 + 1 + 5 + (*z).CompoundMessage.Vote.Msgsize() + 9 + (*z).CompoundMessage.Proposal.Msgsize() + 21 + msgp.ArrayHeaderSize
+	for zb0001 := range (*z).UnauthenticatedVotes {
+		s += (*z).UnauthenticatedVotes[zb0001].Msgsize()
+	}
+	s += 4
+	if (*z).Err == nil {
+		s += msgp.NilSize
+	} else {
+		s += msgp.StringPrefixSize + len(string(*(*z).Err))
+	}
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z *networkAction) MsgIsZero() bool {
+	return ((*z).T == 0) && ((*z).Tag.MsgIsZero()) && ((*z).UnauthenticatedVote.MsgIsZero()) && ((*z).UnauthenticatedBundle.MsgIsZero()) && (((*z).CompoundMessage.Vote.MsgIsZero()) && ((*z).CompoundMessage.Proposal.MsgIsZero())) && (len((*z).UnauthenticatedVotes) == 0) && ((*z).Err == nil)
+}
+
+// NetworkActionMaxSize returns a maximum valid message size for this message type
+func NetworkActionMaxSize() (s int) {
+	s = 1 + 2 + msgp.Uint8Size + 4 + protocol.TagMaxSize() + 20 + UnauthenticatedVoteMaxSize() + 22 + UnauthenticatedBundleMaxSize() + 16 + 1 + 5 + UnauthenticatedVoteMaxSize() + 9 + UnauthenticatedProposalMaxSize() + 21
+	// Calculating size of slice: z.UnauthenticatedVotes
+	panic("Slice z.UnauthenticatedVotes is unbounded")
+}
+
+// MarshalMsg implements msgp.Marshaler
 func (z *nextThresholdStatusEvent) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// map header, size 2
@@ -3837,6 +4942,98 @@ func (z *nextThresholdStatusEvent) MsgIsZero() bool {
 // NextThresholdStatusEventMaxSize returns a maximum valid message size for this message type
 func NextThresholdStatusEventMaxSize() (s int) {
 	s = 1 + 7 + msgp.BoolSize + 9 + ProposalValueMaxSize()
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *noopAction) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 0
+	o = append(o, 0x80)
+	return
+}
+
+func (_ *noopAction) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(*noopAction)
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *noopAction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []byte, err error) {
+	if st.AllowableDepth == 0 {
+		err = msgp.ErrMaxDepthExceeded{}
+		return
+	}
+	st.AllowableDepth--
+	var field []byte
+	_ = field
+	var zb0001 int
+	var zb0002 bool
+	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if _, ok := err.(msgp.TypeError); ok {
+		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0001 > 0 {
+			err = msgp.ErrTooManyArrayFields(zb0001)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array")
+				return
+			}
+		}
+	} else {
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0002 {
+			(*z) = noopAction{}
+		}
+		for zb0001 > 0 {
+			zb0001--
+			field, bts, err = msgp.ReadMapKeyZC(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+			switch string(field) {
+			default:
+				err = msgp.ErrNoField(string(field))
+				if err != nil {
+					err = msgp.WrapError(err)
+					return
+				}
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *noopAction) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.UnmarshalMsgWithState(bts, msgp.DefaultUnmarshalState)
+}
+func (_ *noopAction) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*noopAction)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *noopAction) Msgsize() (s int) {
+	s = 1
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z *noopAction) MsgIsZero() bool {
+	return true
+}
+
+// NoopActionMaxSize returns a maximum valid message size for this message type
+func NoopActionMaxSize() (s int) {
+	s = 1
 	return
 }
 
@@ -7284,6 +8481,206 @@ func ProposerSeedMaxSize() (s int) {
 }
 
 // MarshalMsg implements msgp.Marshaler
+func (z *pseudonodeAction) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 5
+	// string "Period"
+	o = append(o, 0x85, 0xa6, 0x50, 0x65, 0x72, 0x69, 0x6f, 0x64)
+	o = msgp.AppendUint64(o, uint64((*z).Period))
+	// string "Proposal"
+	o = append(o, 0xa8, 0x50, 0x72, 0x6f, 0x70, 0x6f, 0x73, 0x61, 0x6c)
+	o = (*z).Proposal.MarshalMsg(o)
+	// string "Round"
+	o = append(o, 0xa5, 0x52, 0x6f, 0x75, 0x6e, 0x64)
+	o = (*z).Round.MarshalMsg(o)
+	// string "Step"
+	o = append(o, 0xa4, 0x53, 0x74, 0x65, 0x70)
+	o = msgp.AppendUint64(o, uint64((*z).Step))
+	// string "T"
+	o = append(o, 0xa1, 0x54)
+	o = msgp.AppendUint8(o, uint8((*z).T))
+	return
+}
+
+func (_ *pseudonodeAction) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(*pseudonodeAction)
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *pseudonodeAction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []byte, err error) {
+	if st.AllowableDepth == 0 {
+		err = msgp.ErrMaxDepthExceeded{}
+		return
+	}
+	st.AllowableDepth--
+	var field []byte
+	_ = field
+	var zb0001 int
+	var zb0002 bool
+	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if _, ok := err.(msgp.TypeError); ok {
+		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0001 > 0 {
+			zb0001--
+			{
+				var zb0003 uint8
+				zb0003, bts, err = msgp.ReadUint8Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "struct-from-array", "T")
+					return
+				}
+				(*z).T = actionType(zb0003)
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Round.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Round")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			{
+				var zb0004 uint64
+				zb0004, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "struct-from-array", "Period")
+					return
+				}
+				(*z).Period = period(zb0004)
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			{
+				var zb0005 uint64
+				zb0005, bts, err = msgp.ReadUint64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "struct-from-array", "Step")
+					return
+				}
+				(*z).Step = step(zb0005)
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Proposal.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Proposal")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			err = msgp.ErrTooManyArrayFields(zb0001)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array")
+				return
+			}
+		}
+	} else {
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0002 {
+			(*z) = pseudonodeAction{}
+		}
+		for zb0001 > 0 {
+			zb0001--
+			field, bts, err = msgp.ReadMapKeyZC(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+			switch string(field) {
+			case "T":
+				{
+					var zb0006 uint8
+					zb0006, bts, err = msgp.ReadUint8Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "T")
+						return
+					}
+					(*z).T = actionType(zb0006)
+				}
+			case "Round":
+				bts, err = (*z).Round.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Round")
+					return
+				}
+			case "Period":
+				{
+					var zb0007 uint64
+					zb0007, bts, err = msgp.ReadUint64Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Period")
+						return
+					}
+					(*z).Period = period(zb0007)
+				}
+			case "Step":
+				{
+					var zb0008 uint64
+					zb0008, bts, err = msgp.ReadUint64Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Step")
+						return
+					}
+					(*z).Step = step(zb0008)
+				}
+			case "Proposal":
+				bts, err = (*z).Proposal.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Proposal")
+					return
+				}
+			default:
+				err = msgp.ErrNoField(string(field))
+				if err != nil {
+					err = msgp.WrapError(err)
+					return
+				}
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *pseudonodeAction) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.UnmarshalMsgWithState(bts, msgp.DefaultUnmarshalState)
+}
+func (_ *pseudonodeAction) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*pseudonodeAction)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *pseudonodeAction) Msgsize() (s int) {
+	s = 1 + 2 + msgp.Uint8Size + 6 + (*z).Round.Msgsize() + 7 + msgp.Uint64Size + 5 + msgp.Uint64Size + 9 + (*z).Proposal.Msgsize()
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z *pseudonodeAction) MsgIsZero() bool {
+	return ((*z).T == 0) && ((*z).Round.MsgIsZero()) && ((*z).Period == 0) && ((*z).Step == 0) && ((*z).Proposal.MsgIsZero())
+}
+
+// PseudonodeActionMaxSize returns a maximum valid message size for this message type
+func PseudonodeActionMaxSize() (s int) {
+	s = 1 + 2 + msgp.Uint8Size + 6 + basics.RoundMaxSize() + 7 + msgp.Uint64Size + 5 + msgp.Uint64Size + 9 + ProposalValueMaxSize()
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
 func (z *rawVote) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
@@ -7508,6 +8905,114 @@ func (z *rawVote) MsgIsZero() bool {
 // RawVoteMaxSize returns a maximum valid message size for this message type
 func RawVoteMaxSize() (s int) {
 	s = 1 + 4 + basics.AddressMaxSize() + 4 + basics.RoundMaxSize() + 4 + msgp.Uint64Size + 5 + msgp.Uint64Size + 5 + ProposalValueMaxSize()
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *rezeroAction) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "Round"
+	o = append(o, 0x81, 0xa5, 0x52, 0x6f, 0x75, 0x6e, 0x64)
+	o = (*z).Round.MarshalMsg(o)
+	return
+}
+
+func (_ *rezeroAction) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(*rezeroAction)
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *rezeroAction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []byte, err error) {
+	if st.AllowableDepth == 0 {
+		err = msgp.ErrMaxDepthExceeded{}
+		return
+	}
+	st.AllowableDepth--
+	var field []byte
+	_ = field
+	var zb0001 int
+	var zb0002 bool
+	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if _, ok := err.(msgp.TypeError); ok {
+		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Round.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Round")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			err = msgp.ErrTooManyArrayFields(zb0001)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array")
+				return
+			}
+		}
+	} else {
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0002 {
+			(*z) = rezeroAction{}
+		}
+		for zb0001 > 0 {
+			zb0001--
+			field, bts, err = msgp.ReadMapKeyZC(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+			switch string(field) {
+			case "Round":
+				bts, err = (*z).Round.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Round")
+					return
+				}
+			default:
+				err = msgp.ErrNoField(string(field))
+				if err != nil {
+					err = msgp.WrapError(err)
+					return
+				}
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *rezeroAction) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.UnmarshalMsgWithState(bts, msgp.DefaultUnmarshalState)
+}
+func (_ *rezeroAction) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*rezeroAction)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *rezeroAction) Msgsize() (s int) {
+	s = 1 + 6 + (*z).Round.Msgsize()
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z *rezeroAction) MsgIsZero() bool {
+	return ((*z).Round.MsgIsZero())
+}
+
+// RezeroActionMaxSize returns a maximum valid message size for this message type
+func RezeroActionMaxSize() (s int) {
+	s = 1 + 6 + basics.RoundMaxSize()
 	return
 }
 
@@ -8632,6 +10137,114 @@ func (z serializableError) MsgIsZero() bool {
 // SerializableErrorMaxSize returns a maximum valid message size for this message type
 func SerializableErrorMaxSize() (s int) {
 	panic("Unable to determine max size: String type string(z) is unbounded")
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *stageDigestAction) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "Certificate"
+	o = append(o, 0x81, 0xab, 0x43, 0x65, 0x72, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x65)
+	o = (*z).Certificate.MarshalMsg(o)
+	return
+}
+
+func (_ *stageDigestAction) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(*stageDigestAction)
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *stageDigestAction) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []byte, err error) {
+	if st.AllowableDepth == 0 {
+		err = msgp.ErrMaxDepthExceeded{}
+		return
+	}
+	st.AllowableDepth--
+	var field []byte
+	_ = field
+	var zb0001 int
+	var zb0002 bool
+	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if _, ok := err.(msgp.TypeError); ok {
+		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Certificate.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Certificate")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			err = msgp.ErrTooManyArrayFields(zb0001)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array")
+				return
+			}
+		}
+	} else {
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0002 {
+			(*z) = stageDigestAction{}
+		}
+		for zb0001 > 0 {
+			zb0001--
+			field, bts, err = msgp.ReadMapKeyZC(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+			switch string(field) {
+			case "Certificate":
+				bts, err = (*z).Certificate.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Certificate")
+					return
+				}
+			default:
+				err = msgp.ErrNoField(string(field))
+				if err != nil {
+					err = msgp.WrapError(err)
+					return
+				}
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *stageDigestAction) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.UnmarshalMsgWithState(bts, msgp.DefaultUnmarshalState)
+}
+func (_ *stageDigestAction) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*stageDigestAction)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *stageDigestAction) Msgsize() (s int) {
+	s = 1 + 12 + (*z).Certificate.Msgsize()
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z *stageDigestAction) MsgIsZero() bool {
+	return ((*z).Certificate.MsgIsZero())
+}
+
+// StageDigestActionMaxSize returns a maximum valid message size for this message type
+func StageDigestActionMaxSize() (s int) {
+	s = 1 + 12 + CertificateMaxSize()
+	return
 }
 
 // MarshalMsg implements msgp.Marshaler

--- a/agreement/msgp_gen_test.go
+++ b/agreement/msgp_gen_test.go
@@ -313,6 +313,66 @@ func BenchmarkUnmarshalbundle(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalcheckpointAction(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	v := checkpointAction{}
+	bts := v.MarshalMsg(nil)
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func TestRandomizedEncodingcheckpointAction(t *testing.T) {
+	protocol.RunEncodingTest(t, &checkpointAction{})
+}
+
+func BenchmarkMarshalMsgcheckpointAction(b *testing.B) {
+	v := checkpointAction{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgcheckpointAction(b *testing.B) {
+	v := checkpointAction{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalcheckpointAction(b *testing.B) {
+	v := checkpointAction{}
+	bts := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalcompoundMessage(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	v := compoundMessage{}
@@ -373,6 +433,66 @@ func BenchmarkUnmarshalcompoundMessage(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalcryptoAction(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	v := cryptoAction{}
+	bts := v.MarshalMsg(nil)
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func TestRandomizedEncodingcryptoAction(t *testing.T) {
+	protocol.RunEncodingTest(t, &cryptoAction{})
+}
+
+func BenchmarkMarshalMsgcryptoAction(b *testing.B) {
+	v := cryptoAction{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgcryptoAction(b *testing.B) {
+	v := cryptoAction{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalcryptoAction(b *testing.B) {
+	v := cryptoAction{}
+	bts := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshaldiskState(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	v := diskState{}
@@ -421,6 +541,66 @@ func BenchmarkAppendMsgdiskState(b *testing.B) {
 
 func BenchmarkUnmarshaldiskState(b *testing.B) {
 	v := diskState{}
+	bts := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalensureAction(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	v := ensureAction{}
+	bts := v.MarshalMsg(nil)
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func TestRandomizedEncodingensureAction(t *testing.T) {
+	protocol.RunEncodingTest(t, &ensureAction{})
+}
+
+func BenchmarkMarshalMsgensureAction(b *testing.B) {
+	v := ensureAction{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgensureAction(b *testing.B) {
+	v := ensureAction{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalensureAction(b *testing.B) {
+	v := ensureAction{}
 	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
@@ -733,6 +913,66 @@ func BenchmarkUnmarshalmessageEvent(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalnetworkAction(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	v := networkAction{}
+	bts := v.MarshalMsg(nil)
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func TestRandomizedEncodingnetworkAction(t *testing.T) {
+	protocol.RunEncodingTest(t, &networkAction{})
+}
+
+func BenchmarkMarshalMsgnetworkAction(b *testing.B) {
+	v := networkAction{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgnetworkAction(b *testing.B) {
+	v := networkAction{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalnetworkAction(b *testing.B) {
+	v := networkAction{}
+	bts := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalnextThresholdStatusEvent(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	v := nextThresholdStatusEvent{}
@@ -781,6 +1021,66 @@ func BenchmarkAppendMsgnextThresholdStatusEvent(b *testing.B) {
 
 func BenchmarkUnmarshalnextThresholdStatusEvent(b *testing.B) {
 	v := nextThresholdStatusEvent{}
+	bts := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalnoopAction(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	v := noopAction{}
+	bts := v.MarshalMsg(nil)
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func TestRandomizedEncodingnoopAction(t *testing.T) {
+	protocol.RunEncodingTest(t, &noopAction{})
+}
+
+func BenchmarkMarshalMsgnoopAction(b *testing.B) {
+	v := noopAction{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgnoopAction(b *testing.B) {
+	v := noopAction{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalnoopAction(b *testing.B) {
+	v := noopAction{}
 	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
@@ -1513,6 +1813,66 @@ func BenchmarkUnmarshalproposerSeed(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalpseudonodeAction(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	v := pseudonodeAction{}
+	bts := v.MarshalMsg(nil)
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func TestRandomizedEncodingpseudonodeAction(t *testing.T) {
+	protocol.RunEncodingTest(t, &pseudonodeAction{})
+}
+
+func BenchmarkMarshalMsgpseudonodeAction(b *testing.B) {
+	v := pseudonodeAction{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgpseudonodeAction(b *testing.B) {
+	v := pseudonodeAction{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalpseudonodeAction(b *testing.B) {
+	v := pseudonodeAction{}
+	bts := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalrawVote(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	v := rawVote{}
@@ -1561,6 +1921,66 @@ func BenchmarkAppendMsgrawVote(b *testing.B) {
 
 func BenchmarkUnmarshalrawVote(b *testing.B) {
 	v := rawVote{}
+	bts := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalrezeroAction(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	v := rezeroAction{}
+	bts := v.MarshalMsg(nil)
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func TestRandomizedEncodingrezeroAction(t *testing.T) {
+	protocol.RunEncodingTest(t, &rezeroAction{})
+}
+
+func BenchmarkMarshalMsgrezeroAction(b *testing.B) {
+	v := rezeroAction{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgrezeroAction(b *testing.B) {
+	v := rezeroAction{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalrezeroAction(b *testing.B) {
+	v := rezeroAction{}
 	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))
@@ -1801,6 +2221,66 @@ func BenchmarkAppendMsgselector(b *testing.B) {
 
 func BenchmarkUnmarshalselector(b *testing.B) {
 	v := selector{}
+	bts := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalstageDigestAction(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	v := stageDigestAction{}
+	bts := v.MarshalMsg(nil)
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func TestRandomizedEncodingstageDigestAction(t *testing.T) {
+	protocol.RunEncodingTest(t, &stageDigestAction{})
+}
+
+func BenchmarkMarshalMsgstageDigestAction(b *testing.B) {
+	v := stageDigestAction{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgstageDigestAction(b *testing.B) {
+	v := stageDigestAction{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalstageDigestAction(b *testing.B) {
+	v := stageDigestAction{}
 	bts := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))

--- a/agreement/persistence.go
+++ b/agreement/persistence.go
@@ -82,9 +82,11 @@ func encode(t timers.Clock[TimeoutType], rr rootRouter, p player, a []action, re
 	s.Actions = make([][]byte, len(a))
 	for i, act := range a {
 		s.ActionTypes[i] = act.t()
-
-		// still use reflection for actions since action is an interface and we can't define marshaller methods on it
-		s.Actions[i] = protocol.EncodeReflect(act)
+		if reflect {
+			s.Actions[i] = protocol.EncodeReflect(act)
+		} else {
+			s.Actions[i] = encodeAction(act)
+		}
 	}
 	if reflect {
 		raw = protocol.EncodeReflect(s)
@@ -278,11 +280,27 @@ func decode(raw []byte, t0 timers.Clock[TimeoutType], log serviceLogger, reflect
 	}
 
 	for i := range s.Actions {
-		act := zeroAction(s.ActionTypes[i])
-		// always use reflection for actions since action is an interface and we can't define unmarshaller methods on it
-		err = protocol.DecodeReflect(s.Actions[i], &act)
-		if err != nil {
-			return
+		var act action
+		if reflect {
+			act = zeroAction(s.ActionTypes[i])
+			err = protocol.DecodeReflect(s.Actions[i], &act)
+			if err != nil {
+				return
+			}
+		} else {
+			act, err = decodeAction(s.ActionTypes[i], s.Actions[i])
+			if err != nil {
+				// fall back to reflection to read crash state written by a
+				// release that still encoded actions with go-codec
+				log.Warnf("decode (agreement): failed to decode action %d using msgp (len = %v): %v. Trying reflection", i, len(s.Actions[i]), err)
+				ract := zeroAction(s.ActionTypes[i])
+				err = protocol.DecodeReflect(s.Actions[i], &ract)
+				if err != nil {
+					log.Errorf("decode (agreement): failed to decode action %d using either reflection or msgp: %v", i, err)
+					return
+				}
+				act = ract
+			}
 		}
 		a2 = append(a2, act)
 	}

--- a/agreement/persistence.go
+++ b/agreement/persistence.go
@@ -204,11 +204,14 @@ func decode(raw []byte, t0 timers.Clock[TimeoutType], log serviceLogger) (t time
 	var p2 player
 	a2 := []action{}
 	var s diskState
-
 	err = protocol.Decode(raw, &s)
 	if err != nil {
-		log.Errorf("decode (agreement): error decoding retrieved state (len = %v): %v", len(raw), err)
-		return
+		log.Warnf("decode (agreement): error decoding retrieved state using msgp (len = %v): %v. Trying reflection", len(raw), err)
+		err = protocol.DecodeReflect(raw, &s)
+		if err != nil {
+			log.Errorf("decode (agreement): error decoding using either reflection or msgp): %v", err)
+			return
+		}
 	}
 
 	t2, err = t0.Decode(s.Clock)
@@ -218,8 +221,12 @@ func decode(raw []byte, t0 timers.Clock[TimeoutType], log serviceLogger) (t time
 
 	err = protocol.Decode(s.Player, &p2)
 	if err != nil {
-		log.Errorf("decode (agreement): failed to decode Player (len = %v): %v", len(s.Player), err)
-		return
+		log.Warnf("decode (agreement): failed to decode Player using msgp (len = %v): %v. Trying reflection", len(s.Player), err)
+		err = protocol.DecodeReflect(s.Player, &p2)
+		if err != nil {
+			log.Errorf("decode (agreement): failed to decode Player using either reflection or msgp: %v", err)
+			return
+		}
 	}
 	p2.lowestCredentialArrivals = makeCredentialArrivalHistory(dynamicFilterCredentialArrivalHistory)
 	if p2.OldDeadline != 0 {
@@ -229,16 +236,29 @@ func decode(raw []byte, t0 timers.Clock[TimeoutType], log serviceLogger) (t time
 	rr2 = makeRootRouter(p2)
 	err = protocol.Decode(s.Router, &rr2)
 	if err != nil {
-		log.Errorf("decode (agreement): failed to decode Router (len = %v): %v", len(s.Router), err)
-		return
+		log.Warnf("decode (agreement): failed to decode Router using msgp (len = %v): %v. Trying reflection", len(s.Router), err)
+		rr2 = makeRootRouter(p2)
+		err = protocol.DecodeReflect(s.Router, &rr2)
+		if err != nil {
+			log.Errorf("decode (agreement): failed to decode Router using either reflection or msgp: %v", err)
+			return
+		}
 	}
 
 	for i := range s.Actions {
 		var act action
 		act, err = decodeAction(s.ActionTypes[i], s.Actions[i])
 		if err != nil {
-			log.Errorf("decode (agreement): failed to decode action %d (len = %v): %v", i, len(s.Actions[i]), err)
-			return
+			// fall back to reflection to read crash state written by a
+			// release that still encoded actions with go-codec
+			log.Warnf("decode (agreement): failed to decode action %d using msgp (len = %v): %v. Trying reflection", i, len(s.Actions[i]), err)
+			ract := zeroAction(s.ActionTypes[i])
+			err = protocol.DecodeReflect(s.Actions[i], &ract)
+			if err != nil {
+				log.Errorf("decode (agreement): failed to decode action %d using either reflection or msgp: %v", i, err)
+				return
+			}
+			act = ract
 		}
 		a2 = append(a2, act)
 	}

--- a/agreement/persistence.go
+++ b/agreement/persistence.go
@@ -53,7 +53,7 @@ func persistent(as []action) bool {
 }
 
 // encode serializes the current state into a byte array.
-func encode(t timers.Clock[TimeoutType], rr rootRouter, p player, a []action, reflect bool) (raw []byte) {
+func encode(t timers.Clock[TimeoutType], rr rootRouter, p player, a []action) (raw []byte) {
 	var s diskState
 
 	// Don't persist state for old rounds
@@ -70,29 +70,16 @@ func encode(t timers.Clock[TimeoutType], rr rootRouter, p player, a []action, re
 		rr.Children = children
 	}
 
-	if reflect {
-		s.Router = protocol.EncodeReflect(rr)
-		s.Player = protocol.EncodeReflect(p)
-	} else {
-		s.Router = protocol.Encode(&rr)
-		s.Player = protocol.Encode(&p)
-	}
+	s.Router = protocol.Encode(&rr)
+	s.Player = protocol.Encode(&p)
 	s.Clock = t.Encode()
 	s.ActionTypes = make([]actionType, len(a))
 	s.Actions = make([][]byte, len(a))
 	for i, act := range a {
 		s.ActionTypes[i] = act.t()
-		if reflect {
-			s.Actions[i] = protocol.EncodeReflect(act)
-		} else {
-			s.Actions[i] = encodeAction(act)
-		}
+		s.Actions[i] = encodeAction(act)
 	}
-	if reflect {
-		raw = protocol.EncodeReflect(s)
-	} else {
-		raw = protocol.Encode(&s)
-	}
+	raw = protocol.Encode(&s)
 	return
 }
 
@@ -211,28 +198,17 @@ func restore(log logging.Logger, crash db.Accessor) (raw []byte, err error) {
 // decode process the incoming raw bytes array and attempt to reconstruct the agreement state objects.
 //
 // In all decoding errors, it returns the error code in err
-func decode(raw []byte, t0 timers.Clock[TimeoutType], log serviceLogger, reflect bool) (t timers.Clock[TimeoutType], rr rootRouter, p player, a []action, err error) {
+func decode(raw []byte, t0 timers.Clock[TimeoutType], log serviceLogger) (t timers.Clock[TimeoutType], rr rootRouter, p player, a []action, err error) {
 	var t2 timers.Clock[TimeoutType]
 	var rr2 rootRouter
 	var p2 player
 	a2 := []action{}
 	var s diskState
-	if reflect {
-		err = protocol.DecodeReflect(raw, &s)
-		if err != nil {
-			log.Errorf("decode (agreement): error decoding retrieved state (len = %v): %v", len(raw), err)
-			return
-		}
-	} else {
-		err = protocol.Decode(raw, &s)
-		if err != nil {
-			log.Warnf("decode (agreement): error decoding retrieved state using msgp (len = %v): %v. Trying reflection", len(raw), err)
-			err = protocol.DecodeReflect(raw, &s)
-			if err != nil {
-				log.Errorf("decode (agreement): error decoding using either reflection or msgp): %v", err)
-				return
-			}
-		}
+
+	err = protocol.Decode(raw, &s)
+	if err != nil {
+		log.Errorf("decode (agreement): error decoding retrieved state (len = %v): %v", len(raw), err)
+		return
 	}
 
 	t2, err = t0.Decode(s.Clock)
@@ -240,67 +216,29 @@ func decode(raw []byte, t0 timers.Clock[TimeoutType], log serviceLogger, reflect
 		return
 	}
 
-	if reflect {
-		err = protocol.DecodeReflect(s.Player, &p2)
-		if err != nil {
-			return
-		}
-		p2.lowestCredentialArrivals = makeCredentialArrivalHistory(dynamicFilterCredentialArrivalHistory)
-		rr2 = makeRootRouter(p2)
-		err = protocol.DecodeReflect(s.Router, &rr2)
-		if err != nil {
-			return
-		}
-	} else {
-		err = protocol.Decode(s.Player, &p2)
-		if err != nil {
-			log.Warnf("decode (agreement): failed to decode Player using msgp (len = %v): %v. Trying reflection", len(s.Player), err)
-			err = protocol.DecodeReflect(s.Player, &p2)
-			if err != nil {
-				log.Errorf("decode (agreement): failed to decode Player using either reflection or msgp: %v", err)
-				return
-			}
-		}
-		p2.lowestCredentialArrivals = makeCredentialArrivalHistory(dynamicFilterCredentialArrivalHistory)
-		if p2.OldDeadline != 0 {
-			p2.Deadline = Deadline{Duration: p2.OldDeadline, Type: TimeoutDeadline}
-			p2.OldDeadline = 0 // clear old value
-		}
-		rr2 = makeRootRouter(p2)
-		err = protocol.Decode(s.Router, &rr2)
-		if err != nil {
-			log.Warnf("decode (agreement): failed to decode Router using msgp (len = %v): %v. Trying reflection", len(s.Router), err)
-			rr2 = makeRootRouter(p2)
-			err = protocol.DecodeReflect(s.Router, &rr2)
-			if err != nil {
-				log.Errorf("decode (agreement): failed to decode Router using either reflection or msgp: %v", err)
-				return
-			}
-		}
+	err = protocol.Decode(s.Player, &p2)
+	if err != nil {
+		log.Errorf("decode (agreement): failed to decode Player (len = %v): %v", len(s.Player), err)
+		return
+	}
+	p2.lowestCredentialArrivals = makeCredentialArrivalHistory(dynamicFilterCredentialArrivalHistory)
+	if p2.OldDeadline != 0 {
+		p2.Deadline = Deadline{Duration: p2.OldDeadline, Type: TimeoutDeadline}
+		p2.OldDeadline = 0 // clear old value
+	}
+	rr2 = makeRootRouter(p2)
+	err = protocol.Decode(s.Router, &rr2)
+	if err != nil {
+		log.Errorf("decode (agreement): failed to decode Router (len = %v): %v", len(s.Router), err)
+		return
 	}
 
 	for i := range s.Actions {
 		var act action
-		if reflect {
-			act = zeroAction(s.ActionTypes[i])
-			err = protocol.DecodeReflect(s.Actions[i], &act)
-			if err != nil {
-				return
-			}
-		} else {
-			act, err = decodeAction(s.ActionTypes[i], s.Actions[i])
-			if err != nil {
-				// fall back to reflection to read crash state written by a
-				// release that still encoded actions with go-codec
-				log.Warnf("decode (agreement): failed to decode action %d using msgp (len = %v): %v. Trying reflection", i, len(s.Actions[i]), err)
-				ract := zeroAction(s.ActionTypes[i])
-				err = protocol.DecodeReflect(s.Actions[i], &ract)
-				if err != nil {
-					log.Errorf("decode (agreement): failed to decode action %d using either reflection or msgp: %v", i, err)
-					return
-				}
-				act = ract
-			}
+		act, err = decodeAction(s.ActionTypes[i], s.Actions[i])
+		if err != nil {
+			log.Errorf("decode (agreement): failed to decode action %d (len = %v): %v", i, len(s.Actions[i]), err)
+			return
 		}
 		a2 = append(a2, act)
 	}
@@ -398,7 +336,7 @@ func (p *asyncPersistenceLoop) loop(ctx context.Context) {
 		// sanity check; we check it after the fact, since it's not expected to ever happen.
 		// performance-wise, it takes approximitly 300000ns to execute, and we don't want it to
 		// block the persist operation.
-		_, _, _, _, derr := decode(s.raw, s.clock, p.log, false)
+		_, _, _, _, derr := decode(s.raw, s.clock, p.log)
 		if derr != nil {
 			p.log.Errorf("could not decode own encoded disk state: %v", derr)
 		}

--- a/agreement/persistence_test.go
+++ b/agreement/persistence_test.go
@@ -42,11 +42,11 @@ func TestAgreementSerialization(t *testing.T) {
 	router := makeRootRouter(status)
 	a := []action{checkpointAction{}, disconnectAction(messageEvent{}, nil)}
 
-	encodedBytes := encode(clock, router, status, a, false)
+	encodedBytes := encode(clock, router, status, a)
 
 	t0 := timers.MakeMonotonicClock[TimeoutType](time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC))
 	log := makeServiceLogger(logging.Base())
-	clock2, router2, status2, a2, err := decode(encodedBytes, t0, log, false)
+	clock2, router2, status2, a2, err := decode(encodedBytes, t0, log)
 	require.NoError(t, err)
 	require.Equalf(t, clock, clock2, "Clock wasn't serialized/deserialized correctly")
 	require.Equalf(t, router, router2, "Router wasn't serialized/deserialized correctly")
@@ -59,10 +59,10 @@ func TestAgreementSerialization(t *testing.T) {
 	router3 := makeRootRouter(status3)
 	a3 := []action{checkpointAction{}, disconnectAction(messageEvent{}, nil)}
 
-	encodedBytes2 := encode(clock3, router3, status3, a3, false)
+	encodedBytes2 := encode(clock3, router3, status3, a3)
 
 	t1 := timers.MakeMonotonicClock[TimeoutType](time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC))
-	clock4, router4, status4, a4, err := decode(encodedBytes2, t1, log, false)
+	clock4, router4, status4, a4, err := decode(encodedBytes2, t1, log)
 	require.NoError(t, err)
 	require.Equalf(t, clock, clock4, "Clock wasn't serialized/deserialized correctly")
 	require.Equalf(t, status, status4, "Status wasn't serialized/deserialized correctly")
@@ -81,7 +81,7 @@ func BenchmarkAgreementSerialization(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		encode(clock, router, status, a, false)
+		encode(clock, router, status, a)
 	}
 }
 
@@ -94,12 +94,12 @@ func BenchmarkAgreementDeserialization(b *testing.B) {
 	router := makeRootRouter(status)
 	a := []action{}
 
-	encodedBytes := encode(clock, router, status, a, false)
+	encodedBytes := encode(clock, router, status, a)
 	t0 := timers.MakeMonotonicClock[TimeoutType](time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC))
 	log := makeServiceLogger(logging.Base())
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		decode(encodedBytes, t0, log, false)
+		decode(encodedBytes, t0, log)
 	}
 }
 
@@ -220,6 +220,36 @@ func persistedTestActions() []action {
 	}
 }
 
+// encodeDiskStateReflect replicates the retired go-codec reflection encoder
+// for crash state, so tests keep proving that the msgp encoder produces the
+// exact bytes every past release wrote to the crash database.
+func encodeDiskStateReflect(t timers.Clock[TimeoutType], rr rootRouter, p player, a []action) []byte {
+	var s diskState
+
+	children := make(map[round]*roundRouter)
+	for rnd, rndRouter := range rr.Children {
+		if rnd >= p.Round {
+			children[rnd] = rndRouter
+		}
+	}
+	if len(children) == 0 {
+		rr.Children = nil
+	} else {
+		rr.Children = children
+	}
+
+	s.Router = protocol.EncodeReflect(rr)
+	s.Player = protocol.EncodeReflect(p)
+	s.Clock = t.Encode()
+	s.ActionTypes = make([]actionType, len(a))
+	s.Actions = make([][]byte, len(a))
+	for i, act := range a {
+		s.ActionTypes[i] = act.t()
+		s.Actions[i] = protocol.EncodeReflect(act)
+	}
+	return protocol.EncodeReflect(s)
+}
+
 func TestRandomizedEncodingFullDiskState(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	iterations := 1000
@@ -232,17 +262,15 @@ func TestRandomizedEncodingFullDiskState(t *testing.T) {
 		a := persistedTestActions()
 		clock := timers.MakeMonotonicClock[TimeoutType](time.Date(2015, 1, 2, 5, 6, 7, 8, time.UTC))
 		log := makeServiceLogger(logging.Base())
-		e1 := encode(clock, router, player, a, true)
-		e2 := encode(clock, router, player, a, false)
-		require.Equalf(t, e1, e2, "msgp and go-codec encodings differ: len(msgp)=%v, len(reflect)=%v", len(e1), len(e2))
-		_, rr1, p1, a1, err1 := decode(e1, clock, log, true)
-		_, rr2, p2, a2, err2 := decode(e1, clock, log, false)
-		require.NoErrorf(t, err1, "reflect decoding failed")
-		require.NoErrorf(t, err2, "msgp decoding failed")
-		require.Equalf(t, rr1, rr2, "rootRouters decoded differently")
-		require.Equalf(t, p1, p2, "players decoded differently")
-		require.Equalf(t, a, a1, "reflect-decoded actions differ from the originals")
-		require.Equalf(t, a, a2, "msgp-decoded actions differ from the originals")
+		e1 := encodeDiskStateReflect(clock, router, player, a)
+		e2 := encode(clock, router, player, a)
+		require.Equalf(t, e1, e2, "msgp and go-codec encodings differ: len(reflect)=%v, len(msgp)=%v", len(e1), len(e2))
+		_, rr2, p2, a2, err := decode(e1, clock, log)
+		require.NoErrorf(t, err, "decoding failed")
+		require.Equalf(t, a, a2, "decoded actions differ from the originals")
+		// the decoded state must re-encode to the same canonical bytes
+		e3 := encode(clock, rr2, p2, a2)
+		require.Equalf(t, e1, e3, "re-encoding of decoded state differs")
 	}
 
 }
@@ -253,18 +281,12 @@ func TestCredentialHistoryAllocated(t *testing.T) {
 	a := []action{}
 	clock := timers.MakeMonotonicClock[TimeoutType](time.Date(2015, 1, 2, 5, 6, 7, 8, time.UTC))
 	log := makeServiceLogger(logging.Base())
-	e1 := encode(clock, router, player, a, true)
-	e2 := encode(clock, router, player, a, false)
-	require.Equalf(t, e1, e2, "msgp and go-codec encodings differ: len(msgp)=%v, len(reflect)=%v", len(e1), len(e2))
-	_, _, p1, _, err1 := decode(e1, clock, log, true)
-	_, _, p2, _, err2 := decode(e1, clock, log, false)
-	require.NoErrorf(t, err1, "reflect decoding failed")
-	require.NoErrorf(t, err2, "msgp decoding failed")
+	e1 := encode(clock, router, player, a)
+	_, _, p2, _, err := decode(e1, clock, log)
+	require.NoErrorf(t, err, "decoding failed")
 
-	require.Len(t, p1.lowestCredentialArrivals.history, dynamicFilterCredentialArrivalHistory)
 	require.Len(t, p2.lowestCredentialArrivals.history, dynamicFilterCredentialArrivalHistory)
 	emptyHistory := makeCredentialArrivalHistory(dynamicFilterCredentialArrivalHistory)
-	require.Equalf(t, p1.lowestCredentialArrivals, emptyHistory, "credential arrival history isn't empty")
 	require.Equalf(t, p2.lowestCredentialArrivals, emptyHistory, "credential arrival history isn't empty")
 }
 
@@ -274,7 +296,7 @@ func BenchmarkRandomizedEncode(b *testing.B) {
 	a := []action{}
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		encode(clock, router, player, a, false)
+		encode(clock, router, player, a)
 	}
 }
 
@@ -282,11 +304,11 @@ func BenchmarkRandomizedDecode(b *testing.B) {
 	clock := timers.MakeMonotonicClock[TimeoutType](time.Date(2015, 1, 2, 5, 6, 7, 8, time.UTC))
 	router, player := randomizeDiskState()
 	a := []action{}
-	ds := encode(clock, router, player, a, false)
+	ds := encode(clock, router, player, a)
 	log := makeServiceLogger(logging.Base())
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		decode(ds, clock, log, false)
+		decode(ds, clock, log)
 	}
 }
 
@@ -324,7 +346,7 @@ func TestDecodeErrs(t *testing.T) {
 		}
 		uds := diskState{UnexpectedDiskField: 5}
 		udse := protocol.EncodeReflect(uds)
-		_, _, _, _, err := decode(udse, clock, log, false)
+		_, _, _, _, err := decode(udse, clock, log)
 		require.ErrorContains(t, err, "UnexpectedDiskField")
 
 	}
@@ -338,7 +360,7 @@ func TestDecodeErrs(t *testing.T) {
 		pe := protocol.EncodeReflect(p)
 		ds := diskState{Player: pe, Router: re, Clock: ce}
 		dse := protocol.EncodeReflect(ds)
-		_, _, _, _, err := decode(dse, clock, log, false)
+		_, _, _, _, err := decode(dse, clock, log)
 		require.ErrorContains(t, err, "UnexpectedPlayerField")
 	}
 
@@ -351,7 +373,7 @@ func TestDecodeErrs(t *testing.T) {
 		re := protocol.EncodeReflect(router)
 		ds := diskState{Player: pe, Router: re, Clock: ce}
 		dse := protocol.EncodeReflect(ds)
-		_, _, _, _, err := decode(dse, clock, log, false)
+		_, _, _, _, err := decode(dse, clock, log)
 		require.ErrorContains(t, err, "UnexpectedRouterField")
 	}
 }

--- a/agreement/persistence_test.go
+++ b/agreement/persistence_test.go
@@ -204,6 +204,22 @@ func randomizeDiskState() (rr rootRouter, p player) {
 	return
 }
 
+// persistedTestActions covers every concrete action type so encoding tests
+// exercise the msgp and reflection codecs on each of them.
+func persistedTestActions() []action {
+	return []action{
+		noopAction{},
+		networkAction{T: broadcast, Tag: protocol.AgreementVoteTag, UnauthenticatedVotes: []unauthenticatedVote{{}, {}}},
+		networkAction{T: disconnect, Err: makeSerErrStr("test disconnect")},
+		cryptoAction{T: verifyVote, Round: 100, Period: 2, Step: soft, TaskIndex: 7, Pinned: true},
+		ensureAction{Certificate: Certificate{Round: 100}},
+		stageDigestAction{Certificate: Certificate{Round: 101, Period: 3}},
+		rezeroAction{Round: 102},
+		pseudonodeAction{T: attest, Round: 103, Period: 1, Step: cert},
+		checkpointAction{Round: 104, Period: 2, Step: cert, Err: makeSerErrStr("test checkpoint")},
+	}
+}
+
 func TestRandomizedEncodingFullDiskState(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	iterations := 1000
@@ -213,18 +229,20 @@ func TestRandomizedEncodingFullDiskState(t *testing.T) {
 
 	for i := 0; i < iterations; i++ {
 		router, player := randomizeDiskState()
-		a := []action{}
+		a := persistedTestActions()
 		clock := timers.MakeMonotonicClock[TimeoutType](time.Date(2015, 1, 2, 5, 6, 7, 8, time.UTC))
 		log := makeServiceLogger(logging.Base())
 		e1 := encode(clock, router, player, a, true)
 		e2 := encode(clock, router, player, a, false)
 		require.Equalf(t, e1, e2, "msgp and go-codec encodings differ: len(msgp)=%v, len(reflect)=%v", len(e1), len(e2))
-		_, rr1, p1, _, err1 := decode(e1, clock, log, true)
-		_, rr2, p2, _, err2 := decode(e1, clock, log, false)
+		_, rr1, p1, a1, err1 := decode(e1, clock, log, true)
+		_, rr2, p2, a2, err2 := decode(e1, clock, log, false)
 		require.NoErrorf(t, err1, "reflect decoding failed")
 		require.NoErrorf(t, err2, "msgp decoding failed")
 		require.Equalf(t, rr1, rr2, "rootRouters decoded differently")
 		require.Equalf(t, p1, p2, "players decoded differently")
+		require.Equalf(t, a, a1, "reflect-decoded actions differ from the originals")
+		require.Equalf(t, a, a2, "msgp-decoded actions differ from the originals")
 	}
 
 }

--- a/agreement/player.go
+++ b/agreement/player.go
@@ -275,7 +275,7 @@ func (p *player) issueFastVote(r routerHandle) (actions []action) {
 
 func (p *player) handleCheckpointEvent(r routerHandle, e checkpointEvent) []action {
 	return []action{
-		checkpointAction{ //nolint:staticcheck // explicit assignment for clarity
+		checkpointAction{
 			Round:  e.Round,
 			Period: e.Period,
 			Step:   e.Step,

--- a/agreement/service.go
+++ b/agreement/service.go
@@ -223,7 +223,7 @@ func (s *Service) mainLoop(input <-chan externalEvent, output chan<- []action, r
 	var err error
 	raw, err := restore(s.log, s.Accessor)
 	if err == nil {
-		clock, router, status, a, err = decode(raw, s.Clock, s.log, false)
+		clock, router, status, a, err = decode(raw, s.Clock, s.log)
 		if err != nil {
 			reset(s.log, s.Accessor)
 		} else {
@@ -279,7 +279,7 @@ func (s *Service) mainLoop(input <-chan externalEvent, output chan<- []action, r
 // usage semantics : caller should ensure to call this function only when we have participation
 // keys for the given voting round.
 func (s *Service) persistState(done chan error) (events <-chan externalEvent) {
-	raw := encode(s.Clock, s.persistRouter, s.persistStatus, s.persistActions, false)
+	raw := encode(s.Clock, s.persistRouter, s.persistStatus, s.persistActions)
 	return s.persistenceLoop.Enqueue(s.Clock, s.persistStatus.Round, s.persistStatus.Period, s.persistStatus.Step, raw, done)
 }
 

--- a/catchup/universalFetcher.go
+++ b/catchup/universalFetcher.go
@@ -192,7 +192,7 @@ func (w *wsFetcherClient) requestBlock(ctx context.Context, round basics.Round) 
 		return nil, makeErrWsFetcherRequestFailed(round, w.target.GetAddress(), "Cert data not found")
 	}
 
-	blockCertBytes := protocol.EncodeReflect(rpcs.PreEncodedBlockCert{
+	blockCertBytes := protocol.Encode(&rpcs.PreEncodedBlockCert{
 		Block:       blk,
 		Certificate: cert})
 

--- a/catchup/universalFetcher_test.go
+++ b/catchup/universalFetcher_test.go
@@ -156,7 +156,7 @@ func TestProcessBlockBytesErrors(t *testing.T) {
 	}
 
 	blkData := protocol.Encode(&blk)
-	bc := protocol.EncodeReflect(rpcs.PreEncodedBlockCert{
+	bc := protocol.Encode(&rpcs.PreEncodedBlockCert{
 		Block: blkData,
 	})
 

--- a/rpcs/blockService.go
+++ b/rpcs/blockService.go
@@ -30,8 +30,8 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/algorand/go-codec/codec"
 	"github.com/algorand/go-deadlock"
+	"github.com/algorand/msgp/msgp"
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"
@@ -120,11 +120,11 @@ type EncodedBlockCert struct {
 
 // PreEncodedBlockCert defines how GetBlockBytes encodes a block and its certificate,
 // using a pre-encoded Block and Certificate in msgpack format.
-//
-//msgp:ignore PreEncodedBlockCert
 type PreEncodedBlockCert struct {
-	Block       codec.Raw `codec:"block"`
-	Certificate codec.Raw `codec:"cert"`
+	_struct struct{} `codec:""`
+
+	Block       msgp.Raw `codec:"block"`
+	Certificate msgp.Raw `codec:"cert"`
 }
 
 type fallbackEndpoints struct {
@@ -489,7 +489,7 @@ func RawBlockBytes(l LedgerForBlockService, round basics.Round) ([]byte, error) 
 		return nil, ledgercore.ErrNoEntry{Round: round}
 	}
 
-	return protocol.EncodeReflect(PreEncodedBlockCert{
+	return protocol.Encode(&PreEncodedBlockCert{
 		Block:       blk,
 		Certificate: cert,
 	}), nil

--- a/rpcs/blockService_test.go
+++ b/rpcs/blockService_test.go
@@ -350,7 +350,7 @@ forloop:
 			require.NoError(t, err)
 			require.NotEqual(t, 0, len(bodyData))
 			var blkCert PreEncodedBlockCert
-			err = protocol.DecodeReflect(bodyData, &blkCert)
+			err = protocol.Decode(bodyData, &blkCert)
 			require.NoError(t, err)
 			err = protocol.Decode(blkCert.Block, &blk)
 			require.NoError(t, err)

--- a/rpcs/msgp_gen.go
+++ b/rpcs/msgp_gen.go
@@ -20,6 +20,16 @@ import (
 //         |-----> (*) MsgIsZero
 //         |-----> EncodedBlockCertMaxSize()
 //
+// PreEncodedBlockCert
+//          |-----> (*) MarshalMsg
+//          |-----> (*) CanMarshalMsg
+//          |-----> (*) UnmarshalMsg
+//          |-----> (*) UnmarshalMsgWithState
+//          |-----> (*) CanUnmarshalMsg
+//          |-----> (*) Msgsize
+//          |-----> (*) MsgIsZero
+//          |-----> PreEncodedBlockCertMaxSize()
+//
 
 // MarshalMsg implements msgp.Marshaler
 func (z *EncodedBlockCert) MarshalMsg(b []byte) (o []byte) {
@@ -144,4 +154,129 @@ func (z *EncodedBlockCert) MsgIsZero() bool {
 func EncodedBlockCertMaxSize() (s int) {
 	s = 1 + 6 + bookkeeping.BlockMaxSize() + 5 + agreement.CertificateMaxSize()
 	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *PreEncodedBlockCert) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "block"
+	o = append(o, 0x82, 0xa5, 0x62, 0x6c, 0x6f, 0x63, 0x6b)
+	o = (*z).Block.MarshalMsg(o)
+	// string "cert"
+	o = append(o, 0xa4, 0x63, 0x65, 0x72, 0x74)
+	o = (*z).Certificate.MarshalMsg(o)
+	return
+}
+
+func (_ *PreEncodedBlockCert) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(*PreEncodedBlockCert)
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *PreEncodedBlockCert) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []byte, err error) {
+	if st.AllowableDepth == 0 {
+		err = msgp.ErrMaxDepthExceeded{}
+		return
+	}
+	st.AllowableDepth--
+	var field []byte
+	_ = field
+	var zb0001 int
+	var zb0002 bool
+	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if _, ok := err.(msgp.TypeError); ok {
+		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Block.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Block")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Certificate.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Certificate")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			err = msgp.ErrTooManyArrayFields(zb0001)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array")
+				return
+			}
+		}
+	} else {
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0002 {
+			(*z) = PreEncodedBlockCert{}
+		}
+		for zb0001 > 0 {
+			zb0001--
+			field, bts, err = msgp.ReadMapKeyZC(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+			switch string(field) {
+			case "block":
+				bts, err = (*z).Block.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Block")
+					return
+				}
+			case "cert":
+				bts, err = (*z).Certificate.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Certificate")
+					return
+				}
+			default:
+				err = msgp.ErrNoField(string(field))
+				if err != nil {
+					err = msgp.WrapError(err)
+					return
+				}
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *PreEncodedBlockCert) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.UnmarshalMsgWithState(bts, msgp.DefaultUnmarshalState)
+}
+func (_ *PreEncodedBlockCert) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*PreEncodedBlockCert)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *PreEncodedBlockCert) Msgsize() (s int) {
+	s = 1 + 6 + (*z).Block.Msgsize() + 5 + (*z).Certificate.Msgsize()
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z *PreEncodedBlockCert) MsgIsZero() bool {
+	return ((*z).Block.MsgIsZero()) && ((*z).Certificate.MsgIsZero())
+}
+
+// PreEncodedBlockCertMaxSize returns a maximum valid message size for this message type
+func PreEncodedBlockCertMaxSize() (s int) {
+	s = 1 + 6
+	panic("Unable to determine max size: MaxSize() not implemented for Raw type")
 }

--- a/rpcs/msgp_gen_test.go
+++ b/rpcs/msgp_gen_test.go
@@ -72,3 +72,63 @@ func BenchmarkUnmarshalEncodedBlockCert(b *testing.B) {
 		}
 	}
 }
+
+func TestMarshalUnmarshalPreEncodedBlockCert(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	v := PreEncodedBlockCert{}
+	bts := v.MarshalMsg(nil)
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func TestRandomizedEncodingPreEncodedBlockCert(t *testing.T) {
+	protocol.RunEncodingTest(t, &PreEncodedBlockCert{})
+}
+
+func BenchmarkMarshalMsgPreEncodedBlockCert(b *testing.B) {
+	v := PreEncodedBlockCert{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgPreEncodedBlockCert(b *testing.B) {
+	v := PreEncodedBlockCert{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalPreEncodedBlockCert(b *testing.B) {
+	v := PreEncodedBlockCert{}
+	bts := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This removes a few more uses of reflection-based msgp encoders/decoders in favor of code-generated encoders. 
- agreement: use generic dispatcher for encoding/decoding actions
- catchup / rpcs: use generated encoder/decoder for PreEncodedBlockCert

## Test Plan

Existing tests should pass, new tests added.