### PR TITLE
tests: fix flaky peer-count assertions in network tests

### DIFF
--- a/network/websocketProxy_test.go
+++ b/network/websocketProxy_test.go
@@ -309,7 +309,12 @@ func TestWebsocketProxyWsNet(t *testing.T) {
 		return len(netB.GetPeers(PeersConnectedOut)) == 1
 	}, 5*time.Second, 10*time.Millisecond)
 
-	require.Equal(t, 1, len(netA.GetPeers(PeersConnectedIn)))
+	// netA is the server for this connection: the client's dial completes at
+	// the websocket upgrade, but netA only registers the peer via addPeer
+	// after the upgrade, so wait for it before asserting.
+	require.Eventually(t, func() bool {
+		return len(netA.GetPeers(PeersConnectedIn)) == 1
+	}, 5*time.Second, 10*time.Millisecond)
 	require.Equal(t, 0, len(netA.GetPeers(PeersConnectedOut)))
 	require.Equal(t, 0, len(netB.GetPeers(PeersConnectedIn)))
 	require.Equal(t, 1, len(netB.GetPeers(PeersConnectedOut)))

--- a/network/websocketProxy_test.go
+++ b/network/websocketProxy_test.go
@@ -309,12 +309,7 @@ func TestWebsocketProxyWsNet(t *testing.T) {
 		return len(netB.GetPeers(PeersConnectedOut)) == 1
 	}, 5*time.Second, 10*time.Millisecond)
 
-	// netA is the server for this connection: the client's dial completes at
-	// the websocket upgrade, but netA only registers the peer via addPeer
-	// after the upgrade, so wait for it before asserting.
-	require.Eventually(t, func() bool {
-		return len(netA.GetPeers(PeersConnectedIn)) == 1
-	}, 5*time.Second, 10*time.Millisecond)
+	require.Equal(t, 1, len(netA.GetPeers(PeersConnectedIn)))
 	require.Equal(t, 0, len(netA.GetPeers(PeersConnectedOut)))
 	require.Equal(t, 0, len(netB.GetPeers(PeersConnectedIn)))
 	require.Equal(t, 1, len(netB.GetPeers(PeersConnectedOut)))

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -2301,7 +2301,15 @@ func TestPeeringWithBadIdentityVerification(t *testing.T) {
 		}
 
 		assert.Equal(t, tc.totalInA, len(netA.GetPeers(PeersConnectedIn)))
-		assert.Equal(t, tc.totalOutA, len(netA.GetPeers(PeersConnectedOut)))
+		// in the failure cases, tryConnect has already registered the outgoing
+		// peer before sending the verification message; netA only drops it
+		// after netB rejects that message and closes the connection, so wait
+		// for the count to settle rather than asserting immediately
+		assert.Eventually(
+			t,
+			func() bool { return len(netA.GetPeers(PeersConnectedOut)) == tc.totalOutA },
+			5*time.Second,
+			100*time.Millisecond)
 		assert.Equal(t, tc.totalOutB, len(netB.GetPeers(PeersConnectedOut)))
 		// it is possible for NetB to be in the process of doing addPeer while
 		// the underlying connection is being closed. In this case, the read loop

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -1560,7 +1560,13 @@ func TestPeeringWithIdentityChallenge(t *testing.T) {
 	// A->B and A->C both open
 	assert.Equal(t, 0, len(netA.GetPeers(PeersConnectedIn)))
 	assert.Equal(t, 2, len(netA.GetPeers(PeersConnectedOut)))
-	assert.Equal(t, 1, len(netB.GetPeers(PeersConnectedIn)))
+	// the earlier wait for netB to settle at one inbound peer can pass before
+	// netB's addPeer has run for the abandoned second connection, in which
+	// case netB transiently reports two inbound peers here until the read
+	// loop reaps the closed one, so wait rather than assert equality
+	assert.Eventually(t, func() bool {
+		return len(netB.GetPeers(PeersConnectedIn)) == 1
+	}, time.Second, 50*time.Millisecond)
 	assert.Equal(t, 0, len(netB.GetPeers(PeersConnectedOut)))
 	assert.Equal(t, 1, len(netC.GetPeers(PeersConnectedIn)))
 	assert.Equal(t, 0, len(netC.GetPeers(PeersConnectedOut)))

--- a/network/wsNetwork_test.go
+++ b/network/wsNetwork_test.go
@@ -4211,17 +4211,23 @@ func TestDiscardUnrequestedBlockResponse(t *testing.T) {
 		peerEnqueued: time.Now(),
 		ctx:          context.Background(),
 	}
+	// the metric is a package-wide counter, so compare against its value
+	// before the message rather than an absolute count
+	oldDropped := networkConnectionsDroppedTotal.GetUint64ValueForLabels(map[string]string{"reason": "unrequestedTS"})
 	netA.peers[0].sendBufferBulk <- msg
 	require.Eventually(t,
 		func() bool {
-			return networkConnectionsDroppedTotal.GetUint64ValueForLabels(map[string]string{"reason": "unrequestedTS"}) == 1
+			return networkConnectionsDroppedTotal.GetUint64ValueForLabels(map[string]string{"reason": "unrequestedTS"}) > oldDropped
 		},
 		1*time.Second,
 		50*time.Millisecond,
 	)
 
-	// Stop and confirm that we hit the case of disconnecting a peer for sending an unrequested block response
-	require.Zero(t, netB.NumPeers())
+	// Confirm that we hit the case of disconnecting a peer for sending an
+	// unrequested block response. The metric above is incremented in the read
+	// loop before the deferred cleanup unregisters the peer, so wait for the
+	// peer count to drop rather than asserting immediately.
+	require.Eventually(t, func() bool { return netB.NumPeers() == 0 }, 1*time.Second, 25*time.Millisecond)
 
 	netC.Start()
 	defer netC.Stop()


### PR DESCRIPTION
## Summary

Fixes three flaky network tests sharing one root cause: the server side of a
websocket connection only registers the peer via `addPeer()` after the upgrade
completes, while the client's dial returns at the upgrade itself. Asserting a
peer count on one side after synchronizing only on the other races against
that registration, or against the matching asynchronous removal on teardown.

- `TestPeeringWithIdentityChallenge`: the settle-wait can pass before netB's
  `addPeer` runs for the abandoned duplicate connection, so a later assert can
  see two inbound peers until the read loop reaps the closed one. A second
  race in the test addressed by #6657.
- `TestPeeringWithBadIdentityVerification`: netA's outgoing count was asserted
  behind a fixed 250ms sleep while the doomed peer's removal is asynchronous.
  Applies the same `Eventually` treatment the netB half already got.
- `TestDiscardUnrequestedBlockResponse`: the drop metric increments in the
  read loop before the deferred cleanup unregisters the peer, so waiting on
  the metric does not guarantee the peer count has dropped.

Running the last test with `-count=3` also exposed that it checked the
package-global drop metric against an absolute value, which only holds on the
first run in a process. It now compares against the value captured before the
message is sent.

An earlier commit on this branch also fixed `TestWebsocketProxyWsNet` (the
same race on netA's inbound registration); that change has been reverted
since #6701 landed a more suitable fix for it on master.

## Testing

Each test passes repeatedly under `-race` (`-count=3` to `-count=5`), as does
the full `./network/...` package. Each fix waits on the exact state transition
the code performs asynchronously rather than extending sleeps.
