### PR TITLE
AVM: report actual inner group fee shortfall

### DIFF
--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -5898,9 +5898,9 @@ func opItxnSubmit(cx *EvalContext) (err error) {
 		shortfall := groupFee.SubSaturate(groupPaid)
 		if cx.FeeCredit == nil || cx.FeeCredit.LessThan(shortfall) {
 			if cx.FeeCredit != nil {
-				groupFee = groupFee.SubSaturate(*cx.FeeCredit)
+				shortfall = shortfall.SubSaturate(*cx.FeeCredit)
 			}
-			return fmt.Errorf("group fee %s too small (needs %s more) %#v", groupPaid, groupFee, cx.subtxns)
+			return fmt.Errorf("group fee %s too small (needs %s more) %#v", groupPaid, shortfall, cx.subtxns)
 		}
 		*cx.FeeCredit = cx.FeeCredit.SubSaturate(shortfall)
 	} else {

--- a/data/transactions/logic/evalAppTxn_test.go
+++ b/data/transactions/logic/evalAppTxn_test.go
@@ -1073,15 +1073,16 @@ txn Sender; itxn_field Receiver;
 	// Note size 540 increases fee by 1.040_000 factor. But the first problem is
 	// that the default fee population mechanism can't know about the big Note,
 	// so it tries to populate for 2 basic transactions, which is 2002-401=1601.
-	// The "need" is 1.642 because one of the transaction's costs goes from 1001
-	// to ceil(1001*1.040) = 1042.
+	// The requirement is 2.043 because one of the transaction's costs goes from
+	// 1001 to ceil(1001*1.040) = 1042. After the 401 fee credit, paying 1601
+	// leaves the group 41uA short.
 	ledger.NewAccount(appAddr(888), 1000+2*minFee-401) // replenish
 	TestApp(t, "itxn_begin"+pay+"itxn_next"+pay+
 		"int 540; bzero; itxn_field Note; itxn_submit; int 1", ep,
-		"group fee 1.601mA too small (needs 1.642mA more)")
+		"group fee 1.601mA too small (needs 41uA more)")
 	TestApp(t, "itxn_begin"+pay+"itxn_next"+pay+
 		"int 540; bzero; itxn_field Note; int 1041; itxn_field Fee; itxn_submit; int 1", ep,
-		"group fee 1.641mA too small (needs 1.642mA more)")
+		"group fee 1.641mA too small (needs 1uA more)")
 	ledger.NewAccount(appAddr(888), 1000+2*minFee-401+41) // replenish
 	TestApp(t, "itxn_begin"+pay+"itxn_next"+pay+
 		"int 540; bzero; itxn_field Note; int 1042; itxn_field Fee; itxn_submit; int 1", ep)


### PR DESCRIPTION
Fix the `itxn_submit` error message to report the actual additional fee needed when an inner transaction group underpays.

Previously, the message subtracted available fee credit from the required group fee but did not subtract the fee already paid by the inner group. This overstated the remaining shortfall.

The reported amount is now calculated as:
> required group fee - paid group fee - available fee credit

Tests have been updated to verify both a 41 µAlgo shortfall and a 1 µAlgo boundary case. This only changes error reporting; fee validation and accounting behavior are unchanged.