### PR TITLE
tests: network tags test fix

### DIFF
--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -61,6 +61,12 @@ var spec = transactions.SpecialAddresses{
 	RewardsPool: poolAddr,
 }
 
+func init() {
+	useEd25519Consensus := crypto.RandUint64()%2 == 0
+	fmt.Printf("Using Ed25519ConsensusBatchVerifier: %v\n", useEd25519Consensus)
+	crypto.SetEd25519BatchVerifier(useEd25519Consensus)
+}
+
 func verifyTxnGroup(stxs []transactions.SignedTxn, contextHdr *bookkeeping.BlockHeader) error {
 	_, err := txnGroup(stxs, contextHdr, nil, nil, nil)
 	return err

--- a/ledger/catchpointtracker_test.go
+++ b/ledger/catchpointtracker_test.go
@@ -1965,15 +1965,19 @@ func TestCatchpointFastUpdates(t *testing.T) {
 	wg.Wait()
 	ml.trackers.waitAccountsWriting()
 
-	for ml.trackers.getDbRound() <= basics.Round(proto.CatchpointLookback) {
-		// db round stuck <= 320? likely committedUpTo dropped some commit tasks, due to deferredCommits channel full
-		// so give it another try
+	// The racing committedUpTo calls above might not have produced a catchpoint label yet:
+	// 1. commit tasks could have been dropped (deferredCommits channel full), leaving dbRound behind, or
+	// 2. the only catchpoint round crossed had no first stage record, because no commit landed exactly
+	//    on its accountsRound (finishCatchpoint silently skips label creation in that case).
+	// In both cases re-driving committedUpTo(lastRound) advances dbRound across newer catchpoint
+	// rounds whose first stage records exist, so a label eventually appears.
+	require.Eventually(t, func() bool {
+		if ct.GetLastCatchpointLabel() != "" {
+			return true
+		}
 		ml.trackers.committedUpTo(lastRound)
-		require.Eventually(t, func() bool {
-			//ml.trackers.waitAccountsWriting()
-			return ml.trackers.getDbRound() > basics.Round(proto.CatchpointLookback)
-		}, 5*time.Second, 100*time.Millisecond)
-	}
+		return ct.GetLastCatchpointLabel() != ""
+	}, 10*time.Second, 100*time.Millisecond)
 
 	require.NotEmpty(t, ct.GetLastCatchpointLabel())
 }

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -361,7 +361,7 @@ func setupWebsocketNetworkABwithLogger(t *testing.T, countTarget int, log loggin
 	success = true
 	closeFunc := func() {
 		netStop(t, netB, "B")
-		netStop(t, netB, "A")
+		netStop(t, netA, "A")
 	}
 	return netA, netB, counter, closeFunc
 }
@@ -411,9 +411,28 @@ func TestWebsocketNetworkBasicInvalidTags(t *testing.T) { // nolint:paralleltest
 	log := logging.TestingLog(t)
 	log.SetOutput(&logOutput)
 	log.SetLevel(logging.Level(logging.Debug))
-	netA, netB, counter, closeFunc := setupWebsocketNetworkABwithLogger(t, 0, log)
 
-	defer closeFunc()
+	// set up two nodes without waiting for ready: the invalid tags cause the
+	// MsgOfInterest exchange to drop the connection, sometimes before the peer
+	// is counted toward readiness, so Ready() might never fire.
+	netA := makeTestWebsocketNode(t)
+	netA.config.GossipFanout = 1
+	netA.log = log
+	netA.Start()
+	defer netStop(t, netA, "A")
+
+	netB := makeTestWebsocketNode(t)
+	netB.config.GossipFanout = 1
+	netB.log = log
+	addrA, postListen := netA.Address()
+	require.True(t, postListen)
+	t.Log(addrA)
+	netB.phonebook.ReplacePeerList([]string{addrA}, "default", phonebook.RelayRole)
+	netB.Start()
+	defer netStop(t, netB, "B")
+
+	counter := newMessageCounter(t, 0)
+	netB.RegisterHandlers([]TaggedMessageHandler{{Tag: protocol.TxnTag, MessageHandler: counter}})
 	// register a handler that should never get called, because the message will never be delivered
 	netB.RegisterHandlers([]TaggedMessageHandler{
 		{Tag: "XX", MessageHandler: HandlerFunc(func(msg IncomingMessage) OutgoingMessage {
@@ -424,13 +443,9 @@ func TestWebsocketNetworkBasicInvalidTags(t *testing.T) { // nolint:paralleltest
 	// it should not go through because the defaultSendMessageTags should not be accepted
 	// and the connection should be dropped
 	netA.Broadcast(context.Background(), "XX", []byte("foo"), false, nil)
-	for p := 0; p < 100; p++ {
-		if strings.Contains(logOutput.String(), "wsPeer handleMessageOfInterest: could not unmarshall message from") {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	require.Contains(t, logOutput.String(), "wsPeer handleMessageOfInterest: could not unmarshall message from")
+	require.Eventually(t, func() bool {
+		return strings.Contains(logOutput.String(), "wsPeer handleMessageOfInterest: could not unmarshall message from")
+	}, 5*time.Second, 20*time.Millisecond)
 	require.Equal(t, 0, counter.count)
 }
 


### PR DESCRIPTION
## Summary

1. `TestWebsocketNetworkBasicInvalidTags` test fix as seen recently few times
      ```
      2026-07-21T16:57:33.8538226Z === [31mFailed[0m
      2026-07-21T16:57:33.8538450Z === [31mFAIL[0m: network TestWebsocketNetworkBasicInvalidTags (5.01s)
      2026-07-21T16:57:33.8538663Z     wsNetwork_test.go:343: http://127.0.0.1:44451
      2026-07-21T16:57:33.8539078Z     wsNetwork_test.go:307: /home/runner/work/go-algorand/go-algorand/network/wsNetwork_test.go:355 timeout waiting for ready
      2026-07-21T16:57:33.8539219Z     wsNetwork_test.go:313: stopping B
      2026-07-21T16:57:33.8539352Z     wsNetwork_test.go:316: B done
      2026-07-21T16:57:33.8539480Z     wsNetwork_test.go:313: stopping A
      2026-07-21T16:57:33.8539607Z     wsNetwork_test.go:316: A done
      ```
    On invalid message interest connection is dropped and it appears it races with `waitReady` check.

2. Verify tests: call `crypto.SetEd25519BatchVerifier` with a random boolean value to exercise both `makeEd25519ConsensusBatchVerifier` (as in production now) and legacy `makeLibsodiumBatchVerifier` default option.

3. Fix flaky `TestCatchpointFastUpdates` by directly waiting for non-empty label instead of dbRound that appeared still to be racy

## Test Plan

These are test fixes