### PR TITLE
goal: don't fail asset info when the reserve holds nothing

### DIFF
--- a/cmd/goal/asset.go
+++ b/cmd/goal/asset.go
@@ -18,11 +18,14 @@ package main
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
 	"github.com/algorand/go-algorand/cmd/util/datadir"
+	apiclient "github.com/algorand/go-algorand/daemon/algod/api/client"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/libgoal"
 )
@@ -773,11 +776,21 @@ var infoAssetCmd = &cobra.Command{
 			asset.Params.Reserve = &asset.Params.Creator
 		}
 
+		// The reserve is an arbitrary address chosen at asset creation. It may
+		// not exist, or may never have opted in, in which case the account/asset
+		// lookup returns a 404. Treat a missing holding as a zero balance rather
+		// than failing the whole command, since the asset parameters themselves
+		// are still valid.
+		var reserveAmount uint64
 		reserve, err := client.AccountAssetInformation(*asset.Params.Reserve, assetID)
 		if err != nil {
-			reportErrorf(errorRequestFail, err)
+			var httpError apiclient.HTTPError
+			if !errors.As(err, &httpError) || httpError.StatusCode != http.StatusNotFound {
+				reportErrorf(errorRequestFail, err)
+			}
+		} else if reserve.AssetHolding != nil {
+			reserveAmount = reserve.AssetHolding.Amount
 		}
-		res := reserve.AssetHolding
 
 		fmt.Printf("Asset ID:         %d\n", assetID)
 		fmt.Printf("Creator:          %s\n", asset.Params.Creator)
@@ -793,8 +806,8 @@ var infoAssetCmd = &cobra.Command{
 		}
 		reportInfof("Unit name:        %s", units)
 		fmt.Printf("Maximum issue:    %s %s\n", assetDecimalsFmt(asset.Params.Total, asset.Params.Decimals), units)
-		fmt.Printf("Reserve amount:   %s %s\n", assetDecimalsFmt(res.Amount, asset.Params.Decimals), units)
-		fmt.Printf("Issued:           %s %s\n", assetDecimalsFmt(asset.Params.Total-res.Amount, asset.Params.Decimals), units)
+		fmt.Printf("Reserve amount:   %s %s\n", assetDecimalsFmt(reserveAmount, asset.Params.Decimals), units)
+		fmt.Printf("Issued:           %s %s\n", assetDecimalsFmt(asset.Params.Total-reserveAmount, asset.Params.Decimals), units)
 		fmt.Printf("Decimals:         %d\n", asset.Params.Decimals)
 		fmt.Printf("Default frozen:   %t\n", nilToZero(asset.Params.DefaultFrozen))
 		safeURL := ""

--- a/test/e2e-go/cli/goal/expect/goalAssetTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalAssetTest.exp
@@ -62,6 +62,25 @@ if { [catch {
         eof { catch wait result; if { [lindex $result 3] != 0 } { ::AlgorandGoal::Abort "Unable to query asset info" } }
     }
 
+    # Regression test: a reserve account that does not exist or has not opted in
+    # must not cause "asset info" to fail. Its holding is treated as zero.
+    set FOREIGN_RESERVE_ADDRESS R2LPJRKONXXURMO6F65VHGCXPKAZM4GGDC5KH5VZ2W3ZFIZYQRAQT7GLM4
+    set timeout 20
+    spawn goal asset create --creator $PRIMARY_ACCOUNT_ADDRESS --total 90000 --name 'reserveassetname' --unitname 'r' --reserve $FOREIGN_RESERVE_ADDRESS --datadir $TEST_PRIMARY_NODE_DIR
+    expect {
+        timeout { close; ::AlgorandGoal::Abort "Asset Create (foreign reserve) timed out" }
+        -re "Created asset with asset index *" { set ASSET_CREATED 1; exp_continue }
+        eof { catch wait result; if { [lindex $result 3] != 0 } { ::AlgorandGoal::Abort "Unable to create asset with foreign reserve" } }
+    }
+
+    set timeout 5
+    spawn goal asset info --creator $PRIMARY_ACCOUNT_ADDRESS --unitname 'r' --datadir $TEST_PRIMARY_NODE_DIR
+    expect {
+        timeout { close; ::AlgorandGoal::Abort "Asset Info (foreign reserve) Failed" }
+        "Reserve amount:   0 r" { puts "Successfully displayed asset with a non-holding reserve"; close;}
+        eof { catch wait result; if { [lindex $result 3] != 0 } { ::AlgorandGoal::Abort "asset info failed for an asset whose reserve does not hold it" } }
+    }
+
     # Shutdown the network
     ::AlgorandGoal::StopNetwork $NETWORK_NAME $TEST_ROOT_DIR
 } EXCEPTION] } {

--- a/test/scripts/e2e_subs/asset-misc.sh
+++ b/test/scripts/e2e_subs/asset-misc.sh
@@ -102,14 +102,15 @@ fi
 # case 3: asset created with manager, reserve, freezer, and clawback different from the creator
 ${gcmd} asset create --creator "${ACCOUNT}" --manager "${ACCOUNTB}" --reserve "${ACCOUNTC}" --freezer "${ACCOUNTD}" --clawback "${ACCOUNTE}" --name "${ASSET_NAME}" --unitname dma --total 1000000000000 --asseturl "${ASSET_URL}"
 
-# case 3a: asset info should fail if reserve address has not opted into the asset.
-EXPERROR='account asset info not found'
+# case 3a: asset info should succeed even if the reserve address has not opted
+# into the asset. A missing reserve holding is reported as a zero balance
+# rather than failing the whole command.
 RES=$(${gcmd} asset info --creator $ACCOUNT --unitname dma 2>&1 || true)
-if [[ $RES != *"${EXPERROR}"* ]]; then
-    date "+${scriptname} FAIL asset info should fail unless reserve account was opted in %Y%m%d_%H%M%S"
-    exit 1
-else
+if [[ $RES == *"Reserve amount:   0"* ]] && [[ $RES == *"Issued:           1000000000000"* ]]; then
     echo ok
+else
+    date "+${scriptname} FAIL asset info should report a zero reserve when the reserve has not opted in %Y%m%d_%H%M%S"
+    exit 1
 fi
 
 # case 3b: Reserve address opts into the the asset, and gets asset info successfully.


### PR DESCRIPTION
goal asset info fetches the reserve account's holding to display the reserve amount and issued totals. When the reserve is an address that does not exist or never opted in, that lookup returns a 404, which aborted the whole command even though the asset parameters are valid.

Treat a 404 (or a nil holding) as a zero reserve balance instead, so the command reports Reserve amount: 0 and Issued: <total>. This matches the graceful 404 handling already used in goal account info and goal app read. Any other error still fails as before.

Adds an expect regression test covering an asset whose reserve does not hold it. I also discovered and added a new commit because `asset-misc.sh` case 3a, which (surprisingly) asserted the old behaviour of failing with "account asset info not found" when the reserve had not opted in. It now expects success with "Reserve amount: 0".