### PR TITLE
network: remove GetNetworkType from wsPeer

### DIFF
--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -1698,7 +1698,6 @@ func TestP2PGetPeersTransportConnections(t *testing.T) {
 	require.Len(t, gossipPeers, 1)
 	gossipPeer, ok := gossipPeers[0].(*wsPeer)
 	require.True(t, ok)
-	require.Equal(t, PeerNetworkTypeLibP2P, gossipPeer.GetNetworkType())
 
 	connPeers := netA.GetPeers(PeersTransportConnectionsIn)
 	require.Len(t, connPeers, 1)

--- a/network/wsNetwork.go
+++ b/network/wsNetwork.go
@@ -560,7 +560,7 @@ func (wn *WebsocketNetwork) transportConnPeers(outgoing bool) []Peer {
 	var peers []Peer
 	for _, peer := range wn.peers {
 		if peer.outgoing == outgoing {
-			peers = append(peers, transportPeer{addr: peer.GetAddress(), networkType: peer.GetNetworkType()})
+			peers = append(peers, transportPeer{addr: peer.GetAddress(), networkType: PeerNetworkTypeWebsocket})
 		}
 	}
 	return peers

--- a/network/wsPeer.go
+++ b/network/wsPeer.go
@@ -482,14 +482,6 @@ func (wp *wsPeer) OriginAddress() string {
 	return wp.originAddress
 }
 
-// GetNetworkType returns the transport protocol carrying this peer connection.
-func (wp *wsPeer) GetNetworkType() PeerNetworkType {
-	if wp.peerType == peerTypeP2P {
-		return PeerNetworkTypeLibP2P
-	}
-	return PeerNetworkTypeWebsocket
-}
-
 func (wp *wsPeer) reportReadErr(err error) {
 	// only report error if we haven't already closed the peer
 	if wp.didInnerClose.Load() == 0 {

--- a/node/follower_node.go
+++ b/node/follower_node.go
@@ -372,6 +372,7 @@ func (node *AlgorandFollowerNode) StartCatchup(catchpoint string) error {
 	}
 	err = node.catchpointCatchupService.Start(node.ctx)
 	if err != nil {
+		node.catchpointCatchupService = nil
 		node.log.Warn(err.Error())
 		return MakeStartCatchpointError(catchpoint, err)
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -1230,6 +1230,7 @@ func (node *AlgorandFullNode) StartCatchup(catchpoint string) error {
 	}
 	err = node.catchpointCatchupService.Start(node.ctx)
 	if err != nil {
+		node.catchpointCatchupService = nil
 		node.log.Warn(err.Error())
 		return MakeStartCatchpointError(catchpoint, err)
 	}


### PR DESCRIPTION
## Summary

This PR combines two fixes:
1. a followup for the [comment](https://github.com/algorand/go-algorand/pull/6674#discussion_r3722245485) in #6674
2. Fixes `TestCatchpointCatchupErr` when the test sometimes fails:
   ```
       Error Trace:    /Users/runner/work/go-algorand/go-algorand/test/e2e-go/features/catchup/catchpointCatchup_test.go:193
                                   /Users/runner/work/go-algorand/go-algorand/test/e2e-go/features/catchup/catchpointCatchup_test.go:327
       Error:          Received unexpected error:
                       signal: killed
       Test:           TestCatchpointCatchupErr
       Messages:       Node at /Users/runner/work/go-algorand/go-algorand/tmp/out/e2e/297918-1784658828619/go/TestCatchpointCatchupErr/Node has terminated with error code -1
   ```
   The failure is caused when `node.Stop()` calls `catchpointCatchupService.Stop()` but the catchpoint service failed to start (`MakeStartCatchpointError` asserted by the test) so its `cancelCtxFunc` and `abortCtxFunc` are not initialized.
   Fixed by resetting `catchpointCatchupService` to nil. Alternative is to modify `CatchpointCatchupService.Start` and init context objects at the very beginning.

## Test Plan

Existing tests