### PR TITLE
AVM: Fix reversed costs arguments

### DIFF
--- a/data/transactions/logic/TEAL_opcodes_v13.md
+++ b/data/transactions/logic/TEAL_opcodes_v13.md
@@ -1194,7 +1194,7 @@ Signature B is variable-length, with maximum size 1423 bytes.
 - Bytecode: 0x87
 - Stack: ..., A: []byte &rarr; ..., [64]byte
 - SHA512 of value A, yields [64]byte
-- **Cost**: 15 + 32 per 2 bytes of A
+- **Cost**: 15 + 2 per 32 bytes of A
 - Availability: v13
 
 ## callsub

--- a/data/transactions/logic/crypto_test.go
+++ b/data/transactions/logic/crypto_test.go
@@ -882,6 +882,37 @@ int ` + fmt.Sprintf("%d", testLogicBudget-2500-8) + `
 	testAccepts(t, source, fidoVersion)
 }
 
+func testHashCost(t *testing.T, hash string, size int, expected int, intro uint64) {
+	hashCostCheck := `
+pushint %d
+bzero
+%s
+pop
+pushint ` + strconv.Itoa(testLogicBudget-5) + ` // 5 non sha instructions
+global OpcodeBudget
+-
+pushint %d
+==
+`
+	t.Helper()
+	testAccepts(t, fmt.Sprintf(hashCostCheck, size, hash, expected), intro)
+}
+
+func TestHashCosts(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	testHashCost(t, "sha512", 0, 15, 13)
+	testHashCost(t, "sha512", 1, 17, 13)
+	testHashCost(t, "sha512", 64, 19, 13)
+	testHashCost(t, "sha512", 1000, 79, 13)
+
+	testHashCost(t, "sumhash512", 0, 150, sumhashVersion)
+	testHashCost(t, "sumhash512", 1, 154, sumhashVersion)
+	testHashCost(t, "sumhash512", 64, 190, sumhashVersion)
+	testHashCost(t, "sumhash512", 1000, 722, sumhashVersion)
+}
+
 func BenchmarkHashes(b *testing.B) {
 	for _, hash := range []string{"sha256", "keccak256" /* skip, same as keccak "sha3_256", */, "sha512_256", "sumhash512", "mimc BN254Mp110", "mimc BLS12_381Mp111", "poseidon2 BN254t2", "poseidon2 BLS12_381t2", "sha512"} {
 		for _, size := range []int{0, 32, 128, 512, 1024, 4096} {

--- a/data/transactions/logic/langspec_v13.json
+++ b/data/transactions/logic/langspec_v13.json
@@ -3146,7 +3146,7 @@
         "[64]byte"
       ],
       "Size": 1,
-      "DocCost": "15 + 32 per 2 bytes of A",
+      "DocCost": "15 + 2 per 32 bytes of A",
       "Doc": "SHA512 of value A, yields [64]byte",
       "IntroducedVersion": 13,
       "Groups": [

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -701,8 +701,8 @@ var OpSpecs = []OpSpec{
 
 	{0x84, "ed25519verify_bare", opEd25519VerifyBare, proto("bb{64}b{32}:T"), 7, costly(1900)},
 	{0x85, "falcon_verify", opFalconVerify, proto("bbb{1793}:T"), 12, costly(1700)},
-	{0x86, "sumhash512", opSumhash512, proto("b:b{64}"), sumhashVersion, costByLength(150, 7, 4, 0)},
-	{0x87, "sha512", opSHA512, proto("b:b{64}"), 13, costByLength(15, 32, 2, 0)},
+	{0x86, "sumhash512", opSumhash512, proto("b:b{64}"), sumhashVersion, costByLength(150, 4, 7, 0)},
+	{0x87, "sha512", opSHA512, proto("b:b{64}"), 13, costByLength(15, 2, 32, 0)},
 
 	// "Function oriented"
 	{0x88, "callsub", opCallSub2B, proto(":"), 4, detBranch2B()},


### PR DESCRIPTION
Added a test so that one can easily insert some costs checks that ensure you've got the roughly the right costs.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines

In particular ensure that you've run the following:
* make generate
* make sanity (which runs make fmt, make lint, make fix and make vet)

It is also a good idea to run tests:
* make test
* make integration
-->

## Summary

<!-- Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged. -->

## Test Plan

<!-- How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale. -->
