### PR TITLE
ci: bind nightly/PR workflow inputs via env before shell

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -290,8 +290,10 @@ jobs:
           BRANCH_NAME: ${{ github.event.inputs.branch || github.ref_name }}
         run: |
           # Set CI_E2E_FILENAME based on branch name, replacing '/' with '-' - used when publishing e2e test data to S3 (e2e.sh) for indexer tests
-          MODIFIED_BRANCH_NAME="${BRANCH_NAME//\//-}"
-          echo "CI_E2E_FILENAME=${MODIFIED_BRANCH_NAME}" >> $GITHUB_ENV
+          # Drop CR/LF first: workflow_dispatch inputs are free-form, and a newline here would append extra entries to the $GITHUB_ENV file
+          SANITIZED_BRANCH_NAME="${BRANCH_NAME//[$'\r\n']/}"
+          MODIFIED_BRANCH_NAME="${SANITIZED_BRANCH_NAME//\//-}"
+          echo "CI_E2E_FILENAME=${MODIFIED_BRANCH_NAME}" >> "$GITHUB_ENV"
       - name: Download workspace archive
         uses: actions/download-artifact@v4
         with:
@@ -396,10 +398,11 @@ jobs:
           S3_RELEASE_BUCKET: ${{ secrets.S3_RELEASE_BUCKET }}
         timeout-minutes: 20
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/rel/nightly" ]]; then
+          # GITHUB_REF/GITHUB_REF_NAME are runner-provided defaults, so the ref never reaches the shell as interpolated text
+          if [[ "$GITHUB_REF" == "refs/heads/rel/nightly" ]]; then
             export NIGHTLY_BUILD="true"
           fi
-          export TRAVIS_BRANCH="${{ github.ref_name }}"
+          export TRAVIS_BRANCH="$GITHUB_REF_NAME"
           scripts/travis/deploy_packages.sh
         shell: bash
       - name: Notify Slack on failure

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -286,9 +286,10 @@ jobs:
       AWS_ROLE: ${{ secrets.AWS_ROLE }}
     steps:
       - name: Set CI_E2E_FILENAME for e2e test data publishing
+        env:
+          BRANCH_NAME: ${{ github.event.inputs.branch || github.ref_name }}
         run: |
           # Set CI_E2E_FILENAME based on branch name, replacing '/' with '-' - used when publishing e2e test data to S3 (e2e.sh) for indexer tests
-          BRANCH_NAME="${{ github.event.inputs.branch || github.ref_name }}"
           MODIFIED_BRANCH_NAME="${BRANCH_NAME//\//-}"
           echo "CI_E2E_FILENAME=${MODIFIED_BRANCH_NAME}" >> $GITHUB_ENV
       - name: Download workspace archive

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -59,11 +59,13 @@ jobs:
       - name: Setup test environment
         uses: ./.github/actions/setup-test
       - name: Run tests
+        env:
+          FULL_COVERAGE: ${{ inputs.full_coverage }}
         run: |
           PACKAGES="$(go list ./... | grep -v /go-algorand/test/)"
           export PACKAGE_NAMES=$(echo $PACKAGES | tr -d '\n')
           COVERPKG_FLAG=""
-          if [[ "${{ inputs.full_coverage }}" == "true" ]]; then
+          if [[ "$FULL_COVERAGE" == "true" ]]; then
             COVERPACKAGES="$(go list ./... | grep -E -v '/go-algorand/(test|debug|cmd|config/defaultsGenerator|tools)' | grep -E -v '(test|testing|mock|mocks)$' | paste -sd ',' -)"
             COVERPKG_FLAG="-coverpkg=$COVERPACKAGES"
           fi


### PR DESCRIPTION
## Summary
- Bind `github.event.inputs.branch || github.ref_name` through `env:` before CI_E2E_FILENAME construction in `ci-nightly.yml`.
- Bind `inputs.full_coverage` through `env:` before the coverage package selection shell branch in `ci-pr.yml`.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] Nightly still derives CI_E2E_FILENAME from branch/ref
- [ ] PR tests with full_coverage=true still enable -coverpkg


Made with [Cursor](https://cursor.com)