### PR TITLE
Txn: Make challenge discount explicit in HeartbeatTransaction

### DIFF
--- a/data/transactions/heartbeat.go
+++ b/data/transactions/heartbeat.go
@@ -50,21 +50,54 @@ type HeartbeatTxnFields struct {
 
 	// HbKeyDilution must match HbAddress account's current KeyDilution.
 	HbKeyDilution uint64 `codec:"kd"`
+
+	// HbChallengeDiscount requests the challenge fee discount: when set, the
+	// required fee is reduced by one min fee. It is optional even for a
+	// challenged account (an account willing to pay the normal fee can leave it
+	// off), so it is a request, not an assertion. apply verifies HbAddress is
+	// actually under challenge before granting it. The flag is only allowed
+	// once transaction size pricing is enabled (proto.TxnSizePricingEnabled());
+	// it makes sense to think in terms of transaction fields changing fees
+	// now, so it needs no separate consensus flag. Before then, the discount
+	// was inferred from an underpaid singleton heartbeat instead (see
+	// wellFormed and apply).
+	HbChallengeDiscount bool `codec:"c"`
 }
 
 // wellFormed performs some stateless checks on the Heartbeat transaction
 func (hb HeartbeatTxnFields) wellFormed(header Header, proto config.ConsensusParams) error {
-	// If this is a free/cheap heartbeat, it must be very simple.
-	factor := basics.AddSaturate(header.FeeContribution(proto), 1e6)
-	// Fee a normal (non-cheap) heartbeat owes, computed the same way as a
-	// top-level group: no cost multiplier (1e6), no prior residue. FeeForUsage saturates.
-	requiredFee, _, _ := proto.MinFee().FeeForUsage(factor, 1e6, 0)
-	if header.Fee.LessThan(requiredFee) && header.Group.IsZero() {
-		kind := "free"
-		if header.Fee.Raw > 0 {
-			kind = "cheap"
+	// A heartbeat that claims the challenge discount must be very simple, so it
+	// can't smuggle in other work at a reduced fee. kind describes how the
+	// discount is being claimed (only for error messages); an empty kind means
+	// no discount, so no restrictions apply.
+	var kind string
+	if proto.TxnSizePricingEnabled() {
+		// The discount is claimed explicitly with HbChallengeDiscount.
+		if hb.HbChallengeDiscount {
+			kind = "discounted"
 		}
+	} else {
+		// Before the explicit-discount rule, HbChallengeDiscount has no meaning
+		// and must not be set, so it can't alter a heartbeat's encoding under the
+		// old rules.
+		if hb.HbChallengeDiscount {
+			return errors.New("tx.HbChallengeDiscount set before it is allowed")
+		}
+		// The discount is instead inferred: a singleton heartbeat that underpays
+		// the normal fee is claiming it.
+		factor := basics.AddSaturate(header.FeeContribution(proto), 1e6)
+		// Fee a normal (non-cheap) heartbeat owes, computed the same way as a
+		// top-level group: no cost multiplier (1e6), no prior residue. FeeForUsage saturates.
+		requiredFee, _, _ := proto.MinFee().FeeForUsage(factor, 1e6, 0)
+		if header.Fee.LessThan(requiredFee) && header.Group.IsZero() {
+			kind = "free"
+			if header.Fee.Raw > 0 {
+				kind = "cheap"
+			}
+		}
+	}
 
+	if kind != "" {
 		if len(header.Note) > 0 {
 			return fmt.Errorf("tx.Note is set in %s heartbeat", kind)
 		}

--- a/data/transactions/heartbeat_test.go
+++ b/data/transactions/heartbeat_test.go
@@ -36,6 +36,7 @@ func TestWellFormedHeartbeatErrors(t *testing.T) {
 
 	futureProto := config.Consensus[protocol.ConsensusFuture]
 	protoV36 := config.Consensus[protocol.ConsensusV36]
+	protoV41 := config.Consensus[protocol.ConsensusV41]
 	addr1, err := basics.UnmarshalChecksumAddress("NDQCJNNY5WWWFLP4GFZ7MEF2QJSMZYK6OWIV2AQ7OMAVLEFCGGRHFPKJJA")
 	require.NoError(t, err)
 	okHeader := Header{
@@ -131,6 +132,120 @@ func TestWellFormedHeartbeatErrors(t *testing.T) {
 			proto: futureProto,
 		},
 		{
+			// With the explicit-discount rule, the restrictions apply to a heartbeat that
+			// claims the discount with HbChallengeDiscount, regardless of fee.
+			tx: Transaction{
+				Type: protocol.HeartbeatTx,
+				Header: Header{
+					Sender:     addr1,
+					Fee:        futureProto.MinFee(),
+					LastValid:  105,
+					FirstValid: 100,
+					Note:       []byte{0x01},
+				},
+				HeartbeatTxnFields: &HeartbeatTxnFields{
+					HbProof: crypto.HeartbeatProof{
+						Sig: [64]byte{0x01},
+					},
+					HbSeed:              committee.Seed{0x02},
+					HbVoteID:            crypto.OneTimeSignatureVerifier{0x03},
+					HbKeyDilution:       10,
+					HbChallengeDiscount: true,
+				},
+			},
+			proto:         futureProto,
+			expectedError: fmt.Errorf("tx.Note is set in discounted heartbeat"),
+		},
+		{
+			tx: Transaction{
+				Type: protocol.HeartbeatTx,
+				Header: Header{
+					Sender:     addr1,
+					Fee:        futureProto.MinFee(),
+					LastValid:  105,
+					FirstValid: 100,
+					Lease:      [32]byte{0x01},
+				},
+				HeartbeatTxnFields: &HeartbeatTxnFields{
+					HbProof: crypto.HeartbeatProof{
+						Sig: [64]byte{0x01},
+					},
+					HbSeed:              committee.Seed{0x02},
+					HbVoteID:            crypto.OneTimeSignatureVerifier{0x03},
+					HbKeyDilution:       10,
+					HbChallengeDiscount: true,
+				},
+			},
+			proto:         futureProto,
+			expectedError: fmt.Errorf("tx.Lease is set in discounted heartbeat"),
+		},
+		{
+			tx: Transaction{
+				Type: protocol.HeartbeatTx,
+				Header: Header{
+					Sender:     addr1,
+					LastValid:  105,
+					FirstValid: 100,
+					RekeyTo:    [32]byte{0x01},
+				},
+				HeartbeatTxnFields: &HeartbeatTxnFields{
+					HbProof: crypto.HeartbeatProof{
+						Sig: [64]byte{0x01},
+					},
+					HbSeed:              committee.Seed{0x02},
+					HbVoteID:            crypto.OneTimeSignatureVerifier{0x03},
+					HbKeyDilution:       10,
+					HbChallengeDiscount: true,
+				},
+			},
+			proto:         futureProto,
+			expectedError: fmt.Errorf("tx.RekeyTo is set in discounted heartbeat"),
+		},
+		{
+			// A large Note is fine on a paid heartbeat, but a challenged
+			// heartbeat may carry no Note at all.
+			tx: Transaction{
+				Type: protocol.HeartbeatTx,
+				Header: Header{
+					Sender:     addr1,
+					LastValid:  105,
+					FirstValid: 100,
+					Note:       make([]byte, 1025),
+				},
+				HeartbeatTxnFields: &HeartbeatTxnFields{
+					HbProof: crypto.HeartbeatProof{
+						Sig: [64]byte{0x01},
+					},
+					HbSeed:              committee.Seed{0x02},
+					HbVoteID:            crypto.OneTimeSignatureVerifier{0x03},
+					HbKeyDilution:       10,
+					HbChallengeDiscount: true,
+				},
+			},
+			proto:         futureProto,
+			expectedError: fmt.Errorf("tx.Note is set in discounted heartbeat"),
+		},
+		{
+			// HbChallengeDiscount has no meaning before the explicit-discount rule and is rejected.
+			tx: Transaction{
+				Type:   protocol.HeartbeatTx,
+				Header: okHeader,
+				HeartbeatTxnFields: &HeartbeatTxnFields{
+					HbProof: crypto.HeartbeatProof{
+						Sig: [64]byte{0x01},
+					},
+					HbSeed:              committee.Seed{0x02},
+					HbVoteID:            crypto.OneTimeSignatureVerifier{0x03},
+					HbKeyDilution:       10,
+					HbChallengeDiscount: true,
+				},
+			},
+			proto:         protoV41,
+			expectedError: fmt.Errorf("tx.HbChallengeDiscount set before it is allowed"),
+		},
+		{
+			// before the explicit-discount rule, the same restrictions apply to an underpaid
+			// singleton heartbeat, inferred from its low fee.
 			tx: Transaction{
 				Type: protocol.HeartbeatTx,
 				Header: Header{
@@ -149,72 +264,7 @@ func TestWellFormedHeartbeatErrors(t *testing.T) {
 					HbKeyDilution: 10,
 				},
 			},
-			proto:         futureProto,
-			expectedError: fmt.Errorf("tx.Note is set in cheap heartbeat"),
-		},
-		{
-			tx: Transaction{
-				Type: protocol.HeartbeatTx,
-				Header: Header{
-					Sender:     addr1,
-					Fee:        basics.MicroAlgos{Raw: 100},
-					LastValid:  105,
-					FirstValid: 100,
-					Lease:      [32]byte{0x01},
-				},
-				HeartbeatTxnFields: &HeartbeatTxnFields{
-					HbProof: crypto.HeartbeatProof{
-						Sig: [64]byte{0x01},
-					},
-					HbSeed:        committee.Seed{0x02},
-					HbVoteID:      crypto.OneTimeSignatureVerifier{0x03},
-					HbKeyDilution: 10,
-				},
-			},
-			proto:         futureProto,
-			expectedError: fmt.Errorf("tx.Lease is set in cheap heartbeat"),
-		},
-		{
-			tx: Transaction{
-				Type: protocol.HeartbeatTx,
-				Header: Header{
-					Sender:     addr1,
-					LastValid:  105,
-					FirstValid: 100,
-					RekeyTo:    [32]byte{0x01},
-				},
-				HeartbeatTxnFields: &HeartbeatTxnFields{
-					HbProof: crypto.HeartbeatProof{
-						Sig: [64]byte{0x01},
-					},
-					HbSeed:        committee.Seed{0x02},
-					HbVoteID:      crypto.OneTimeSignatureVerifier{0x03},
-					HbKeyDilution: 10,
-				},
-			},
-			proto:         futureProto,
-			expectedError: fmt.Errorf("tx.RekeyTo is set in free heartbeat"),
-		},
-		{
-			tx: Transaction{
-				Type: protocol.HeartbeatTx,
-				Header: Header{
-					Sender:     addr1,
-					LastValid:  105,
-					FirstValid: 100,
-					Note:       make([]byte, 1025),   // Big notes are legal now
-					Fee:        futureProto.MinFee(), // But they need a bigger fee
-				},
-				HeartbeatTxnFields: &HeartbeatTxnFields{
-					HbProof: crypto.HeartbeatProof{
-						Sig: [64]byte{0x01},
-					},
-					HbSeed:        committee.Seed{0x02},
-					HbVoteID:      crypto.OneTimeSignatureVerifier{0x03},
-					HbKeyDilution: 10,
-				},
-			},
-			proto:         futureProto,
+			proto:         protoV41,
 			expectedError: fmt.Errorf("tx.Note is set in cheap heartbeat"),
 		},
 	}

--- a/data/transactions/msgp_gen.go
+++ b/data/transactions/msgp_gen.go
@@ -3072,27 +3072,31 @@ func HeaderMaxSize() (s int) {
 func (z *HeartbeatTxnFields) MarshalMsg(b []byte) (o []byte) {
 	o = msgp.Require(b, z.Msgsize())
 	// omitempty: check for empty values
-	zb0001Len := uint32(5)
-	var zb0001Mask uint8 /* 6 bits */
+	zb0001Len := uint32(6)
+	var zb0001Mask uint8 /* 7 bits */
 	if (*z).HbAddress.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x2
 	}
-	if (*z).HbKeyDilution == 0 {
+	if (*z).HbChallengeDiscount == false {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if (*z).HbProof.MsgIsZero() {
+	if (*z).HbKeyDilution == 0 {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
-	if (*z).HbSeed.MsgIsZero() {
+	if (*z).HbProof.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x10
 	}
-	if (*z).HbVoteID.MsgIsZero() {
+	if (*z).HbSeed.MsgIsZero() {
 		zb0001Len--
 		zb0001Mask |= 0x20
+	}
+	if (*z).HbVoteID.MsgIsZero() {
+		zb0001Len--
+		zb0001Mask |= 0x40
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -3103,21 +3107,26 @@ func (z *HeartbeatTxnFields) MarshalMsg(b []byte) (o []byte) {
 			o = (*z).HbAddress.MarshalMsg(o)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not empty
+			// string "c"
+			o = append(o, 0xa1, 0x63)
+			o = msgp.AppendBool(o, (*z).HbChallengeDiscount)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not empty
 			// string "kd"
 			o = append(o, 0xa2, 0x6b, 0x64)
 			o = msgp.AppendUint64(o, (*z).HbKeyDilution)
 		}
-		if (zb0001Mask & 0x8) == 0 { // if not empty
+		if (zb0001Mask & 0x10) == 0 { // if not empty
 			// string "prf"
 			o = append(o, 0xa3, 0x70, 0x72, 0x66)
 			o = (*z).HbProof.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x10) == 0 { // if not empty
+		if (zb0001Mask & 0x20) == 0 { // if not empty
 			// string "sd"
 			o = append(o, 0xa2, 0x73, 0x64)
 			o = (*z).HbSeed.MarshalMsg(o)
 		}
-		if (zb0001Mask & 0x20) == 0 { // if not empty
+		if (zb0001Mask & 0x40) == 0 { // if not empty
 			// string "vid"
 			o = append(o, 0xa3, 0x76, 0x69, 0x64)
 			o = (*z).HbVoteID.MarshalMsg(o)
@@ -3190,6 +3199,14 @@ func (z *HeartbeatTxnFields) UnmarshalMsgWithState(bts []byte, st msgp.Unmarshal
 			}
 		}
 		if zb0001 > 0 {
+			zb0001--
+			(*z).HbChallengeDiscount, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "HbChallengeDiscount")
+				return
+			}
+		}
+		if zb0001 > 0 {
 			err = msgp.ErrTooManyArrayFields(zb0001)
 			if err != nil {
 				err = msgp.WrapError(err, "struct-from-array")
@@ -3242,6 +3259,12 @@ func (z *HeartbeatTxnFields) UnmarshalMsgWithState(bts []byte, st msgp.Unmarshal
 					err = msgp.WrapError(err, "HbKeyDilution")
 					return
 				}
+			case "c":
+				(*z).HbChallengeDiscount, bts, err = msgp.ReadBoolBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "HbChallengeDiscount")
+					return
+				}
 			default:
 				err = msgp.ErrNoField(string(field))
 				if err != nil {
@@ -3265,18 +3288,18 @@ func (_ *HeartbeatTxnFields) CanUnmarshalMsg(z interface{}) bool {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *HeartbeatTxnFields) Msgsize() (s int) {
-	s = 1 + 2 + (*z).HbAddress.Msgsize() + 4 + (*z).HbProof.Msgsize() + 3 + (*z).HbSeed.Msgsize() + 4 + (*z).HbVoteID.Msgsize() + 3 + msgp.Uint64Size
+	s = 1 + 2 + (*z).HbAddress.Msgsize() + 4 + (*z).HbProof.Msgsize() + 3 + (*z).HbSeed.Msgsize() + 4 + (*z).HbVoteID.Msgsize() + 3 + msgp.Uint64Size + 2 + msgp.BoolSize
 	return
 }
 
 // MsgIsZero returns whether this is a zero value
 func (z *HeartbeatTxnFields) MsgIsZero() bool {
-	return ((*z).HbAddress.MsgIsZero()) && ((*z).HbProof.MsgIsZero()) && ((*z).HbSeed.MsgIsZero()) && ((*z).HbVoteID.MsgIsZero()) && ((*z).HbKeyDilution == 0)
+	return ((*z).HbAddress.MsgIsZero()) && ((*z).HbProof.MsgIsZero()) && ((*z).HbSeed.MsgIsZero()) && ((*z).HbVoteID.MsgIsZero()) && ((*z).HbKeyDilution == 0) && ((*z).HbChallengeDiscount == false)
 }
 
 // HeartbeatTxnFieldsMaxSize returns a maximum valid message size for this message type
 func HeartbeatTxnFieldsMaxSize() (s int) {
-	s = 1 + 2 + basics.AddressMaxSize() + 4 + crypto.HeartbeatProofMaxSize() + 3 + committee.SeedMaxSize() + 4 + crypto.OneTimeSignatureVerifierMaxSize() + 3 + msgp.Uint64Size
+	s = 1 + 2 + basics.AddressMaxSize() + 4 + crypto.HeartbeatProofMaxSize() + 3 + committee.SeedMaxSize() + 4 + crypto.OneTimeSignatureVerifierMaxSize() + 3 + msgp.Uint64Size + 2 + msgp.BoolSize
 	return
 }
 

--- a/data/transactions/signedtxn.go
+++ b/data/transactions/signedtxn.go
@@ -132,13 +132,7 @@ func (s SignedTxn) signatureFeeContribution(proto config.ConsensusParams) basics
 // sigs).  It is expressed as a fixed-point integer with 6 digits of
 // precision. So 1e6 is a normal base fee transaction.
 func (s SignedTxn) FeeFactor(proto config.ConsensusParams) basics.Micros {
-	factor := s.Txn.feeFactor(proto)
-	if s.Txn.isSingletonHeartbeat() && s.Txn.Fee.IsZero() {
-		// Free singleton heartbeats do not pay signature surcharges.
-		return factor
-	}
-	factor = basics.AddSaturate(factor, s.signatureFeeContribution(proto))
-	return factor
+	return basics.AddSaturate(s.signatureFeeContribution(proto), s.Txn.feeFactor(proto))
 }
 
 // AssembleSignedTxn assembles a multisig-signed transaction from a transaction an optional sig, and an optional multisig.

--- a/data/transactions/signedtxn_test.go
+++ b/data/transactions/signedtxn_test.go
@@ -122,6 +122,14 @@ func TestSignedTxnFeeFactorPQSignatureContribution(t *testing.T) {
 	pqPaidSingletonHeartbeat.Txn.Fee = proto.MinFee()
 	pqGroupedHeartbeat := pqSingletonHeartbeat
 	pqGroupedHeartbeat.Txn.Group = crypto.Digest{1}
+	// A challenged heartbeat gets one min fee off, but still owes any signature
+	// surcharge: only the base fee is discounted.
+	challengedHeartbeat := regularSingletonHeartbeat
+	challengedHeartbeat.Txn.HeartbeatTxnFields = &HeartbeatTxnFields{HbChallengeDiscount: true}
+	pqChallengedHeartbeat := pqSingletonHeartbeat
+	pqChallengedHeartbeat.Txn.HeartbeatTxnFields = &HeartbeatTxnFields{HbChallengeDiscount: true}
+	pqChallengedGrouped := pqChallengedHeartbeat
+	pqChallengedGrouped.Txn.Group = crypto.Digest{1}
 
 	for _, stxn := range []SignedTxn{baseTxn, regularSigned, msigSigned, lsigSigned} {
 		require.Equal(t, basics.Micros(1e6), stxn.FeeFactor(proto))
@@ -130,11 +138,17 @@ func TestSignedTxnFeeFactorPQSignatureContribution(t *testing.T) {
 	require.Equal(t, basics.Micros(1e6), unknownPQSigned.FeeFactor(proto))
 	require.Equal(t, basics.Micros(3e6), pqSigned.FeeFactor(proto))
 	require.Equal(t, basics.Micros(3e6), pqAndRegularSigned.FeeFactor(proto))
-	require.Equal(t, basics.Micros(0), regularSingletonHeartbeat.FeeFactor(proto))
-	require.Equal(t, basics.Micros(0), pqSingletonHeartbeat.FeeFactor(proto))
-	require.Equal(t, basics.Micros(0), mixedSingletonHeartbeat.FeeFactor(proto))
-	require.Equal(t, basics.Micros(2e6), pqPaidSingletonHeartbeat.FeeFactor(proto))
+	// With the explicit-discount rule a plain heartbeat pays the base fee (plus surcharges),
+	// whether or not it is a singleton.
+	require.Equal(t, basics.Micros(1e6), regularSingletonHeartbeat.FeeFactor(proto))
+	require.Equal(t, basics.Micros(3e6), pqSingletonHeartbeat.FeeFactor(proto))
+	require.Equal(t, basics.Micros(3e6), mixedSingletonHeartbeat.FeeFactor(proto))
+	require.Equal(t, basics.Micros(3e6), pqPaidSingletonHeartbeat.FeeFactor(proto))
 	require.Equal(t, basics.Micros(3e6), pqGroupedHeartbeat.FeeFactor(proto))
+	// The challenge discount removes exactly one min fee, leaving surcharges.
+	require.Equal(t, basics.Micros(0), challengedHeartbeat.FeeFactor(proto))
+	require.Equal(t, basics.Micros(2e6), pqChallengedHeartbeat.FeeFactor(proto))
+	require.Equal(t, basics.Micros(2e6), pqChallengedGrouped.FeeFactor(proto))
 
 	requiredFee, _, overflow := proto.MinFee().FeeForUsage(pqSigned.FeeFactor(proto), 1e6, 0)
 	require.False(t, overflow)

--- a/data/transactions/transaction.go
+++ b/data/transactions/transaction.go
@@ -199,12 +199,18 @@ func (tx Transaction) feeFactor(proto config.ConsensusParams) basics.Micros {
 	case protocol.StateProofTx:
 		return 0
 	case protocol.HeartbeatTx:
-		if tx.isSingletonHeartbeat() {
-			// Not every such heartbeat is free. We confirm a
-			// low/no fee singleton heartbeat is legal in heartbeat's
-			// wellFormed() and in apply/heartbeat.go (for the dynamic check for
-			// challenge).
-			return 0
+		// A heartbeat that claims the challenge discount owes one less min fee.
+		// wellFormed() forbids extras (Note, etc.) on such a heartbeat, so factor
+		// is 1e6 for it and this drops it to 0. apply/heartbeat.go verifies the
+		// account is actually under challenge. The explicit discount rule shares
+		// the transaction-size-pricing upgrade; before it, the same discount is
+		// inferred from an underpaid singleton heartbeat instead.
+		if proto.TxnSizePricingEnabled() {
+			if tx.HeartbeatTxnFields != nil && tx.HeartbeatTxnFields.HbChallengeDiscount {
+				factor = basics.SubSaturate(factor, basics.Micros(1e6))
+			}
+		} else if tx.isSingletonHeartbeat() {
+			factor = basics.SubSaturate(factor, basics.Micros(1e6))
 		}
 	case protocol.ApplicationCallTx:
 		factor = basics.AddSaturate(factor, tx.ApplicationCallTxnFields.feeContribution(proto))

--- a/data/transactions/transaction_test.go
+++ b/data/transactions/transaction_test.go
@@ -367,20 +367,31 @@ func TestFeeFactor_StateProofAndHeartbeat(t *testing.T) {
 	}
 	assert.Equal(t, basics.Micros(0), stateProofTx.feeFactor(vFuture), "StateProof should be free")
 
-	// Singleton heartbeat (no group) should be free. Again, having a note is
-	// not allowed in a free heartbeat, but that is checked elsewhere.
+	// With the explicit-discount rule a plain heartbeat pays the normal fee whether or not
+	// it is a singleton; only a challenged heartbeat is discounted.
 	singletonHeartbeat := Transaction{
 		Type: protocol.HeartbeatTx,
 		Header: Header{
 			Sender:     addr,
 			FirstValid: 100,
 			LastValid:  200,
-			Note:       make([]byte, 2048), // Large note
 		},
+		HeartbeatTxnFields: &HeartbeatTxnFields{},
 	}
-	assert.Equal(t, basics.Micros(0), singletonHeartbeat.feeFactor(vFuture), "Singleton heartbeat should be free")
+	assert.Equal(t, basics.Micros(1e6), singletonHeartbeat.feeFactor(vFuture), "plain singleton heartbeat pays base fee")
 
-	// Grouped heartbeat should have normal fee
+	// A challenged heartbeat owes one less min fee. WellFormed forbids extras
+	// (like a Note) on it, so the base fee is all there is, and it drops to 0.
+	challengedHeartbeat := singletonHeartbeat
+	challengedHeartbeat.HeartbeatTxnFields = &HeartbeatTxnFields{HbChallengeDiscount: true}
+	assert.Zero(t, challengedHeartbeat.feeFactor(vFuture))
+
+	// The discount applies inside a group too.
+	challengedGrouped := challengedHeartbeat
+	challengedGrouped.Group = crypto.Digest{1}
+	assert.Zero(t, challengedGrouped.feeFactor(vFuture))
+
+	// Grouped (non-challenged) heartbeat should have normal fee
 	groupedHeartbeat := Transaction{
 		Type: protocol.HeartbeatTx,
 		Header: Header{
@@ -390,21 +401,29 @@ func TestFeeFactor_StateProofAndHeartbeat(t *testing.T) {
 			Note:       make([]byte, 1024),
 			Group:      crypto.Digest{1}, // Has a group
 		},
+		HeartbeatTxnFields: &HeartbeatTxnFields{},
 	}
 	assert.Equal(t, basics.Micros(1e6), groupedHeartbeat.feeFactor(vFuture), "Grouped heartbeat should have base fee")
 
 	// Grouped heartbeat with big note should have the extra charge for it
-	groupedHeartbeatBigNote := Transaction{
+	groupedHeartbeatBigNote := groupedHeartbeat
+	groupedHeartbeatBigNote.Note = make([]byte, 1124)
+	assert.Equal(t, basics.Micros(1_010_000), groupedHeartbeatBigNote.feeFactor(vFuture), "Grouped heartbeat should have extra fee")
+
+	// before the explicit-discount rule, any singleton heartbeat is free, even
+	// with a big note. (though it will fail at wellFormed and apply time)
+	v41 := config.Consensus[protocol.ConsensusV41]
+	oldSingletonHeartbeat := Transaction{
 		Type: protocol.HeartbeatTx,
 		Header: Header{
 			Sender:     addr,
 			FirstValid: 100,
 			LastValid:  200,
-			Note:       make([]byte, 1124),
-			Group:      crypto.Digest{1}, // Has a group
+			Note:       make([]byte, 2048), // Large note
 		},
+		HeartbeatTxnFields: &HeartbeatTxnFields{},
 	}
-	assert.Equal(t, basics.Micros(1_010_000), groupedHeartbeatBigNote.feeFactor(vFuture), "Grouped heartbeat should have extra fee")
+	assert.Zero(t, oldSingletonHeartbeat.feeFactor(v41))
 }
 
 // TestWellFormed_BigNotes tests Note size validation with MaxAbsoluteTxnNoteBytes

--- a/data/txntest/txn.go
+++ b/data/txntest/txn.go
@@ -95,11 +95,12 @@ type Txn struct {
 	StateProof     stateproof.StateProof
 	StateProofMsg  stateproofmsg.Message
 
-	HbAddress     basics.Address
-	HbProof       crypto.HeartbeatProof
-	HbSeed        committee.Seed
-	HbVoteID      crypto.OneTimeSignatureVerifier
-	HbKeyDilution uint64
+	HbAddress           basics.Address
+	HbProof             crypto.HeartbeatProof
+	HbSeed              committee.Seed
+	HbVoteID            crypto.OneTimeSignatureVerifier
+	HbKeyDilution       uint64
+	HbChallengeDiscount bool
 }
 
 // internalCopy "finishes" a shallow copy done by a simple Go assignment by
@@ -273,11 +274,12 @@ func (tx Txn) Txn() transactions.Transaction {
 	}
 
 	hb := &transactions.HeartbeatTxnFields{
-		HbAddress:     tx.HbAddress,
-		HbProof:       tx.HbProof,
-		HbSeed:        tx.HbSeed,
-		HbVoteID:      tx.HbVoteID,
-		HbKeyDilution: tx.HbKeyDilution,
+		HbAddress:           tx.HbAddress,
+		HbProof:             tx.HbProof,
+		HbSeed:              tx.HbSeed,
+		HbVoteID:            tx.HbVoteID,
+		HbKeyDilution:       tx.HbKeyDilution,
+		HbChallengeDiscount: tx.HbChallengeDiscount,
 	}
 	if hb.MsgIsZero() {
 		hb = nil

--- a/heartbeat/service.go
+++ b/heartbeat/service.go
@@ -191,6 +191,13 @@ func (s *Service) prepareHeartbeat(pr account.ParticipationRecordForRound, lates
 		HbSeed:        latest.Seed,
 		HbVoteID:      pr.Voting.OneTimeSignatureVerifier,
 		HbKeyDilution: pr.KeyDilution,
+		// Once the explicit-discount rule is active (gated on transaction size
+		// pricing), claim the challenge discount so the zero-fee heartbeat covers
+		// its own (nonexistent) fee. The service only heartbeats accounts it
+		// found under challenge, so this is legitimate. Before then the zero fee
+		// alone signals the claim, and the flag must stay unset (WellFormed
+		// rejects it).
+		HbChallengeDiscount: config.Consensus[latest.CurrentProtocol].TxnSizePricingEnabled(),
 	}
 
 	return stxn

--- a/heartbeat/service_test.go
+++ b/heartbeat/service_test.go
@@ -304,6 +304,8 @@ func TestHeartbeatOnlyWhenChallenged(t *testing.T) {
 	a.Len(txns[0], 1)
 	a.Equal(txns[0][0].Txn.Type, protocol.HeartbeatTx)
 	a.Equal(txns[0][0].Txn.HbAddress, joe)
+	// ConsensusFuture enables the explicit discount, so the service claims the discount.
+	a.True(txns[0][0].Txn.HbChallengeDiscount)
 
 	s.Stop()
 }

--- a/ledger/apply/heartbeat.go
+++ b/ledger/apply/heartbeat.go
@@ -31,22 +31,35 @@ func Heartbeat(hb transactions.HeartbeatTxnFields, header transactions.Header, b
 		return err
 	}
 
-	// In SummarizeFees, we do not charge for singleton (Group.IsZero)
-	// heartbeats. But we only _want_ to allow cheap heartbeats if the account
-	// is under challenge.
-
 	proto := balances.ConsensusParams()
-	headerFactor := basics.AddSaturate(header.FeeContribution(proto), 1e6)
 
-	// Fee a normal (non-cheap) heartbeat owes, computed the same way as a
-	// top-level group: no cost multiplier (1e6), no prior residue. FeeForUsage saturates.
-	requiredFee, _, _ := proto.MinFee().FeeForUsage(headerFactor, 1e6, 0)
-	if header.Fee.LessThan(requiredFee) && header.Group.IsZero() {
-		kind := "free"
-		if !header.Fee.IsZero() {
-			kind = "cheap"
+	// A heartbeat may claim the challenge fee discount (see feeFactor). When it
+	// does, we allow the discount only if the account really is under challenge:
+	// online, incentive eligible, and failing a current challenge. kind
+	// describes how the discount was claimed (for error messages); an empty kind
+	// means no discount, so no verification is needed.
+	var kind string
+	if proto.TxnSizePricingEnabled() {
+		if hb.HbChallengeDiscount {
+			kind = "discounted"
 		}
+	} else {
+		// Before the explicit-discount rule the discount is inferred: SummarizeFees
+		// does not charge for a singleton (Group.IsZero) heartbeat, so an underpaying
+		// singleton is the one claiming to be under challenge.
+		headerFactor := basics.AddSaturate(header.FeeContribution(proto), 1e6)
+		// Fee a normal (non-cheap) heartbeat owes, computed the same way as a
+		// top-level group: no cost multiplier (1e6), no prior residue. FeeForUsage saturates.
+		requiredFee, _, _ := proto.MinFee().FeeForUsage(headerFactor, 1e6, 0)
+		if header.Fee.LessThan(requiredFee) && header.Group.IsZero() {
+			kind = "free"
+			if !header.Fee.IsZero() {
+				kind = "cheap"
+			}
+		}
+	}
 
+	if kind != "" {
 		if account.Status != basics.Online {
 			return fmt.Errorf("%s heartbeat is not allowed for %s %+v", kind, account.Status, hb.HbAddress)
 		}

--- a/ledger/apply/heartbeat_test.go
+++ b/ledger/apply/heartbeat_test.go
@@ -79,14 +79,12 @@ func TestHeartbeat(t *testing.T) {
 	tx := test.Txn()
 
 	rnd := basics.Round(150)
-	// no fee
+	// Claiming the challenge discount when no challenge is active is rejected.
+	// (rnd 150 is well before the first ChallengeInterval.)
+	tx.HeartbeatTxnFields.HbChallengeDiscount = true
 	err := Heartbeat(*tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
-	require.ErrorContains(t, err, "free heartbeat")
-
-	// just as bad: cheap
-	tx.Fee = basics.MicroAlgos{Raw: 10}
-	err = Heartbeat(*tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, rnd)
-	require.ErrorContains(t, err, "cheap heartbeat")
+	require.ErrorContains(t, err, "discounted heartbeat")
+	tx.HeartbeatTxnFields.HbChallengeDiscount = false
 
 	// address fee
 	testProto := config.Consensus[testConsensusVersion]
@@ -126,7 +124,6 @@ func TestCheapRules(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	testConsensusVersion := protocol.ConsensusFuture
 	type tcase struct {
 		rnd              basics.Round
 		addrStart        byte
@@ -154,60 +151,67 @@ func TestCheapRules(t *testing.T) {
 		{1000 + half + 1, 0x01, basics.Offline, true, nil, empty, empty, "not allowed for Offline"},
 		{1000 + half + 1, 0x01, basics.Online, false, nil, empty, empty, "not allowed when not IncentiveEligible"},
 	}
-	for _, tc := range cases {
-		const keyDilution = 777
+	// The challenge-eligibility rules are identical before and after the
+	// explicit-discount rule; only how the discount is claimed differs. Before,
+	// it is inferred from a singleton that underpays (low Fee); after, it is
+	// claimed explicitly with HbChallengeDiscount.
+	for _, testConsensusVersion := range []protocol.ConsensusVersion{protocol.ConsensusV41, protocol.ConsensusFuture} {
+		explicit := config.Consensus[testConsensusVersion].TxnSizePricingEnabled()
+		for _, tc := range cases {
+			const keyDilution = 777
 
-		lv := basics.Round(tc.rnd + 10)
+			lv := basics.Round(tc.rnd + 10)
 
-		id := basics.OneTimeIDForRound(lv, keyDilution)
-		otss := crypto.GenerateOneTimeSignatureSecrets(1, 10) // This will cover rounds 1-10*777
+			id := basics.OneTimeIDForRound(lv, keyDilution)
+			otss := crypto.GenerateOneTimeSignatureSecrets(1, 10) // This will cover rounds 1-10*777
 
-		// Make sender in each test unique, but all with same first byte
-		sender := basics.Address{0x01}
-		voter := basics.Address{tc.addrStart}
-		mockBal := makeMockBalancesWithAccounts(testConsensusVersion, map[basics.Address]basics.AccountData{
-			sender: {
-				MicroAlgos: basics.MicroAlgos{Raw: 10_000_000},
-			},
-			voter: {
-				Status:            tc.status,
-				MicroAlgos:        basics.MicroAlgos{Raw: 100_000_000},
-				VoteID:            otss.OneTimeSignatureVerifier,
-				VoteKeyDilution:   keyDilution,
-				IncentiveEligible: tc.incentiveEligble,
-			},
-		})
+			sender := basics.Address{0x01}
+			voter := basics.Address{tc.addrStart}
+			mockBal := makeMockBalancesWithAccounts(testConsensusVersion, map[basics.Address]basics.AccountData{
+				sender: {
+					MicroAlgos: basics.MicroAlgos{Raw: 10_000_000},
+				},
+				voter: {
+					Status:            tc.status,
+					MicroAlgos:        basics.MicroAlgos{Raw: 100_000_000},
+					VoteID:            otss.OneTimeSignatureVerifier,
+					VoteKeyDilution:   keyDilution,
+					IncentiveEligible: tc.incentiveEligble,
+				},
+			})
 
-		seed := committee.Seed{0x01, 0x02, 0x03}
-		mockHdr := makeMockHeaders()
-		mockHdr.setFallback(bookkeeping.BlockHeader{
-			UpgradeState: bookkeeping.UpgradeState{
-				CurrentProtocol: testConsensusVersion,
-			},
-			Seed: seed,
-		})
-		txn := txntest.Txn{
-			Type:          protocol.HeartbeatTx,
-			Sender:        sender,
-			Fee:           basics.MicroAlgos{Raw: 1},
-			FirstValid:    tc.rnd - 10,
-			LastValid:     tc.rnd + 10,
-			Lease:         tc.lease,
-			Note:          tc.note,
-			RekeyTo:       tc.rekey,
-			HbAddress:     voter,
-			HbProof:       otss.Sign(id, seed).ToHeartbeatProof(),
-			HbSeed:        seed,
-			HbVoteID:      otss.OneTimeSignatureVerifier,
-			HbKeyDilution: keyDilution,
-		}
+			seed := committee.Seed{0x01, 0x02, 0x03}
+			mockHdr := makeMockHeaders()
+			mockHdr.setFallback(bookkeeping.BlockHeader{
+				UpgradeState: bookkeeping.UpgradeState{
+					CurrentProtocol: testConsensusVersion,
+				},
+				Seed: seed,
+			})
+			txn := txntest.Txn{
+				Type:                protocol.HeartbeatTx,
+				Sender:              sender,
+				Fee:                 basics.MicroAlgos{Raw: 1},
+				FirstValid:          tc.rnd - 10,
+				LastValid:           tc.rnd + 10,
+				Lease:               tc.lease,
+				Note:                tc.note,
+				RekeyTo:             tc.rekey,
+				HbAddress:           voter,
+				HbProof:             otss.Sign(id, seed).ToHeartbeatProof(),
+				HbSeed:              seed,
+				HbVoteID:            otss.OneTimeSignatureVerifier,
+				HbKeyDilution:       keyDilution,
+				HbChallengeDiscount: explicit,
+			}
 
-		tx := txn.Txn()
-		err := Heartbeat(*tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, tc.rnd)
-		if tc.err == "" {
-			assert.NoError(t, err)
-		} else {
-			assert.ErrorContains(t, err, tc.err, "%+v", tc)
+			tx := txn.Txn()
+			err := Heartbeat(*tx.HeartbeatTxnFields, tx.Header, mockBal, mockHdr, tc.rnd)
+			if tc.err == "" {
+				assert.NoError(t, err, "%s %+v", testConsensusVersion, tc)
+			} else {
+				assert.ErrorContains(t, err, tc.err, "%s %+v", testConsensusVersion, tc)
+			}
 		}
 	}
 }

--- a/ledger/eval_simple_test.go
+++ b/ledger/eval_simple_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/committee"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/data/transactions/logic"
 	"github.com/algorand/go-algorand/data/txntest"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	ledgertesting "github.com/algorand/go-algorand/ledger/testing"
@@ -1554,7 +1555,7 @@ func TestPQRekeyedAddressAuthorization(t *testing.T) {
 	require.ErrorContains(t, tryBlock([]transactions.SignedTxn{pqSpendByEd}), "should have been authorized by")
 }
 
-func TestPQChallengedAccountCanSelfHeartbeatForZeroFee(t *testing.T) {
+func TestPQChallengedAccountCanHeartbeatForZeroFee(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
@@ -1619,25 +1620,36 @@ func TestPQChallengedAccountCanSelfHeartbeatForZeroFee(t *testing.T) {
 	eval := dl.beginBlock()
 	require.Equal(t, heartbeatRound, eval.Round())
 
+	// A PQ account never pays for a PQ signature on its heartbeat. A heartbeat's
+	// sender is irrelevant to what it proves (onlineness is proven by HbProof,
+	// signed with the account's participation key), so it is sent by the same
+	// ordinary accepting logicsig everyone uses. That sender carries no PQ
+	// surcharge, and the challenge discount covers the base fee, so the account
+	// stays online for free despite authorizing spends with an expensive PQ key.
+	acceptingProgram := logic.MustAssemble(`#pragma version 11
+int 1`)
+	sender := basics.Address(logic.HashProgram(acceptingProgram))
+
 	lastValid := eval.Round() + 10
 	id := basics.OneTimeIDForRound(lastValid, keyDilution)
 	txn := transactions.Transaction{
 		Type: protocol.HeartbeatTx,
 		Header: transactions.Header{
-			Sender:      pqAcct.address,
+			Sender:      sender,
 			FirstValid:  lastHdr.Round,
 			LastValid:   lastValid,
 			GenesisHash: dl.generator.GenesisHash(),
 		},
 		HeartbeatTxnFields: &transactions.HeartbeatTxnFields{
-			HbAddress:     pqAcct.address,
-			HbProof:       otss.Sign(id, lastHdr.Seed).ToHeartbeatProof(),
-			HbSeed:        lastHdr.Seed,
-			HbVoteID:      otss.OneTimeSignatureVerifier,
-			HbKeyDilution: keyDilution,
+			HbAddress:           pqAcct.address,
+			HbProof:             otss.Sign(id, lastHdr.Seed).ToHeartbeatProof(),
+			HbSeed:              lastHdr.Seed,
+			HbVoteID:            otss.OneTimeSignatureVerifier,
+			HbKeyDilution:       keyDilution,
+			HbChallengeDiscount: true,
 		},
 	}
-	stxn := signPQRekeyTestTxn(t, pqAcct, txn, basics.Address{})
+	stxn := transactions.SignedTxn{Txn: txn, Lsig: transactions.LogicSig{Logic: acceptingProgram}}
 	txgroup := []transactions.SignedTxn{stxn}
 
 	require.NoError(t, eval.TestTransactionGroup(txgroup))


### PR DESCRIPTION
Rather than reproducing the fee calculation in `apply`, we now require that the transaction itself _say_ it wants a discount for being challenged.  wellFormed insists that such a transaction avoid using notes and such, and `apply` checks that such a transaction is actualy challenged.

This means that heartbeats are more natural - even discounted ones can appear in groups (though such a use is unlikely, I suppose).

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
