### PR TITLE
tests: fix flaky races in TestAppEmptyBox and TestWebsocketProxyWsNet

### DIFF
--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -1449,8 +1449,16 @@ return
 		l1.AddBlock(blk, agreement.Certificate{})
 	}
 
+	// Wait for the blocks to reach the block DB before flushing the trackers.
+	// commitRound derives the round to flush from l1.Latest(), which counts
+	// blocks still queued in the blockQueue, and Close() discards whatever is
+	// left in that queue. Without this the tracker DB can end up ahead of the
+	// block DB, and reopening below resets the accounts DB back to genesis.
+	l1.WaitForCommit(l1.Latest())
+
 	app, err := l1.LookupApplication(l1.Latest(), creator, appIdx)
 	a.NoError(err)
+	a.NotNil(app.AppParams)
 	a.Greater(len(app.AppParams.ApprovalProgram), 0)
 
 	commitRound(10, 0, l1)
@@ -1464,6 +1472,9 @@ return
 
 	app, err = l2.LookupApplication(l2.Latest(), creator, appIdx)
 	a.NoError(err)
+	// LookupApplication reports a missing app as a nil AppParams with no error,
+	// so assert it exists rather than nil-dereferencing it below.
+	a.NotNil(app.AppParams)
 	a.Greater(len(app.AppParams.ApprovalProgram), 0)
 
 	txHeader = transactions.Header{

--- a/network/websocketProxy_test.go
+++ b/network/websocketProxy_test.go
@@ -305,8 +305,13 @@ func TestWebsocketProxyWsNet(t *testing.T) {
 	netB.wg.Add(1)
 	netB.tryConnect(wsProxyAddr, wsProxyGossip)
 
+	// Wait for both ends to register the connection, not just netB. netB records
+	// its outbound peer once the websocket handshake completes, but netA writes the
+	// 101 response before it finishes building the inbound peer and calls addPeer,
+	// so netA's side can still be empty when netB's is already populated.
 	require.Eventually(t, func() bool {
-		return len(netB.GetPeers(PeersConnectedOut)) == 1
+		return len(netB.GetPeers(PeersConnectedOut)) == 1 &&
+			len(netA.GetPeers(PeersConnectedIn)) == 1
 	}, 5*time.Second, 10*time.Millisecond)
 
 	require.Equal(t, 1, len(netA.GetPeers(PeersConnectedIn)))


### PR DESCRIPTION
## Summary

Fixes two independent flaky-test races surfaced by CI on this branch. Both are test-only synchronization bugs; no non-test code is changed.

## TestAppEmptyBox

Fix race condition in TestAppEmptyBox seen most recently in https://github.com/algorand/go-algorand/actions/runs/31008936525/job/92429913163 as:
```
=== FAIL: ledger TestAppEmptyBox (0.74s)
time="2026-08-05T20:09:42.708118 +0000" level=warning msg="trackerDBInitialize: resetting accounts DB (on round 10, but blocks DB's latest is 1)" file=trackerdb.go function=github.com/algorand/go-algorand/ledger.trackerDBInitialize line=71
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x198cf00]

goroutine 668 [running]:
testing.tRunner.func1.2({0x1f14c40, 0x31e3cc0})
	/opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1872 +0x419
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1875 +0x683
panic({0x1f14c40?, 0x31e3cc0?})
	/opt/hostedtoolcache/go/1.25.3/x64/src/runtime/panic.go:783 +0x132
github.com/algorand/go-algorand/ledger.TestAppEmptyBox(0xc004487a40)
	/home/runner/work/go-algorand/go-algorand/ledger/applications_test.go:1467 +0x1360
testing.tRunner(0xc004487a40, 0x23f86b0)
	/opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1934 +0x21d
created by testing.(*T).Run in goroutine 1
	/opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1997 +0x9d3
```

reproducible if you delay the block syncer goroutine in `ledger/blockqueue.go` with
```diff
        bq.l.log.Warnf("blockQueue.syncer: blockForgetBefore(%d): %v", minToSave, err)
      }

+     time.Sleep(50 * time.Millisecond) // simulate a descheduled syncer goroutine
      bq.mu.Lock()
    }
  }
  ```

> ## Cause
> 
> `blockQueue.stop()` sets `running = false`, and the syncer goroutine's loop head returns as soon as it observes that flag — without draining `bq.q`. Blocks still queued at that moment are discarded and never reach the block DB.
> 
> The test adds 12 blocks and then calls `commitRound(10, 0, l1)`. That helper derives the round to flush from `l.Latest()`, which counts blocks still sitting in the queue, so the tracker DB is flushed to round 10 even when the syncer has only written round 1 to disk. `l1.Close()` then drops the 11 queued blocks. On reopen, `trackerDBInitialize` sees `lastBalancesRound` (10) `> latestBlockRound` (1), resets the accounts DB and replays from the block DB — which now holds only round 1, so app 1002 is never created. `LookupApplication` reports a missing app as a nil `AppParams` with a nil error, so `a.NoError` passes and the next line dereferences nil.
> 
> Instrumenting the block queue at the moment `Close()` runs, the durable round is 1 while `Latest()` is 12 in 24 of 25 local runs. The test normally survives only because the syncer goroutine happens to get scheduled and drain the queue in the window between `commitRound` returning and `stop()` flipping the flag. On a loaded CI runner it loses that race.
> 
> ## Fix
> 
> `l1.WaitForCommit(l1.Latest())` before the tracker flush, so the blocks are durable before `commitRound` chooses a round and before `Close()` can discard any of them. The two `a.NotNil(app.AppParams)` guards are a separate concern: they turn this class of failure into a readable assertion instead of a segfault. That matters beyond this test, because a panic takes down the whole package binary — the run above reported 5 ledger failures, but only `TestAppEmptyBox` has a real duration. `TestOnlineAccountsSuspended`, `TestLookupAppResourcesParamsOnlyDeletion`, `TestAcctOnline_ExpiredCirculationCacheBasic` and `TestBoxNamesByAppIDs` are all logged as `(unknown)`, having been in flight when the process died.
> 
> ## Why this isn't reachable in production
> 
> `Ledger.AddValidatedBlock` never schedules a tracker commit. The only production trigger is `notifyCommit(committed)` -> `trackers.committedUpTo` -> `scheduleCommit`, and that round is always one the block queue has already written to disk. So the tracker DB cannot get ahead of the block DB, and the accounts-DB reset cannot fire. Only the test helper passes `l.Latest()`, which includes rounds that are not yet durable.
> 
> The block loss on `Close()` itself is real for `algod`, but benign: `Wait`/`WaitForCommit` are the documented durability barriers, anything dropped is refetched by catchup on restart, and the resulting state — block DB ahead of tracker DB — is the safe direction. It is only the reverse that forces a reset.
> 

> ## TestWebsocketProxyWsNet
> 
> A second, unrelated flake, seen in the `network` package on shard 2 of the CI run for this branch:
> 
> ```
> === FAIL: network TestWebsocketProxyWsNet (0.01s)
>     websocketProxy_test.go:293: upstream addr: http://127.0.0.1:33349
>     websocketProxy_test.go:294: ws proxy addr: [::1]:45859
>     websocketProxy_test.go:295: client netB addr: http://127.0.0.1:34003
>     websocketProxy_test.go:312:
>         	Error Trace:	websocketProxy_test.go:312
>         	Error:      	Not equal:
>         	            	expected: 1
>         	            	actual  : 0
>         	Test:       	TestWebsocketProxyWsNet
> ```
> 
> The test waits for netB's *outbound* peer count to reach 1 and then immediately asserts netA's *inbound* count with no retry, but those two registrations are not ordered with respect to each other. `WebsocketNetwork.ServeHTTP` writes the 101 Switching Protocols response inside `upgrader.Upgrade()` (`network/wsNetwork.go:1157`) and only reaches `wn.addPeer(peer)` at `:1189`, after constructing the peer and running `peer.init()`. netB's dial returns as soon as it reads that 101, so netB can have registered its outbound peer while netA is still between those two lines and its inbound list is legitimately empty. Routing through the proxy (netB -> wsProxy -> netA) adds a hop and another goroutine, which widens the window compared to the direct-connection tests.
> 
> The fix extends the existing `Eventually` to cover netA's inbound peer as well, so the exact count assertions below it run only once both ends have registered. They are otherwise unchanged.
> 
> Reproducible before the change by delaying the inbound registration in `network/wsNetwork.go`:
> 
> ```diff
>       peer.init(wn.config, wn.outgoingMessagesBufferSize)
> +     time.Sleep(200 * time.Millisecond) // simulate a lagging inbound registration
>       wn.addPeer(peer)
> ```
> 
> which fails the original test at `:312` with `expected: 1, actual: 0` on every run, and passes with the fix applied.

## Test Plan

Existing tests should pass

