### PR TITLE
avm: improve byte constant immediate reporting

### DIFF
--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -3289,11 +3289,9 @@ func parseByteImmArgs(program []byte, pos int) (bytec [][]byte, nextpc int, err 
 			err = fmt.Errorf("could not decode []byte const[%d] at pc=%d", i, pos)
 			return
 		}
+		// pos <= len(program) is guaranteed: Uvarint reports bytesUsed > 0
+		// only when the varint terminated inside the slice.
 		pos += bytesUsed
-		if pos > len(program) {
-			err = errShortByteImmArgs
-			return
-		}
 		end := uint64(pos) + itemLen
 		if end > uint64(len(program)) || end < uint64(pos) {
 			err = errShortByteImmArgs

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -3282,7 +3282,7 @@ func parseByteImmArgs(program []byte, pos int) (bytec [][]byte, nextpc int, err 
 			return
 		}
 		pos += bytesUsed
-		if pos >= len(program) {
+		if pos > len(program) {
 			err = errShortByteImmArgs
 			return
 		}

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -930,6 +930,10 @@ func asmByteImmArgs(ops *OpStream, spec *OpSpec, args []token) ([][]byte, *sourc
 			// in the face of errors.  Hard.
 			return nil, rest[0].errorf("%s %w", spec.Name, err)
 		}
+		if len(val) > maxStringSize {
+			return nil, rest[0].errorf("%s arg %d is too big (%d bytes, limit %d)",
+				spec.Name, len(bvals), len(val), maxStringSize)
+		}
 		bvals = append(bvals, val)
 		rest = rest[consumed:]
 	}
@@ -3296,7 +3300,7 @@ func parseByteImmArgs(program []byte, pos int) (bytec [][]byte, nextpc int, err 
 
 func checkByteImmArgs(cx *EvalContext) error {
 	var err error
-	_, cx.nextpc, err = parseByteImmArgs(cx.program, cx.pc+1)
+	_, cx.nextpc, err = cx.byteImmArgs()
 	return err
 }
 

--- a/data/transactions/logic/assembler.go
+++ b/data/transactions/logic/assembler.go
@@ -643,6 +643,10 @@ func asmPushBytes(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *so
 	if len(args) != consumed {
 		return args[consumed].errorf("%s with extraneous argument", mnemonic.str)
 	}
+	if len(val) > maxStringSize {
+		return args[0].errorf("%s value is too big (%d bytes, limit %d)",
+			mnemonic.str, len(val), maxStringSize)
+	}
 	ops.pending.WriteByte(spec.Opcode)
 	var scratch [binary.MaxVarintLen64]byte
 	vlen := binary.PutUvarint(scratch[:], uint64(len(val)))
@@ -848,6 +852,10 @@ func asmByte(ops *OpStream, spec *OpSpec, mnemonic token, args []token) *sourceE
 	}
 	if len(args) != consumed {
 		return args[consumed].errorf("%s with extraneous argument", spec.Name)
+	}
+	if len(val) > maxStringSize {
+		return args[0].errorf("%s value is too big (%d bytes, limit %d)",
+			spec.Name, len(val), maxStringSize)
 	}
 	err = ops.byteLiteral(val)
 	if err != nil {

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -1840,11 +1840,11 @@ func TestAssembleBranchTooFar(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	// Each chunk: pushbytes opcode (1) + length varint (3) + 16 KB data (1<<14)
-	// + pop (1). 65 chunks gives ~1.04 MB between b and done, comfortably above
-	// the 2^20 limit on a 3-byte varint placeholder.
-	const chunkData = 1 << 14
-	const chunks = 65
+	// Each chunk: pushbytes opcode (1) + length varint (2) + maxStringSize data
+	// (4096) + pop (1). 260 chunks gives ~1.07 MB between b and done,
+	// comfortably above the 2^20 limit on a 3-byte varint placeholder.
+	const chunkData = maxStringSize
+	const chunks = 260
 
 	var src strings.Builder
 	src.Grow(chunks * (2*chunkData + 32))
@@ -2204,6 +2204,9 @@ func TestConstantArgs(t *testing.T) {
 		testProg(t, "byte b32", v, exp(1, "byte b32 needs byte literal argument"))
 		testProg(t, "byte 0xaa 0xbb", v, exp(1, "byte with extraneous argument", 10))
 		testProg(t, "byte b32 MFRGGZDFMY MFRGGZDFMY", v, exp(1, "byte with extraneous argument", 20))
+		testProg(t, "byte 0x"+strings.Repeat("aa", maxStringSize), v)
+		testProg(t, "byte 0x"+strings.Repeat("aa", maxStringSize+1), v,
+			exp(1, "byte value is too big (4097 bytes, limit 4096)"))
 		testProg(t, "bytec", v, exp(1, "bytec expects 1 immediate argument"))
 		testProg(t, "bytec 1 x", v, exp(1, "bytec expects 1 immediate argument"))
 		testProg(t, "bytec pay", v, exp(1, "unable to parse constant \"pay\" as integer", 6)) // don't accept "pay" constant
@@ -2223,6 +2226,9 @@ func TestConstantArgs(t *testing.T) {
 		testProg(t, "pushbytes b32", v, exp(1, "pushbytes b32 needs byte literal argument"))
 		testProg(t, "pushbytes b32(MFRGGZDFMY", v, exp(1, "pushbytes argument b32(MFRGGZDFMY lacks closing parenthesis"))
 		testProg(t, "pushbytes b32(MFRGGZDFMY)X", v, exp(1, "pushbytes argument b32(MFRGGZDFMY)X must end at first closing parenthesis"))
+		testProg(t, "pushbytes 0x"+strings.Repeat("aa", maxStringSize), v)
+		testProg(t, "pushbytes 0x"+strings.Repeat("aa", maxStringSize+1), v,
+			exp(1, "pushbytes value is too big (4097 bytes, limit 4096)"))
 	}
 
 	for v := uint64(8); v <= AssemblerMaxVersion; v++ {

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -2237,6 +2237,16 @@ func TestConstantArgs(t *testing.T) {
 		testProg(t, "pushbytess b32(MFRGGZDFMY) b32(MFRGGZDFMY)", v)
 		testProg(t, "pushbytess b32 MFRGGZDFMY b32 MFRGGZDFMY", v)
 		testProg(t, "pushbytess b32(MFRGGZDFMY b32(MFRGGZDFMY)", v, exp(1, "pushbytess argument b32(MFRGGZDFMY lacks closing parenthesis"))
+
+		testProg(t, "pushbytess 0x"+strings.Repeat("aa", maxStringSize), v)
+		testProg(t, "pushbytess 0x"+strings.Repeat("aa", maxStringSize+1), v,
+			exp(1, "pushbytess arg 0 is too big (4097 bytes, limit 4096)"))
+		testProg(t, "pushbytess 0xaa 0x"+strings.Repeat("aa", maxStringSize+1), v,
+			exp(1, "pushbytess arg 1 is too big (4097 bytes, limit 4096)"))
+
+		testProg(t, "bytecblock 0x"+strings.Repeat("aa", maxStringSize), v)
+		testProg(t, "bytecblock 0x"+strings.Repeat("aa", maxStringSize+1), v,
+			exp(1, "bytecblock arg 0 is too big (4097 bytes, limit 4096)"))
 	}
 }
 

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -4148,6 +4148,10 @@ func TestAssemblePushConsts(t *testing.T) {
 	ops = testProg(t, source, AssemblerMaxVersion)
 	requireProgramLen(t, source, AssemblerMaxVersion, ops.Program, 515) // prefix + opcode (1) + len (2) + bytess (512)
 
+	source = `int 1; pushbytess ""`
+	ops = testProg(t, source, AssemblerMaxVersion)
+	require.Equal(t, []byte{byte(AssemblerMaxVersion), 0x81, 0x01, 0x82, 0x01, 0x00}, ops.Program)
+
 	// enforce correct types
 	source = `pushints "1" "2" "3"`
 	testProg(t, source, AssemblerMaxVersion, exp(1, `strconv.ParseUint: parsing "\"1\"": invalid syntax`))

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -2704,6 +2704,22 @@ func opPushBytes(cx *EvalContext) error {
 	return nil
 }
 
+// rejectTrailingEmptyByteImm reproduces a parsing bug that existed before
+// version 13: an empty final constant, ending exactly at the end of the
+// program, was reported as running past the end of the program. Since the bug
+// could only cause errors, and programs are checked when they are put on
+// chain, no stored program depends on it. Once v13 is in effect, this
+// function and its call sites can simply be deleted.
+func (cx *EvalContext) rejectTrailingEmptyByteImm(bytec [][]byte, nextpc int) error {
+	if cx.Proto.LogicSigVersion >= 13 {
+		return nil
+	}
+	if nextpc == len(cx.program) && len(bytec) > 0 && len(bytec[len(bytec)-1]) == 0 {
+		return errShortByteImmArgs
+	}
+	return nil
+}
+
 func checkByteImmSizes(cx *EvalContext, bytess [][]byte) error {
 	if cx.Proto.LogicSigVersion >= 13 {
 		for i, b := range bytess {
@@ -2717,10 +2733,13 @@ func checkByteImmSizes(cx *EvalContext, bytess [][]byte) error {
 }
 
 // byteImmArgs parses the byte constants of a bytecblock or pushbytess at the
-// current pc, enforcing the size limit.
+// current pc, enforcing the size limit and the historical trailing-empty bug.
 func (cx *EvalContext) byteImmArgs() ([][]byte, int, error) {
 	bytec, nextpc, err := parseByteImmArgs(cx.program, cx.pc+1)
 	if err != nil {
+		return nil, 0, err
+	}
+	if err := cx.rejectTrailingEmptyByteImm(bytec, nextpc); err != nil {
 		return nil, 0, err
 	}
 	if err := checkByteImmSizes(cx, bytec); err != nil {

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -2707,34 +2707,6 @@ func opPushBytes(cx *EvalContext) error {
 	return nil
 }
 
-// rejectTrailingEmptyByteImm reproduces a parsing bug that existed before
-// version 13: an empty final constant, ending exactly at the end of the
-// program, was reported as running past the end of the program. Since the bug
-// could only cause errors, and programs are checked when they are put on
-// chain, no stored program depends on it. Once v13 is in effect, this
-// function and its call sites can simply be deleted.
-func (cx *EvalContext) rejectTrailingEmptyByteImm(bytec [][]byte, nextpc int) error {
-	if cx.Proto.LogicSigVersion >= 13 {
-		return nil
-	}
-	if nextpc == len(cx.program) && len(bytec) > 0 && len(bytec[len(bytec)-1]) == 0 {
-		return errShortByteImmArgs
-	}
-	return nil
-}
-
-func checkByteImmSizes(cx *EvalContext, bytess [][]byte) error {
-	if cx.Proto.LogicSigVersion >= 13 {
-		for i, b := range bytess {
-			if len(b) > maxStringSize {
-				return fmt.Errorf("%s arg %d is too big (%d bytes, limit %d)",
-					cx.GetOpSpec().Name, i, len(b), maxStringSize)
-			}
-		}
-	}
-	return nil
-}
-
 // byteImmArgs parses the byte constants of a bytecblock or pushbytess at the
 // current pc, enforcing the size limit and the historical trailing-empty bug.
 func (cx *EvalContext) byteImmArgs() ([][]byte, int, error) {
@@ -2742,11 +2714,25 @@ func (cx *EvalContext) byteImmArgs() ([][]byte, int, error) {
 	if err != nil {
 		return nil, 0, err
 	}
-	if err := cx.rejectTrailingEmptyByteImm(bytec, nextpc); err != nil {
-		return nil, 0, err
-	}
-	if err := checkByteImmSizes(cx, bytec); err != nil {
-		return nil, 0, err
+	if cx.Proto.LogicSigVersion >= 13 {
+		// Each constant is a sub-slice of the program, so none can exceed
+		// maxStringSize unless the program itself does.
+		if len(cx.program) > maxStringSize {
+			for i, b := range bytec {
+				if len(b) > maxStringSize {
+					return nil, 0, fmt.Errorf("%s arg %d is too big (%d bytes, limit %d)",
+						cx.GetOpSpec().Name, i, len(b), maxStringSize)
+				}
+			}
+		}
+	} else if nextpc == len(cx.program) && len(bytec) > 0 && len(bytec[len(bytec)-1]) == 0 {
+		// Reproduce a parsing bug that existed before version 13: an empty
+		// final constant, ending exactly at the end of the program, was
+		// reported as running past the end of the program. Since the bug
+		// could only cause errors, and programs are checked when they are put
+		// on chain, no stored program depends on it. Once v13 is in effect,
+		// this else branch can simply be deleted.
+		return nil, 0, errShortByteImmArgs
 	}
 	return bytec, nextpc, nil
 }

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -1884,13 +1884,17 @@ func (cx *EvalContext) checkStep() (cost int, err error) {
 	return cost, nil
 }
 
-func (cx *EvalContext) ensureStackCap(targetCap int) {
+func (cx *EvalContext) ensureStackCap(targetCap int) error {
+	if targetCap > maxStackDepth {
+		return errors.New("stack overflow")
+	}
 	if cap(cx.Stack) < targetCap {
 		// Let's grow all at once, plus a little slack.
 		newStack := make([]stackValue, len(cx.Stack), targetCap+4)
 		copy(newStack, cx.Stack)
 		cx.Stack = newStack
 	}
+	return nil
 }
 
 func opErr(cx *EvalContext) error {
@@ -2648,10 +2652,9 @@ func opPushInts(cx *EvalContext) error {
 		return err
 	}
 	finalLen := len(cx.Stack) + len(intc)
-	if finalLen > maxStackDepth {
-		return errors.New("stack overflow")
+	if err := cx.ensureStackCap(finalLen); err != nil {
+		return err
 	}
-	cx.ensureStackCap(finalLen)
 	for _, cint := range intc {
 		sv := stackValue{Uint: cint}
 		cx.Stack = append(cx.Stack, sv)
@@ -2741,10 +2744,9 @@ func opPushBytess(cx *EvalContext) error {
 		return err
 	}
 	finalLen := len(cx.Stack) + len(cbytess)
-	if finalLen > maxStackDepth {
-		return errors.New("stack overflow")
+	if err := cx.ensureStackCap(finalLen); err != nil {
+		return err
 	}
-	cx.ensureStackCap(finalLen)
 	for _, cbytes := range cbytess {
 		sv := stackValue{Bytes: cbytes}
 		cx.Stack = append(cx.Stack, sv)

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -2648,6 +2648,9 @@ func opPushInts(cx *EvalContext) error {
 		return err
 	}
 	finalLen := len(cx.Stack) + len(intc)
+	if finalLen > maxStackDepth {
+		return errors.New("stack overflow")
+	}
 	cx.ensureStackCap(finalLen)
 	for _, cint := range intc {
 		sv := stackValue{Uint: cint}
@@ -2754,6 +2757,9 @@ func opPushBytess(cx *EvalContext) error {
 		return err
 	}
 	finalLen := len(cx.Stack) + len(cbytess)
+	if finalLen > maxStackDepth {
+		return errors.New("stack overflow")
+	}
 	cx.ensureStackCap(finalLen)
 	for _, cbytes := range cbytess {
 		sv := stackValue{Bytes: cbytes}

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -2659,7 +2659,7 @@ func opPushInts(cx *EvalContext) error {
 
 func opByteConstBlock(cx *EvalContext) error {
 	var err error
-	cx.bytec, cx.nextpc, err = parseByteImmArgs(cx.program, cx.pc+1)
+	cx.bytec, cx.nextpc, err = cx.byteImmArgs()
 	return err
 }
 
@@ -2704,8 +2704,33 @@ func opPushBytes(cx *EvalContext) error {
 	return nil
 }
 
+func checkByteImmSizes(cx *EvalContext, bytess [][]byte) error {
+	if cx.Proto.LogicSigVersion >= 13 {
+		for i, b := range bytess {
+			if len(b) > maxStringSize {
+				return fmt.Errorf("%s arg %d is too big (%d bytes, limit %d)",
+					cx.GetOpSpec().Name, i, len(b), maxStringSize)
+			}
+		}
+	}
+	return nil
+}
+
+// byteImmArgs parses the byte constants of a bytecblock or pushbytess at the
+// current pc, enforcing the size limit.
+func (cx *EvalContext) byteImmArgs() ([][]byte, int, error) {
+	bytec, nextpc, err := parseByteImmArgs(cx.program, cx.pc+1)
+	if err != nil {
+		return nil, 0, err
+	}
+	if err := checkByteImmSizes(cx, bytec); err != nil {
+		return nil, 0, err
+	}
+	return bytec, nextpc, nil
+}
+
 func opPushBytess(cx *EvalContext) error {
-	cbytess, nextpc, err := parseByteImmArgs(cx.program, cx.pc+1)
+	cbytess, nextpc, err := cx.byteImmArgs()
 	if err != nil {
 		return err
 	}

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -2715,14 +2715,12 @@ func (cx *EvalContext) byteImmArgs() ([][]byte, int, error) {
 		return nil, 0, err
 	}
 	if cx.Proto.LogicSigVersion >= 13 {
-		// Each constant is a sub-slice of the program, so none can exceed
-		// maxStringSize unless the program itself does.
-		if len(cx.program) > maxStringSize {
-			for i, b := range bytec {
-				if len(b) > maxStringSize {
-					return nil, 0, fmt.Errorf("%s arg %d is too big (%d bytes, limit %d)",
-						cx.GetOpSpec().Name, i, len(b), maxStringSize)
-				}
+		// Once v13 is in effect, this check could move into parseByteImmArgs,
+		// which already loops over the constants.
+		for i, b := range bytec {
+			if len(b) > maxStringSize {
+				return nil, 0, fmt.Errorf("%s arg %d is too big (%d bytes, limit %d)",
+					cx.GetOpSpec().Name, i, len(b), maxStringSize)
 			}
 		}
 	} else if nextpc == len(cx.program) && len(bytec) > 0 && len(bytec[len(bytec)-1]) == 0 {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -6463,6 +6463,33 @@ func TestTrailingEmptyByteImm(t *testing.T) {
 		"", "stack finished with bytes not int")
 }
 
+func TestBulkPushStackDepth(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	bulk := func(name string, n int) []byte {
+		program := []byte{LogicVersion, OpsByName[LogicVersion][name].Opcode}
+		program = binary.AppendUvarint(program, uint64(n))
+		for range n {
+			if name == "pushbytess" {
+				program = append(program, 0x01, 0xaa)
+			} else {
+				program = append(program, 0x01)
+			}
+		}
+		return program
+	}
+
+	for _, name := range []string{"pushbytess", "pushints"} {
+		testLogicBytes(t, bulk(name, maxStackDepth), nil,
+			"", fmt.Sprintf("stack len is %d instead of 1", maxStackDepth))
+
+		testLogicBytes(t, bulk(name, maxStackDepth+1), nil, "", "stack overflow")
+
+		testLogicBytes(t, bulk(name, 8000), nil, "", "stack overflow")
+	}
+}
+
 func TestNoHeaderLedger(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -6413,6 +6413,56 @@ func TestPushBytessSize(t *testing.T) {
 	testLogicBytes(t, pushed(LogicVersion), nil, tooBigBcb, tooBigBcb)
 }
 
+func TestTrailingEmptyByteImm(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	const legacyVersion = 12
+	legacy := func() *EvalParams { return optSigParams(protoVer(legacyVersion)) }
+	ran := "const bytes list ran past end of program"
+
+	pop := OpsByName[LogicVersion]["pop"].Opcode
+	for _, v := range []struct {
+		name string
+		tail []byte
+	}{
+		{"pushbytess", []byte{pop, pop, 0x81, 0x01}},
+		{"bytecblock", []byte{0x81, 0x01}},
+	} {
+		opcode := OpsByName[LogicVersion][v.name].Opcode
+
+		trailing := func(version byte) []byte {
+			return []byte{version, 0x81, 0x01, 0x43, opcode, 0x01, 0x00}
+		}
+		testLogicBytes(t, trailing(legacyVersion), legacy(), ran, "")
+		testLogicBytes(t, trailing(LogicVersion), nil)
+
+		testLogicBytes(t, trailing(legacyVersion), nil)
+
+		short := func(version byte) []byte {
+			return []byte{version, opcode, 0x01, 0x05, 0x01, 0x02}
+		}
+		testLogicBytes(t, short(legacyVersion), legacy(), ran, ran)
+		testLogicBytes(t, short(LogicVersion), nil, ran, ran)
+
+		mid := func(version byte) []byte {
+			return append([]byte{version, opcode, 0x02, 0x00, 0x01, 0x61}, v.tail...)
+		}
+		testLogicBytes(t, mid(legacyVersion), legacy())
+		testLogicBytes(t, mid(LogicVersion), nil)
+	}
+
+	pushbytess := OpsByName[LogicVersion]["pushbytess"].Opcode
+
+	assembled := testProg(t, `int 1; return; pushbytess ""`, LogicVersion).Program
+	require.Equal(t, []byte{LogicVersion, 0x81, 0x01, 0x43, pushbytess, 0x01, 0x00}, assembled)
+	_, err := Disassemble(assembled)
+	require.NoError(t, err)
+
+	testLogicBytes(t, []byte{LogicVersion, pushbytess, 0x01, 0x00}, nil,
+		"", "stack finished with bytes not int")
+}
+
 func TestNoHeaderLedger(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -6334,6 +6334,85 @@ int 1
 `, 8)
 }
 
+func TestPushBytessSize(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	const legacyVersion = 12
+	legacy := func() *EvalParams { return optSigParams(protoVer(legacyVersion)) }
+
+	pushbytess := OpsByName[LogicVersion]["pushbytess"].Opcode
+	pop := OpsByName[LogicVersion]["pop"].Opcode
+
+	imm := func(version byte, lengths ...int) []byte {
+		program := []byte{version, pushbytess}
+		program = binary.AppendUvarint(program, uint64(len(lengths)))
+		for _, n := range lengths {
+			program = binary.AppendUvarint(program, uint64(n))
+			program = append(program, make([]byte, n)...)
+		}
+		return program
+	}
+	tail := func(program []byte, pushed int) []byte {
+		for range pushed {
+			program = append(program, pop)
+		}
+		return append(program, 0x81, 0x01)
+	}
+	tooBigErr := "pushbytess arg 0 is too big (4097 bytes, limit 4096)"
+
+	testLogicBytes(t, tail(imm(legacyVersion, maxStringSize), 1), legacy())
+	testLogicBytes(t, tail(imm(LogicVersion, maxStringSize), 1), nil)
+
+	testLogicBytes(t, tail(imm(legacyVersion, maxStringSize+1), 1), legacy())
+	testLogicBytes(t, tail(imm(LogicVersion, maxStringSize+1), 1), nil, tooBigErr, tooBigErr)
+
+	testLogicBytes(t, tail(imm(legacyVersion, 1, maxStringSize+1), 2), legacy())
+	testLogicBytes(t, tail(imm(LogicVersion, 1, maxStringSize+1), 2), nil,
+		"pushbytess arg 1 is too big", "pushbytess arg 1 is too big")
+
+	observable := func(version byte) []byte {
+		program := imm(version, maxStringSize+1)
+		program = append(program, OpsByName[LogicVersion]["len"].Opcode, 0x81)
+		program = binary.AppendUvarint(program, maxStringSize+1)
+		return append(program, OpsByName[LogicVersion]["=="].Opcode)
+	}
+	testLogicBytes(t, observable(legacyVersion), legacy())
+	testLogicBytes(t, observable(LogicVersion), nil, tooBigErr, tooBigErr)
+
+	dupn := func(version byte) []byte {
+		program := imm(version, maxStringSize+1)
+		program = append(program, OpsByName[LogicVersion]["dupn"].Opcode, 0x02)
+		return tail(program, 3)
+	}
+	testLogicBytes(t, dupn(legacyVersion), legacy())
+	testLogicBytes(t, dupn(LogicVersion), nil, tooBigErr, tooBigErr)
+
+	testLogicBytes(t, tail(imm(legacyVersion, maxStringSize+1), 1), nil, tooBigErr, tooBigErr)
+
+	bytecblock := OpsByName[LogicVersion]["bytecblock"].Opcode
+	unpushed := func(version byte) []byte {
+		program := []byte{version, bytecblock}
+		program = binary.AppendUvarint(program, 1)
+		program = binary.AppendUvarint(program, maxStringSize+1)
+		program = append(program, make([]byte, maxStringSize+1)...)
+		return append(program, 0x81, 0x01)
+	}
+	tooBigBcb := "bytecblock arg 0 is too big (4097 bytes, limit 4096)"
+	testLogicBytes(t, unpushed(legacyVersion), legacy())
+	testLogicBytes(t, unpushed(LogicVersion), nil, tooBigBcb, tooBigBcb)
+	testLogicBytes(t, unpushed(legacyVersion), nil, tooBigBcb, tooBigBcb)
+
+	tooBigBytec := "bytec_0 produced a too big (4097) byte-array"
+	pushed := func(version byte) []byte {
+		program := unpushed(version)
+		return append(program[:len(program)-2],
+			OpsByName[LogicVersion]["bytec_0"].Opcode, OpsByName[LogicVersion]["len"].Opcode)
+	}
+	testLogicBytes(t, pushed(legacyVersion), legacy(), "", tooBigBytec)
+	testLogicBytes(t, pushed(LogicVersion), nil, tooBigBcb, tooBigBcb)
+}
+
 func TestNoHeaderLedger(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()

--- a/data/transactions/logic/frames.go
+++ b/data/transactions/logic/frames.go
@@ -114,7 +114,9 @@ func opDupN(cx *EvalContext) error {
 
 	n := int(cx.program[cx.pc+1])
 	finalLen := len(cx.Stack) + n
-	cx.ensureStackCap(finalLen)
+	if err := cx.ensureStackCap(finalLen); err != nil {
+		return err
+	}
 	for i := 0; i < n; i++ {
 		// There will be enough room that this will not allocate
 		cx.Stack = append(cx.Stack, cx.Stack[last])


### PR DESCRIPTION
Improve byte constant immediate handling, so they get the same error reporting as byte values elsewhere in the AVM. Also fixes an off-by-one that rejected a trailing empty byte constant, and reports stack overflow from bulk pushes up front instead of after the fact.