### PR TITLE
Txn: Check for local schema setting in update

### DIFF
--- a/data/transactions/application.go
+++ b/data/transactions/application.go
@@ -454,24 +454,26 @@ func (ac ApplicationCallTxnFields) wellFormed(proto config.ConsensusParams) erro
 	}
 
 	effectiveEPP := ac.ExtraProgramPages
-	// Schemas and ExtraProgramPages may only be set during application creation
-	// and explicit attempts to change size during updates.
-	if ac.ApplicationID != 0 && !(proto.AppSizeUpdates && ac.UpdatingSizes()) {
-		if !ac.GlobalStateSchema.Empty() {
-			return fmt.Errorf("inappropriate non-zero tx.GlobalStateSchema (%v)",
-				ac.GlobalStateSchema)
-		}
+	if ac.ApplicationID != 0 {
+		// Local schema can only be set during creation
 		if !ac.LocalStateSchema.Empty() {
 			return fmt.Errorf("inappropriate non-zero tx.LocalStateSchema (%v)",
 				ac.LocalStateSchema)
 		}
-		if ac.ExtraProgramPages != 0 {
-			return fmt.Errorf("inappropriate non-zero tx.ExtraProgramPages (%d)",
-				ac.ExtraProgramPages)
+		// Global schema and extra program pages can only be set during creation or update
+		if !(proto.AppSizeUpdates && ac.UpdatingSizes()) {
+			if !ac.GlobalStateSchema.Empty() {
+				return fmt.Errorf("inappropriate non-zero tx.GlobalStateSchema (%v)",
+					ac.GlobalStateSchema)
+			}
+			if ac.ExtraProgramPages != 0 {
+				return fmt.Errorf("inappropriate non-zero tx.ExtraProgramPages (%d)",
+					ac.ExtraProgramPages)
+			}
+			// allow maximum size programs for now, since we have not checked
+			// the app params to know the actual epp.
+			effectiveEPP = uint32(proto.MaxAbsoluteExtraProgramPages)
 		}
-		// allow maximimum size programs for now, since we have not checked the
-		// app params to know the actual epp.
-		effectiveEPP = uint32(proto.MaxAbsoluteExtraProgramPages)
 	}
 
 	if err := ac.WellSizedPrograms(effectiveEPP, proto); err != nil {

--- a/data/transactions/application_test.go
+++ b/data/transactions/application_test.go
@@ -463,10 +463,6 @@ func TestAppCallCreateWellFormed(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			// test the same thing for update, unless test has epp, which is illegal in update
-			if tc.ac.ExtraProgramPages != 0 {
-				return
-			}
 			tc.ac.OnCompletion = UpdateApplicationOC
 			tc.ac.ApplicationID = 1
 			err = tc.ac.wellFormed(config.Consensus[cv])
@@ -840,6 +836,19 @@ func TestWellFormedErrors(t *testing.T) {
 				GlobalStateSchema: basics.StateSchema{NumByteSlice: 1},
 				OnCompletion:      UpdateApplicationOC,
 			},
+		},
+		{
+			ac: ApplicationCallTxnFields{
+				ApplicationID:     1,
+				ApprovalProgram:   v5,
+				ClearStateProgram: v5,
+				// Local schema is fixed at creation, so it stays illegal even in
+				// an update that is allowed to set the other sizing fields.
+				LocalStateSchema:  basics.StateSchema{NumUint: 1},
+				ExtraProgramPages: 1,
+				OnCompletion:      UpdateApplicationOC,
+			},
+			expectedError: "inappropriate non-zero tx.LocalStateSchema",
 		},
 		{
 			ac: ApplicationCallTxnFields{


### PR DESCRIPTION
We should not allow (yet ignore) local schema update.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
