### PR TITLE
sortition: use SelectF128

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -606,6 +606,10 @@ type ConsensusParams struct {
 	// EnablePQSchemeFalcon1024 enables native Falcon-1024 transaction
 	// authorization for the f1 PQ scheme.
 	EnablePQSchemeFalcon1024 bool
+
+	// EnableSelectF128 changes the sortition algorithm to use a 128-bit software
+	// floating point binomial CDF implementation for committee selection.
+	EnableSelectF128 bool
 }
 
 // ProposerPayoutRules puts several related consensus parameters in one place. The same

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1541,6 +1541,7 @@ func initConsensusProtocols() {
 	vFuture.MaxAbsoluteExtraProgramPages = 7 // Allow larger programs with extra fees
 	vFuture.MaxAbsoluteTotalArgLen = 16384   // We _could_ make this as high as 16*4k
 	vFuture.PerByteTxnSurcharge = 100        // Each charged byte adds 0.000100 of min fee
+	vFuture.EnableSelectF128 = true
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 

--- a/data/committee/credential.go
+++ b/data/committee/credential.go
@@ -97,14 +97,19 @@ func (cred UnauthenticatedCredential) Verify(proto config.ConsensusParams, m Mem
 
 	var weight uint64
 	userMoney := m.Record.VotingStake()
-	expectedSelection := float64(m.Selector.CommitteeSize(proto))
+	committeeSize := m.Selector.CommitteeSize(proto)
+	expectedSelection := float64(committeeSize)
 
 	if m.TotalMoney.Raw < userMoney.Raw {
 		logging.Base().Panicf("UnauthenticatedCredential.Verify: total money = %v, but user money = %v", m.TotalMoney, userMoney)
 	} else if m.TotalMoney.IsZero() || expectedSelection == 0 || expectedSelection > float64(m.TotalMoney.Raw) {
 		logging.Base().Panicf("UnauthenticatedCredential.Verify: m.TotalMoney %v, expectedSelection %v", m.TotalMoney.Raw, expectedSelection)
 	} else if !userMoney.IsZero() {
-		weight = sortition.Select(userMoney.Raw, m.TotalMoney.Raw, expectedSelection, sortition.Digest(h))
+		if proto.EnableSelectF128 {
+			weight = sortition.SelectF128(userMoney.Raw, m.TotalMoney.Raw, committeeSize, sortition.Digest(h))
+		} else {
+			weight = sortition.Select(userMoney.Raw, m.TotalMoney.Raw, expectedSelection, sortition.Digest(h))
+		}
 	}
 
 	if weight == 0 {

--- a/data/committee/credential.go
+++ b/data/committee/credential.go
@@ -98,12 +98,11 @@ func (cred UnauthenticatedCredential) Verify(proto config.ConsensusParams, m Mem
 	var weight uint64
 	userMoney := m.Record.VotingStake()
 	committeeSize := m.Selector.CommitteeSize(proto)
-	expectedSelection := float64(committeeSize)
 
 	if m.TotalMoney.Raw < userMoney.Raw {
 		logging.Base().Panicf("UnauthenticatedCredential.Verify: total money = %v, but user money = %v", m.TotalMoney, userMoney)
-	} else if m.TotalMoney.IsZero() || expectedSelection == 0 || expectedSelection > float64(m.TotalMoney.Raw) {
-		logging.Base().Panicf("UnauthenticatedCredential.Verify: m.TotalMoney %v, expectedSelection %v", m.TotalMoney.Raw, expectedSelection)
+	} else if m.TotalMoney.IsZero() || committeeSize == 0 || committeeSize > m.TotalMoney.Raw {
+		logging.Base().Panicf("UnauthenticatedCredential.Verify: m.TotalMoney %v, expectedSelection %v", m.TotalMoney.Raw, committeeSize)
 	} else if !userMoney.IsZero() {
 		if proto.EnableSelectF128 {
 			if userMoney.Raw >= sortition.SelectF128MaxMoney {
@@ -113,7 +112,7 @@ func (cred UnauthenticatedCredential) Verify(proto config.ConsensusParams, m Mem
 			}
 			weight = sortition.SelectF128(userMoney.Raw, m.TotalMoney.Raw, committeeSize, sortition.Digest(h))
 		} else {
-			weight = sortition.Select(userMoney.Raw, m.TotalMoney.Raw, expectedSelection, sortition.Digest(h))
+			weight = sortition.Select(userMoney.Raw, m.TotalMoney.Raw, float64(committeeSize), sortition.Digest(h))
 		}
 	}
 

--- a/data/committee/credential.go
+++ b/data/committee/credential.go
@@ -106,6 +106,11 @@ func (cred UnauthenticatedCredential) Verify(proto config.ConsensusParams, m Mem
 		logging.Base().Panicf("UnauthenticatedCredential.Verify: m.TotalMoney %v, expectedSelection %v", m.TotalMoney.Raw, expectedSelection)
 	} else if !userMoney.IsZero() {
 		if proto.EnableSelectF128 {
+			if userMoney.Raw >= sortition.SelectF128MaxMoney {
+				logging.Base().Errorf("UnauthenticatedCredential.Verify: user money %v larger than SelectF128MaxMoney", userMoney)
+				err = fmt.Errorf("UnauthenticatedCredential.Verify: user money %v larger than SelectF128MaxMoney", userMoney)
+				return
+			}
 			weight = sortition.SelectF128(userMoney.Raw, m.TotalMoney.Raw, committeeSize, sortition.Digest(h))
 		} else {
 			weight = sortition.Select(userMoney.Raw, m.TotalMoney.Raw, expectedSelection, sortition.Digest(h))

--- a/data/committee/credential_test.go
+++ b/data/committee/credential_test.go
@@ -417,11 +417,11 @@ func BenchmarkSortition(b *testing.B) {
 
 // TestSortitionMoneyDomain verifies that every stake reachable under consensus
 // stays inside the domain bound exported by the sortition package. The money
-// argument of sortition.SelectF128 is a voting stake in microalgos, bounded
-// above by total online money and therefore by the supply minted at genesis;
-// behavior at or above sortition.SelectF128MaxMoney is undefined and is NOT
-// checked at runtime. If an economics change (for example an inflationary
-// model) raises the possible supply, or a consensus version introduces a
+	// argument of sortition.SelectF128 is a voting stake in microalgos, bounded
+	// above by total online money and therefore by the supply minted at genesis;
+	// behavior at or above sortition.SelectF128MaxMoney is undefined in the sortition
+	// package (it does not enforce the bound). If an economics change (for example an inflationary
+	// model) raises the possible supply, or a consensus version introduces a
 // committee size beyond it, this test must fail before the change can
 // silently misround consensus.
 func TestSortitionMoneyDomain(t *testing.T) {

--- a/data/committee/credential_test.go
+++ b/data/committee/credential_test.go
@@ -417,11 +417,11 @@ func BenchmarkSortition(b *testing.B) {
 
 // TestSortitionMoneyDomain verifies that every stake reachable under consensus
 // stays inside the domain bound exported by the sortition package. The money
-	// argument of sortition.SelectF128 is a voting stake in microalgos, bounded
-	// above by total online money and therefore by the supply minted at genesis;
-	// behavior at or above sortition.SelectF128MaxMoney is undefined in the sortition
-	// package (it does not enforce the bound). If an economics change (for example an inflationary
-	// model) raises the possible supply, or a consensus version introduces a
+// argument of sortition.SelectF128 is a voting stake in microalgos, bounded
+// above by total online money and therefore by the supply minted at genesis;
+// behavior at or above sortition.SelectF128MaxMoney is undefined in the sortition
+// package (it does not enforce the bound). If an economics change (for example an inflationary
+// model) raises the possible supply, or a consensus version introduces a
 // committee size beyond it, this test must fail before the change can
 // silently misround consensus.
 func TestSortitionMoneyDomain(t *testing.T) {

--- a/data/committee/credential_test.go
+++ b/data/committee/credential_test.go
@@ -452,4 +452,27 @@ func TestSortitionMoneyDomain(t *testing.T) {
 				"consensus version %v: committee size %d exceeds the supply", v, size)
 		}
 	}
+
+	// The checks above prove the guard cannot fire under mainnet economics;
+	// this exercises the guard itself. A stake at the domain bound must make
+	// Verify fail closed with an error instead of calling SelectF128 out of
+	// domain. No released consensus version enables the flag yet, so force it on
+	// a copy of the current proto.
+	protoF128 := proto
+	protoF128.EnableSelectF128 = true
+
+	selParams, _, round, addresses, _, vrfSecrets := testingenv(t, 100, 2000, nil)
+	ok, record, selectionSeed, _ := selParams(addresses[0])
+	require.True(t, ok)
+	// A voting stake exactly at the bound trips the >= check; TotalMoney is set
+	// no lower so the earlier total-money panic does not fire first.
+	record.MicroAlgosWithRewards.Raw = sortition.SelectF128MaxMoney
+	sel := AgreementSelector{Seed: selectionSeed, Round: round, Period: Period(0), Step: Propose}
+	m := Membership{
+		Record:     record,
+		Selector:   sel,
+		TotalMoney: basics.MicroAlgos{Raw: sortition.SelectF128MaxMoney},
+	}
+	_, err := MakeCredential(vrfSecrets[0], sel).Verify(protoF128, m)
+	require.ErrorContains(t, err, "larger than SelectF128MaxMoney")
 }

--- a/data/committee/credential_test.go
+++ b/data/committee/credential_test.go
@@ -23,6 +23,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/algorand/sortition"
+
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
@@ -409,5 +412,44 @@ func BenchmarkSortition(b *testing.B) {
 			TotalMoney: basics.MicroAlgos{Raw: uint64(totalMoney)},
 		}
 		credentials[i], _ = MakeCredential(vrfSecrets[0], sel).Verify(proto, m)
+	}
+}
+
+// TestSortitionMoneyDomain verifies that every stake reachable under consensus
+// stays inside the domain bound exported by the sortition package. The money
+// argument of sortition.SelectF128 is a voting stake in microalgos, bounded
+// above by total online money and therefore by the supply minted at genesis;
+// behavior at or above sortition.SelectF128MaxMoney is undefined and is NOT
+// checked at runtime. If an economics change (for example an inflationary
+// model) raises the possible supply, or a consensus version introduces a
+// committee size beyond it, this test must fail before the change can
+// silently misround consensus.
+func TestSortitionMoneyDomain(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	// 10 billion Algos in microalgos: the mainnet genesis supply. The ledger
+	// conserves total money, so no VotingStake or TotalMoney can exceed it.
+	const mainnetSupply = uint64(10_000_000_000_000_000)
+
+	require.Less(t, mainnetSupply, sortition.SelectF128MaxMoney,
+		"genesis supply reaches the sortition domain bound")
+	// Insist on headroom so erosion of the margin is a deliberate decision.
+	require.LessOrEqual(t, 7*mainnetSupply, sortition.SelectF128MaxMoney,
+		"less than 2 bits of headroom between the supply and the sortition domain bound")
+
+	for v, p := range config.Consensus {
+		if !p.EnableSelectF128 {
+			continue
+		}
+		committees := []uint64{
+			p.NumProposers, p.SoftCommitteeSize, p.CertCommitteeSize, p.NextCommitteeSize,
+			p.LateCommitteeSize, p.RedoCommitteeSize, p.DownCommitteeSize,
+		}
+		for _, size := range committees {
+			// credential.go panics when expectedSelection exceeds total money,
+			// so a committee size beyond the supply could never form a valid p.
+			require.LessOrEqual(t, size, mainnetSupply,
+				"consensus version %v: committee size %d exceeds the supply", v, size)
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/algorand/go-sumhash v0.1.0
 	github.com/algorand/graphtrace v0.1.0
 	github.com/algorand/msgp v1.1.64
-	github.com/algorand/sortition v1.0.0
+	github.com/algorand/sortition v1.1.0
 	github.com/algorand/websocket v1.4.6
 	github.com/aws/aws-sdk-go v1.34.0
 	github.com/cockroachdb/pebble v0.0.0-20230807162746-af8c5f279001
@@ -64,7 +64,7 @@ require (
 	golang.org/x/sys v0.45.0
 	golang.org/x/text v0.37.0
 	gopkg.in/sohlich/elogrus.v3 v3.0.0-20180410122755-1fa29e2f2009
-	pgregory.net/rapid v1.2.0
+	pgregory.net/rapid v1.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/algorand/graphtrace v0.1.0 h1:QemP1iT0W56SExD0NfiU6rsG34/v0Je6bg5UZnp
 github.com/algorand/graphtrace v0.1.0/go.mod h1:HscLQrzBdH1BH+5oehs3ICd8SYcXvnSL9BjfTu8WHCc=
 github.com/algorand/msgp v1.1.64 h1:qoVG2yP4fOo6gEVrGYeqnHe8pD2Fz5G08VyjHfHN9kY=
 github.com/algorand/msgp v1.1.64/go.mod h1:j9sEjNKkS12H0Yhwov/3MfzhM60n3iyr81Ymzv49pu8=
-github.com/algorand/sortition v1.0.0 h1:PJiZtdSTBm4nArQrZXBnhlljHXhuyAXRJBqVWowQu3E=
-github.com/algorand/sortition v1.0.0/go.mod h1:23CZwAbTWPv0bBsq+Php/2J6Y/iXDyzlfcZyepeY5Fo=
+github.com/algorand/sortition v1.1.0 h1:p96hN39DlVUlM/wOv2mwBMaj7odYoTzLKPSb+mlwmKc=
+github.com/algorand/sortition v1.1.0/go.mod h1:g8NJVf0LPZvUYTr04o3nJCPhS4LQmQ8MklwImqc3s/Q=
 github.com/algorand/websocket v1.4.6 h1:I0kV4EYwatuUrKtNiwzYYgojgwh6pksDmlqntKG2Woc=
 github.com/algorand/websocket v1.4.6/go.mod h1:HJmdGzFtnlUQ4nTzZP6WrT29oGYf1t6Ybi64vROcT+M=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -1099,8 +1099,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 lukechampine.com/blake3 v1.4.1 h1:I3Smz7gso8w4/TunLKec6K2fn+kyKtDxr/xcQEN84Wg=
 lukechampine.com/blake3 v1.4.1/go.mod h1:QFosUxmjB8mnrWFSNwKmvxHpfY72bmD2tQ0kBMM3kwo=
-pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
-pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/tools/block-generator/go.mod
+++ b/tools/block-generator/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/algorand/falcon v0.1.0 // indirect
 	github.com/algorand/go-sumhash v0.1.0 // indirect
 	github.com/algorand/msgp v1.1.64 // indirect
-	github.com/algorand/sortition v1.0.0 // indirect
+	github.com/algorand/sortition v1.1.0 // indirect
 	github.com/algorand/websocket v1.4.6 // indirect
 	github.com/aws/aws-sdk-go v1.34.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/tools/block-generator/go.sum
+++ b/tools/block-generator/go.sum
@@ -55,8 +55,8 @@ github.com/algorand/go-sumhash v0.1.0 h1:b/QRhyLuF//vOcicBIxBXYW8bERNoeLxieht/dU
 github.com/algorand/go-sumhash v0.1.0/go.mod h1:OOe7jdDWUhLkuP1XytkK5gnLu9entAviN5DfDZh6XAc=
 github.com/algorand/msgp v1.1.64 h1:qoVG2yP4fOo6gEVrGYeqnHe8pD2Fz5G08VyjHfHN9kY=
 github.com/algorand/msgp v1.1.64/go.mod h1:j9sEjNKkS12H0Yhwov/3MfzhM60n3iyr81Ymzv49pu8=
-github.com/algorand/sortition v1.0.0 h1:PJiZtdSTBm4nArQrZXBnhlljHXhuyAXRJBqVWowQu3E=
-github.com/algorand/sortition v1.0.0/go.mod h1:23CZwAbTWPv0bBsq+Php/2J6Y/iXDyzlfcZyepeY5Fo=
+github.com/algorand/sortition v1.1.0 h1:p96hN39DlVUlM/wOv2mwBMaj7odYoTzLKPSb+mlwmKc=
+github.com/algorand/sortition v1.1.0/go.mod h1:g8NJVf0LPZvUYTr04o3nJCPhS4LQmQ8MklwImqc3s/Q=
 github.com/algorand/websocket v1.4.6 h1:I0kV4EYwatuUrKtNiwzYYgojgwh6pksDmlqntKG2Woc=
 github.com/algorand/websocket v1.4.6/go.mod h1:HJmdGzFtnlUQ4nTzZP6WrT29oGYf1t6Ybi64vROcT+M=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -1033,8 +1033,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 lukechampine.com/blake3 v1.4.1 h1:I3Smz7gso8w4/TunLKec6K2fn+kyKtDxr/xcQEN84Wg=
 lukechampine.com/blake3 v1.4.1/go.mod h1:QFosUxmjB8mnrWFSNwKmvxHpfY72bmD2tQ0kBMM3kwo=
-pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
-pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
## Summary

Once algorand/sortition#8 is merged this will pull the new version into go.mod and use the new `SelectF128` method behidn a new consensus flag.

## Test Plan

Beyond the tests in algorand/sortition#8 a new test TestSortitionMoneyDomain was added, and an additional error-returning check in `UnauthenticatedCredential.Verify` that `userMoney < sortition.SelectF128MaxMoney`.