### PR TITLE
config: auto-shorten proto upgrades for fnet

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,9 @@ const Betanet protocol.NetworkID = "betanet"
 // Alphanet identifies the 'alpha network' use for performance releases of feature/alphanet to the public prior to releasing these to mainnet/testnet
 const Alphanet protocol.NetworkID = "alphanet"
 
+// Fnet identifies the Algorand Foundation's 'fnet' network, a public development network for testing features prior to releasing these to mainnet/testnet
+const Fnet protocol.NetworkID = "fnet"
+
 // Devtestnet identifies the 'development network for tests' use for running tests against development and not generally accessible publicly
 const Devtestnet protocol.NetworkID = "devtestnet"
 
@@ -378,10 +381,10 @@ func LoadConfigurableConsensusProtocols(dataDirectory string) error {
 	return nil
 }
 
-// ApplyShorterUpgradeRoundsForDevNetworks applies a shorter upgrade round time for the Devnet and Betanet networks.
+// ApplyShorterUpgradeRoundsForDevNetworks applies a shorter upgrade round time for the Devnet, Betanet, and Fnet networks.
 // This function should not take precedence over settings loaded via `PreloadConfigurableConsensusProtocols`.
 func ApplyShorterUpgradeRoundsForDevNetworks(id protocol.NetworkID) {
-	if id == Betanet || id == Devnet {
+	if id == Betanet || id == Devnet || id == Fnet {
 		// Go through all approved upgrades and set to the MinUpgradeWaitRounds valid where MinUpgradeWaitRounds is set
 		for _, p := range Consensus {
 			if p.ApprovedUpgrades != nil {

--- a/config/consensus_test.go
+++ b/config/consensus_test.go
@@ -136,6 +136,25 @@ func TestConsensusUpgradeWindow_NetworkOverrides(t *testing.T) {
 		}
 	}
 
+	// reset consensus settings
+	Consensus = make(ConsensusProtocols)
+	initConsensusProtocols()
+
+	ApplyShorterUpgradeRoundsForDevNetworks(Fnet)
+	for _, params := range Consensus {
+		for toVersion, delay := range params.ApprovedUpgrades {
+			if params.MinUpgradeWaitRounds != 0 || params.MaxUpgradeWaitRounds != 0 {
+				require.NotZerof(t, delay, "From :%v\nTo :%v", params, toVersion)
+				require.Equalf(t, delay, params.MinUpgradeWaitRounds, "From :%v\nTo :%v", params, toVersion)
+				// This check is not really needed, but leaving for sanity
+				require.LessOrEqualf(t, delay, params.MaxUpgradeWaitRounds, "From :%v\nTo :%v", params, toVersion)
+			} else {
+				// If no MinUpgradeWaitRounds is set, leaving everything as zero value is expected
+				require.Zerof(t, delay, "From :%v\nTo :%v", params, toVersion)
+			}
+		}
+	}
+
 	// should be no-ops for Testnet
 	Consensus = make(ConsensusProtocols)
 	initConsensusProtocols()


### PR DESCRIPTION
## Summary

Add the `fnet` NetworkID and include it in `ApplyShorterUpgradeRoundsForDevNetworks` so fnet, like betanet and devnet, collapses approved-upgrade wait rounds to `MinUpgradeWaitRounds`.

## Test Plan

Added test scenario in `config/consensus_test.go`, based on betanet.