### PR TITLE
FNet: add fnet1..4 consensus versions, genesis, and docker

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1570,6 +1570,47 @@ func initConsensusProtocols() {
 	vAlpha5.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 	Consensus[protocol.ConsensusVAlpha5] = vAlpha5
 	vAlpha4.ApprovedUpgrades[protocol.ConsensusVAlpha5] = 10000
+
+	// vFnetX are like vAlphaX but for AF's FNet. These are the genesis and
+	// historical protocols for the FNet network; a mainline node needs them to
+	// open the FNet genesis ledger (proto fnet1) and to replay the pre-V40 chain.
+	// The on-chain upgrade path was fnet1->fnet2->fnet3->fnet4->V40.
+	vFnet1 := v39
+	vFnet1.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	vFnet1.LogicSigVersion = 11 // When moving this to a release, put a new higher LogicSigVersion here
+	vFnet1.Payouts.Enabled = true
+	vFnet1.Payouts.Percent = 75
+	vFnet1.Payouts.GoOnlineFee = 2_000_000         // 2 algos
+	vFnet1.Payouts.MinBalance = 30_000_000_000     // 30,000 algos
+	vFnet1.Payouts.MaxBalance = 70_000_000_000_000 // 70M algos
+	vFnet1.Payouts.MaxMarkAbsent = 32
+	vFnet1.Payouts.ChallengeInterval = 1000
+	vFnet1.Payouts.ChallengeGracePeriod = 200
+	vFnet1.Payouts.ChallengeBits = 5
+	vFnet1.Bonus.BaseAmount = 10_000_000 // 10 Algos
+	vFnet1.Bonus.DecayInterval = 250_000 // .99^(10.8/0.25) ~ .648. So 35% decay per year
+	Consensus[protocol.ConsensusVFnet1] = vFnet1
+
+	// vFnet2 guards against a future change in block opcodes that the fnet1 client did not support. No change in parameters
+	vFnet2 := vFnet1
+	vFnet2.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	Consensus[protocol.ConsensusVFnet2] = vFnet2
+	vFnet1.ApprovedUpgrades[protocol.ConsensusVFnet2] = 10000
+
+	// vFnet3 disabled challenges - without heartbeats, participating accounts are being evicted
+	vFnet3 := vFnet2
+	vFnet3.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	vFnet3.Payouts.ChallengeInterval = 0
+	Consensus[protocol.ConsensusVFnet3] = vFnet3
+	vFnet2.ApprovedUpgrades[protocol.ConsensusVFnet3] = 10000
+
+	// vFnet4: challenges and heartbeats
+	vFnet4 := vFnet1
+	vFnet4.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+	Consensus[protocol.ConsensusVFnet4] = vFnet4
+	vFnet3.ApprovedUpgrades[protocol.ConsensusVFnet4] = 10000
+
+	vFnet4.ApprovedUpgrades[protocol.ConsensusV40] = 10000
 }
 
 // Global defines global Algorand protocol parameters which should not be overridden.

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1604,7 +1604,7 @@ func initConsensusProtocols() {
 	Consensus[protocol.ConsensusVFnet3] = vFnet3
 	vFnet2.ApprovedUpgrades[protocol.ConsensusVFnet3] = 10000
 
-	// vFnet4: challenges and heartbeats
+	// vFnet4: replacing challenges and heartbeats, back to vFnet1 parameters, with a new upgrade path to V40
 	vFnet4 := vFnet1
 	vFnet4.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 	Consensus[protocol.ConsensusVFnet4] = vFnet4

--- a/docker/files/run/run.sh
+++ b/docker/files/run/run.sh
@@ -156,13 +156,17 @@ function start_new_public_network() {
     betanet) ID="<network>.algodev.network" ;;
     alphanet) ID="<network>.algodev.network" ;;
     devnet) ID="<network>.algodev.network" ;;
+    fnet) ID="<network>.algorand.tech" ;;
     *)
       echo "Unknown network."
       exit 1
       ;;
     esac
-
-    set -p DNSBootstrapID -v "$ID"
+    echo Setting DNS Bootstrap ID to "$ID"
+    algocfg -d "$ALGORAND_DATA" set -p DNSBootstrapID -v "$ID"
+  elif [ "$NETWORK" = "fnet" ]; then
+    echo Setting FNet DNS Bootstrap ID
+    algocfg -d "$ALGORAND_DATA" set -p DNSBootstrapID -v "<network>.algorand.tech"
   fi
 
   start_public_network

--- a/installer/genesis/fnet/genesis.json
+++ b/installer/genesis/fnet/genesis.json
@@ -1,0 +1,225 @@
+{
+  "alloc": [
+    {
+      "addr": "7777777777777777777777777777777777777777777777777774MSJUVU",
+      "comment": "RewardsPool",
+      "state": {
+        "algo": 1000000,
+        "onl": 2
+      }
+    },
+    {
+      "addr": "FEESINK7OJKODDB5ZB4W2SRYPUSTOTK65UDCUYZ5DB4BW3VOHDHGO6JUNE",
+      "comment": "FeeSink",
+      "state": {
+        "algo": 600000000000000
+      }
+    },
+    {
+      "addr": "FNET3652NR5TZPIKDM2K5I6RJYQ3VPVYJDMY4BCYWK5EHDOFZUWSNOZZLE",
+      "comment": "CorePart1",
+      "state": {
+        "algo": 100000000000000,
+        "onl": 1,
+        "sel": "LxbnrFqZJNh2igk4ipdmccYhkNHbpo1CQHQAQvwaCkQ=",
+        "stprf": "EfxtouDDQ3ASlr2QShEhUOQu6uaSJ82SKJRFqcBuDky8Q4hh5J+0hbYpXkiqHh9s6ribktpfydb+AWZQN3peSw==",
+        "vote": "q2ONSCNb+KdBVhHtGU4DoolkyHNldF3B418ylJe4GPc=",
+        "voteKD": 2000,
+        "voteLst": 4000000
+      }
+    },
+    {
+      "addr": "FNET43EQJGPZNQPDWZSWEPAGTVFBA5WKUB64BPWWWLD4MCJUCMQDSONATA",
+      "comment": "CorePart2",
+      "state": {
+        "algo": 100000000000000,
+        "onl": 1,
+        "sel": "Y9ArFvcIjDU9/+ZBf82Ww+LheP9nggQhcsAF2dpQhno=",
+        "stprf": "9+Vs/YC0NnX2Kcn3otAS1fwaOlh1dJ4VTVklYPNXJIibb3ErJjcVbB9e2AK6hilTw66sDOflNt8hrPLm1wrHQA==",
+        "vote": "Zt/RcclDc2qN5Pi2jFd9HOWk7FAwJ+EkGWgsfmGTNlA=",
+        "voteKD": 2000,
+        "voteLst": 4000000
+      }
+    },
+    {
+      "addr": "FNET57EE5J4N7RVW3SCNGSL6SHCUENKO2GMMJCX3MMQRJKM77THEMEBANE",
+      "comment": "CorePart3",
+      "state": {
+        "algo": 100000000000000,
+        "onl": 1,
+        "sel": "wRCQT+sRLU3Xn/qEqdrNRe4g+cC59jprhZ14mwS7fGE=",
+        "stprf": "97rgXEHne/EjVNGo9JULuo/91IoG9BzyQMt8O9PJTzwWc6WZPCUJErzTlJwKJ5BY7i9ZZxra0Y9Mk/tJ5KkMKw==",
+        "vote": "XcR/JgdanJZb4tCDoJ8NSDOU2Q+Xkog2is0J0Ikjav8=",
+        "voteKD": 2000,
+        "voteLst": 4000000
+      }
+    },
+    {
+      "addr": "FNET67F5XSKPMI5QGZOM2VJPJA4RCE36B7ZO6FZVEKLVG4PUCVBESTSLAY",
+      "comment": "CorePart4",
+      "state": {
+        "algo": 100000000000000,
+        "onl": 1,
+        "sel": "oqYPOf3jH8eWWVIVyVB0gGlf0/WvW3bwtRnkHkzFbWo=",
+        "stprf": "VTDx1kEZt/yvPf70SGhGbmIheuIkOaxaK9pmVEz180BmcT5LM2fAkUHu06TxhEgr5icsIf4q2n2LBf9VfuYkZQ==",
+        "vote": "v2bspPWpF4q2oMBgPRMwWmpXax3L+60LrDZWkQjiXI4=",
+        "voteKD": 2000,
+        "voteLst": 4000000
+      }
+    },
+    {
+      "addr": "FNETC46DGTSSDHA6C54FWEGZ3Z5ADE4YAPYQTX5VEE2YGU5NFPAWTRANCE",
+      "comment": "CorePart5",
+      "state": {
+        "algo": 100000000000000,
+        "onl": 1,
+        "sel": "6A1DkpmeFtTsBQnApn3Z0/mEQ3BnO4wI16Bu8WiNy1I=",
+        "stprf": "ubuek0gVd8GFec2gdcQNcwqDkxserZH1U3Py5qnBdrJXiN9a8318bzsTDPONO88BfGeaQiZHI3Ev2jfroiCi8g==",
+        "vote": "5Jo8v0b/mV/01xohKKzFSmyRzFlqTuBQUtp39PHQXOM=",
+        "voteKD": 2000,
+        "voteLst": 4000000
+      }
+    },
+    {
+      "addr": "FNETJYY6YYB6SUWQDQZ5IDWLXOTOC2TMLW45B4O6MH5LREIBEXPREYSONY",
+      "comment": "CorePart6",
+      "state": {
+        "algo": 100000000000000,
+        "onl": 1,
+        "sel": "iEZus783jnoCS/KEP3w13n3LV1lVTUANouXfGvF0KFc=",
+        "stprf": "ReaczS9WfbNyp8+JGkqa7IcDnhxbL9+mtb78XVBHzoRSti09o34aYJe8/Etv9v3xdbMU+GwkV84mH+LhhKpnjQ==",
+        "vote": "VL9youWsNv4PPpIJKiIToMtlpsQdzyXpNSzB3ESnkN4=",
+        "voteKD": 2000,
+        "voteLst": 4000000
+      }
+    },
+    {
+      "addr": "FNETNDMRNC3GJBLZ4MM2FXL3OYA5W6ULTICOWACLYHDP4EAJWNBXSIMILE",
+      "comment": "CorePart7",
+      "state": {
+        "algo": 100000000000000,
+        "onl": 1,
+        "sel": "LXEyVtCwl4z8X37fshwzorPGG14JOWT2c7H2zytdPGA=",
+        "stprf": "8UV4I/tZOC0C5vSESKOu4q3VGNvfvnEqcaOT/AhYAYEWFqHJ3JuRMtBD2d8V//NSFdEP3aFElpJeVcflcv2dHQ==",
+        "vote": "/MJ642yLYbRtGfckg1JmtSRpbVydhyxolYrPa5zh4Rs=",
+        "voteKD": 2000,
+        "voteLst": 4000000
+      }
+    },
+    {
+      "addr": "FNETXNAQWEQNSGCURWYEDBSRI2OE5AC2CDU2GBPYIB6CZ44PSYMCOUNTRY",
+      "comment": "CorePart8",
+      "state": {
+        "algo": 100000000000000,
+        "onl": 1,
+        "sel": "yRbj0n5jozTfpW47eZvGbTPI/ofcB1RZRWtVB/C9meA=",
+        "stprf": "Be+6O1SlENsSJ9svlwtGTQX5XFChvh6bUP2MH/K+5n7KlumLUXrZaifXLJ/EHPTt5oR2QzseIskgEeg7Of8J4Q==",
+        "vote": "1oh9qj+n0V6D08TXmhTUKcYR3OhFOp7AK5GTGKMFR30=",
+        "voteKD": 2000,
+        "voteLst": 4000000
+      }
+    },
+    {
+      "addr": "FNETYCFSVZBPFBZN4YXCMIH2BCOKD42ROFWEFXQSTNU73VAKRSDINOHIKE",
+      "comment": "CorePart9",
+      "state": {
+        "algo": 100000000000000,
+        "onl": 1,
+        "sel": "gAAzu3/gK+WRGsjqx3LZ9StBHqsyUR04L3O5q0i/ojw=",
+        "stprf": "vXxpFRTjQWka4dvLZPO2FkS3fVjdoUhhEWnQD/3GcR3W5Kk3t3u/ibmBqYepwaramFq355KoGpwJMOhgVMZCaQ==",
+        "vote": "pcaWDfwA3y1nWpqSfc68o3/UFeGOSMUxtNU6FQMr4Jg=",
+        "voteKD": 2000,
+        "voteLst": 4000000
+      }
+    },
+    {
+      "addr": "FNETYTHKXMDRMVFLBHY3LPKQQ6UO4PU2ARZ5N76EGF7NTLE6I7I234MAUI",
+      "comment": "CorePart10",
+      "state": {
+        "algo": 100000000000000,
+        "onl": 1,
+        "sel": "Wi8oeynUS/aerEk36cIxJ/9nrTL5ZxojmlRZ4rXdv6s=",
+        "stprf": "AS89+eY7/EwqBpzFJ9VQFF7+aS6q+FvyecJeT3qRhUcLr8l7iG4E+AVnmoDxh+Kl32j9LuTgbQ1zsjN4iOdO3g==",
+        "vote": "1enWlVySg8Z9O7APngseGyZbFbA5u9ikZ64rWk/pK7M=",
+        "voteKD": 2000,
+        "voteLst": 4000000
+      }
+    },
+    {
+      "addr": "RETIKHIS2MS63F52EZEU673VJSXV6Q4K4IABNLCNZA63MOBE3NA66YI4KM",
+      "comment": "Eco1",
+      "state": {
+        "algo": 100000000000000
+      }
+    },
+    {
+      "addr": "UFCUHHFHPP2NSJK6PTJZ2Q4OK7JN4SWN3DP37CGHM3POIZDHGIX65XLABM",
+      "comment": "Eco2",
+      "state": {
+        "algo": 100000000000000
+      }
+    },
+    {
+      "addr": "WBZRT3HB37ACKFZDNDX6BH6OYTACCHCPZAO4DXFGUYCYZP25KVWMAPMNOE",
+      "comment": "Eco3",
+      "state": {
+        "algo": 100000000000000
+      }
+    },
+    {
+      "addr": "HAQR2TNSO4A4OA26ZU7XO3M7UNYHI2KY2GZTO6MZZHE6323AVR3OBOF6HA",
+      "comment": "Eco4",
+      "state": {
+        "algo": 100000000000000
+      }
+    },
+    {
+      "addr": "PU6VLBLU2GRXCSNBOBO6J2UDVBW6CVJ6QJZR47TTIFWDA5BNHLJNBV53OI",
+      "comment": "Eco5",
+      "state": {
+        "algo": 100000000000000
+      }
+    },
+    {
+      "addr": "DI3INONU2PBZCZG4FEE5KJTBJTOC5KWTSG772NSTBS3VZC7MQAGMKCOF3A",
+      "comment": "Bank1",
+      "state": {
+        "algo": 1500000000000000
+      }
+    },
+    {
+      "addr": "6C44EZRJ4CFISSB7C3CCEFPBRD63AS3FP74GD5DYCYZVQ5AXAICEMW5A24",
+      "comment": "Bank2",
+      "state": {
+        "algo": 1500000000000000
+      }
+    },
+    {
+      "addr": "BANK3D4263ARNGLX2SXSTPWX3P4DR55VZIXUJN3YVZTJIFNETZLBSIJUDY",
+      "comment": "Bank3",
+      "state": {
+        "algo": 1500000000000000
+      }
+    },
+    {
+      "addr": "BANK4QGRKCE6TJ7RTJ66T7PTPSHBKVSEF43FNETXUW2WT6ZGROFBRLSHIM",
+      "comment": "Bank4",
+      "state": {
+        "algo": 1500000000000000
+      }
+    },
+    {
+      "addr": "NULLUN2UWVLFRKMEOGEE2GZQXLNRPCNWHPWDUSTWUTHNUTXQJDUBN3FNHM",
+      "comment": "Bank5",
+      "state": {
+        "algo": 1899999999000000
+      }
+    }
+  ],
+  "fees": "FEESINK7OJKODDB5ZB4W2SRYPUSTOTK65UDCUYZ5DB4BW3VOHDHGO6JUNE",
+  "id": "v1",
+  "network": "fnet",
+  "proto": "fnet1",
+  "rwd": "7777777777777777777777777777777777777777777777777774MSJUVU",
+  "timestamp": 1724938200
+}

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -252,6 +252,22 @@ const ConsensusVAlpha4 = ConsensusVersion("alpha4")
 // ConsensusVAlpha5 uses the same parameters as ConsensusV36.
 const ConsensusVAlpha5 = ConsensusVersion("alpha5")
 
+// ConsensusVFnet1 is the genesis protocol for AF's FNet, based on ConsensusV39
+// with incentives (payouts/challenges) and TEAL v11 enabled.
+const ConsensusVFnet1 = ConsensusVersion("fnet1")
+
+// ConsensusVFnet2 guards against a block-opcode change the fnet1 client did not
+// support; same parameters as fnet1.
+const ConsensusVFnet2 = ConsensusVersion("fnet2")
+
+// ConsensusVFnet3 disables challenges; without heartbeats, participating
+// accounts were being evicted.
+const ConsensusVFnet3 = ConsensusVersion("fnet3")
+
+// ConsensusVFnet4 re-enables challenges and brings heartbeats; upgrades to
+// ConsensusV40.
+const ConsensusVFnet4 = ConsensusVersion("fnet4")
+
 // !!! ********************* !!!
 // !!! *** Please update ConsensusCurrentVersion when adding new protocol versions *** !!!
 // !!! ********************* !!!


### PR DESCRIPTION
## Summary

FNet: add fnet1..4 consensus versions, genesis, and dockerto mainline

Enables stock go-algorand nodes to join the FNet network. Adds the fnet1..fnet4 consensus versions (genesis proto through the fnet4->V40 upgrade path), the FNet genesis file, and docker DNS-bootstrap support for the network (fnet.algorand.tech).

Related: [go-algorand-sdk PR](https://github.com/algorand/go-algorand-sdk/pull/823) for conduit and indexer to work

## Test Plan

Verified: config/protocol tests pass, the FNet genesis loads and MakeGenesisBlock resolves fnet1; computed genesis hash matches the live network.