### PR TITLE
sortition: f128 followups

### DIFF
--- a/data/committee/credential.go
+++ b/data/committee/credential.go
@@ -102,12 +102,12 @@ func (cred UnauthenticatedCredential) Verify(proto config.ConsensusParams, m Mem
 	if m.TotalMoney.Raw < userMoney.Raw {
 		logging.Base().Panicf("UnauthenticatedCredential.Verify: total money = %v, but user money = %v", m.TotalMoney, userMoney)
 	} else if m.TotalMoney.IsZero() || committeeSize == 0 || committeeSize > m.TotalMoney.Raw {
-		logging.Base().Panicf("UnauthenticatedCredential.Verify: m.TotalMoney %v, expectedSelection %v", m.TotalMoney.Raw, committeeSize)
+		logging.Base().Panicf("UnauthenticatedCredential.Verify: m.TotalMoney %v, committeeSize %v", m.TotalMoney.Raw, committeeSize)
 	} else if !userMoney.IsZero() {
 		if proto.EnableSelectF128 {
 			if userMoney.Raw >= sortition.SelectF128MaxMoney {
-				logging.Base().Errorf("UnauthenticatedCredential.Verify: user money %v larger than SelectF128MaxMoney", userMoney)
-				err = fmt.Errorf("UnauthenticatedCredential.Verify: user money %v larger than SelectF128MaxMoney", userMoney)
+				err = fmt.Errorf("UnauthenticatedCredential.Verify: user money %v at or above SelectF128MaxMoney", userMoney)
+				logging.Base().Error(err)
 				return
 			}
 			weight = sortition.SelectF128(userMoney.Raw, m.TotalMoney.Raw, committeeSize, sortition.Digest(h))

--- a/data/committee/credential_test.go
+++ b/data/committee/credential_test.go
@@ -446,7 +446,7 @@ func TestSortitionMoneyDomain(t *testing.T) {
 			p.LateCommitteeSize, p.RedoCommitteeSize, p.DownCommitteeSize,
 		}
 		for _, size := range committees {
-			// credential.go panics when expectedSelection exceeds total money,
+			// credential.go panics when committeeSize exceeds total money,
 			// so a committee size beyond the supply could never form a valid p.
 			require.LessOrEqual(t, size, mainnetSupply,
 				"consensus version %v: committee size %d exceeds the supply", v, size)
@@ -474,5 +474,5 @@ func TestSortitionMoneyDomain(t *testing.T) {
 		TotalMoney: basics.MicroAlgos{Raw: sortition.SelectF128MaxMoney},
 	}
 	_, err := MakeCredential(vrfSecrets[0], sel).Verify(protoF128, m)
-	require.ErrorContains(t, err, "larger than SelectF128MaxMoney")
+	require.ErrorContains(t, err, "at or above SelectF128MaxMoney")
 }

--- a/tools/debug/algodump/go.mod
+++ b/tools/debug/algodump/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/algorand/falcon v0.1.0 // indirect
 	github.com/algorand/go-codec/codec v1.1.10 // indirect
 	github.com/algorand/go-sumhash v0.1.0 // indirect
-	github.com/algorand/msgp v1.1.63 // indirect
-	github.com/algorand/sortition v1.0.0 // indirect
+	github.com/algorand/msgp v1.1.64 // indirect
+	github.com/algorand/sortition v1.1.0 // indirect
 	github.com/algorand/websocket v1.4.6 // indirect
 	github.com/aws/aws-sdk-go v1.34.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/tools/debug/algodump/go.sum
+++ b/tools/debug/algodump/go.sum
@@ -53,10 +53,10 @@ github.com/algorand/go-deadlock v0.2.5 h1:Kn3WJMn9+wK1pqJrr2+1/y3Z8p1dcftpr2Mbbl
 github.com/algorand/go-deadlock v0.2.5/go.mod h1:z0g1kdYBhezsHoEKqYf5dVnP9dGMwOOqqxUSTCk2Oks=
 github.com/algorand/go-sumhash v0.1.0 h1:b/QRhyLuF//vOcicBIxBXYW8bERNoeLxieht/dUYpVg=
 github.com/algorand/go-sumhash v0.1.0/go.mod h1:OOe7jdDWUhLkuP1XytkK5gnLu9entAviN5DfDZh6XAc=
-github.com/algorand/msgp v1.1.63 h1:BK7Ghzq6hvZ1QivZ2p1TDEQDrU8oJ+1oY66yb+1ezXw=
-github.com/algorand/msgp v1.1.63/go.mod h1:j9sEjNKkS12H0Yhwov/3MfzhM60n3iyr81Ymzv49pu8=
-github.com/algorand/sortition v1.0.0 h1:PJiZtdSTBm4nArQrZXBnhlljHXhuyAXRJBqVWowQu3E=
-github.com/algorand/sortition v1.0.0/go.mod h1:23CZwAbTWPv0bBsq+Php/2J6Y/iXDyzlfcZyepeY5Fo=
+github.com/algorand/msgp v1.1.64 h1:qoVG2yP4fOo6gEVrGYeqnHe8pD2Fz5G08VyjHfHN9kY=
+github.com/algorand/msgp v1.1.64/go.mod h1:j9sEjNKkS12H0Yhwov/3MfzhM60n3iyr81Ymzv49pu8=
+github.com/algorand/sortition v1.1.0 h1:p96hN39DlVUlM/wOv2mwBMaj7odYoTzLKPSb+mlwmKc=
+github.com/algorand/sortition v1.1.0/go.mod h1:g8NJVf0LPZvUYTr04o3nJCPhS4LQmQ8MklwImqc3s/Q=
 github.com/algorand/websocket v1.4.6 h1:I0kV4EYwatuUrKtNiwzYYgojgwh6pksDmlqntKG2Woc=
 github.com/algorand/websocket v1.4.6/go.mod h1:HJmdGzFtnlUQ4nTzZP6WrT29oGYf1t6Ybi64vROcT+M=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -994,8 +994,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 lukechampine.com/blake3 v1.4.1 h1:I3Smz7gso8w4/TunLKec6K2fn+kyKtDxr/xcQEN84Wg=
 lukechampine.com/blake3 v1.4.1/go.mod h1:QFosUxmjB8mnrWFSNwKmvxHpfY72bmD2tQ0kBMM3kwo=
-pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
-pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
PR #6672 bumped github.com/algorand/sortition to v1.1.0 in the root and block-generator modules but missed tools/debug/algodump, leaving that module unbuildable ("updates to go.mod needed"). Run go mod tidy there, which also picks up the previously-missed msgp v1.1.64 bump.

Rename the stale `expectedSelection` label in the committee-size panic message, say "at or above" for the >= domain check, and build the error once, logging the same value that is returned.