### PR TITLE
transactions: add Falcon-512 signature type

### DIFF
--- a/cmd/algokey/pq.go
+++ b/cmd/algokey/pq.go
@@ -152,7 +152,7 @@ func init() {
 	pqCmd.AddCommand(pqSignProgramCmd)
 	pqCmd.AddCommand(pqCheckAddressCmd)
 
-	pqGenerateCmd.Flags().StringVarP(&pqGenerateScheme, "scheme", "S", pqGenerateScheme, "Post-quantum signature scheme: falcon-1024 (f1)")
+	pqGenerateCmd.Flags().StringVarP(&pqGenerateScheme, "scheme", "S", pqGenerateScheme, "Post-quantum signature scheme: falcon-1024 (f1), falcon-512 (f5)")
 	pqGenerateCmd.Flags().StringVarP(&pqGenerateKeyfile, "keyfile", "k", "", "Private key filename")
 	mustMarkFlagRequired(pqGenerateCmd, "keyfile")
 
@@ -160,14 +160,14 @@ func init() {
 	mustMarkFlagRequired(pqInfoCmd, "keyfile")
 
 	pqImportCmd.Flags().StringVarP(&pqImportMnemonic, "mnemonic", "m", "", "Private key mnemonic")
-	pqImportCmd.Flags().StringVarP(&pqImportScheme, "scheme", "S", pqImportScheme, "Post-quantum signature scheme: falcon-1024 (f1)")
+	pqImportCmd.Flags().StringVarP(&pqImportScheme, "scheme", "S", pqImportScheme, "Post-quantum signature scheme: falcon-1024 (f1), falcon-512 (f5)")
 	pqImportCmd.Flags().StringVarP(&pqImportKeyfile, "keyfile", "k", "", "Private key filename")
 	mustMarkFlagRequired(pqImportCmd, "mnemonic")
 	mustMarkFlagRequired(pqImportCmd, "keyfile")
 
 	pqSignCmd.Flags().StringVarP(&pqSignKeyfile, "keyfile", "k", "", "Private key filename")
 	pqSignCmd.Flags().StringVarP(&pqSignMnemonic, "mnemonic", "m", "", "Private key mnemonic")
-	pqSignCmd.Flags().StringVarP(&pqSignScheme, "scheme", "S", pqSignScheme, "Post-quantum signature scheme: falcon-1024 (f1); used with --mnemonic")
+	pqSignCmd.Flags().StringVarP(&pqSignScheme, "scheme", "S", pqSignScheme, "Post-quantum signature scheme: falcon-1024 (f1), falcon-512 (f5); used with --mnemonic")
 	pqSignCmd.Flags().StringVarP(&pqSignTxfile, "txfile", "t", "", "Transaction input filename")
 	pqSignCmd.Flags().StringVarP(&pqSignOutfile, "outfile", "o", "", "Transaction output filename")
 	pqSignCmd.Flags().BoolVar(&pqSignOverwrite, "overwrite", false, "Overwrite any existing signature category")
@@ -176,7 +176,7 @@ func init() {
 
 	pqSignProgramCmd.Flags().StringVarP(&pqSignProgramKeyfile, "keyfile", "k", "", "Private key filename")
 	pqSignProgramCmd.Flags().StringVarP(&pqSignProgramMnemonic, "mnemonic", "m", "", "Private key mnemonic")
-	pqSignProgramCmd.Flags().StringVarP(&pqSignProgramScheme, "scheme", "S", pqSignProgramScheme, "Post-quantum signature scheme: falcon-1024 (f1); used with --mnemonic")
+	pqSignProgramCmd.Flags().StringVarP(&pqSignProgramScheme, "scheme", "S", pqSignProgramScheme, "Post-quantum signature scheme: falcon-1024 (f1), falcon-512 (f5); used with --mnemonic")
 	pqSignProgramCmd.Flags().StringVarP(&pqSignProgramProgram, "program", "p", "", "Compiled LogicSig program input filename")
 	pqSignProgramCmd.Flags().StringVarP(&pqSignProgramOutfile, "outfile", "o", "", "LogicSig output filename")
 	mustMarkFlagRequired(pqSignProgramCmd, "program")

--- a/cmd/algokey/pq_scheme.go
+++ b/cmd/algokey/pq_scheme.go
@@ -26,7 +26,10 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 )
 
-const pqSchemeFalcon1024Name = "falcon-1024"
+const (
+	pqSchemeFalcon1024Name = "falcon-1024"
+	pqSchemeFalcon512Name  = "falcon-512"
+)
 
 // pqSchemeOps holds the signing-side, private-key operations for one PQ
 // scheme. The consensus-relevant scheme behavior (signature verification,
@@ -41,14 +44,19 @@ type pqSchemeOps interface {
 
 var pqSchemeOpsByScheme = map[protocol.PQScheme]pqSchemeOps{
 	protocol.PQSchemeFalcon1024: falcon1024Ops{},
+	protocol.PQSchemeFalcon512:  falcon512Ops{},
 }
 
 type falcon1024Ops struct{}
+type falcon512Ops struct{}
 
 func parsePQScheme(value string) (protocol.PQScheme, error) {
 	value = strings.TrimSpace(value)
 	if strings.EqualFold(value, pqSchemeFalcon1024Name) {
 		return protocol.PQSchemeFalcon1024, nil
+	}
+	if strings.EqualFold(value, pqSchemeFalcon512Name) {
+		return protocol.PQSchemeFalcon512, nil
 	}
 
 	var scheme protocol.PQScheme
@@ -62,6 +70,9 @@ func parsePQScheme(value string) (protocol.PQScheme, error) {
 func formatPQScheme(scheme protocol.PQScheme) string {
 	if scheme == protocol.PQSchemeFalcon1024 {
 		return pqSchemeFalcon1024Name
+	}
+	if scheme == protocol.PQSchemeFalcon512 {
+		return pqSchemeFalcon512Name
 	}
 	return scheme.String()
 }
@@ -130,5 +141,43 @@ func (falcon1024Ops) sign(privateKey []byte, message crypto.Hashable) ([]byte, e
 	copy(sk[:], privateKey)
 
 	signer := crypto.Falcon1024Signer{PrivateKey: sk}
+	return signer.Sign(message)
+}
+
+func (falcon512Ops) deriveSigning(seed crypto.Digest) (pqSigningMaterial, error) {
+	signer, err := crypto.GenerateFalcon512Signer(crypto.FalconSeed(seed))
+	if err != nil {
+		return pqSigningMaterial{}, err
+	}
+
+	publicKey := slices.Clone(signer.PublicKey[:])
+	privateKey := slices.Clone(signer.PrivateKey[:])
+	salt, _, err := basics.CanonicalPQAddressSalt(protocol.PQSchemeFalcon512, publicKey)
+	if err != nil {
+		return pqSigningMaterial{}, err
+	}
+
+	return pqSigningMaterial{
+		Public: pqPublicMaterial{
+			Scheme:    protocol.PQSchemeFalcon512,
+			Salt:      salt,
+			PublicKey: publicKey,
+		},
+		PrivateKey: privateKey,
+	}, nil
+}
+
+func (falcon512Ops) publicKeySize() uint64 { return crypto.Falcon512PublicKeySize }
+
+func (falcon512Ops) privateKeySize() uint64 { return crypto.Falcon512PrivateKeySize }
+
+func (falcon512Ops) sign(privateKey []byte, message crypto.Hashable) ([]byte, error) {
+	var sk crypto.Falcon512PrivateKey
+	if len(privateKey) != len(sk) {
+		return nil, fmt.Errorf("%w: got private key size %d, want %d", errPQKeyMalformed, len(privateKey), len(sk))
+	}
+	copy(sk[:], privateKey)
+
+	signer := crypto.Falcon512Signer{PrivateKey: sk}
 	return signer.Sign(message)
 }

--- a/cmd/algokey/pq_test.go
+++ b/cmd/algokey/pq_test.go
@@ -111,22 +111,59 @@ func TestPQGenerateUsesMnemonicSizedEntropy(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	rng := &countingRNG{}
-	entropy, signing, err := generatePQSigningMaterial(protocol.PQSchemeFalcon1024, rng)
-	require.NoError(t, err)
+	testcases := []struct {
+		name   string
+		scheme protocol.PQScheme
+		// address is a known answer pinning the entropy -> seed -> key -> salt
+		// derivation: a change here would break existing mnemonic imports.
+		address string
+		// rederive regenerates the concrete signer's keys straight from the
+		// scheme's keygen seed, independently of the ops registry.
+		rederive func(t *testing.T, seed crypto.Digest) (publicKey, privateKey []byte)
+	}{
+		{
+			name:    "falcon-1024",
+			scheme:  protocol.PQSchemeFalcon1024,
+			address: "ZEJ4BLG3XWAUUZQGCEDJLYIC6D2NCWHRSX5DJMDPE54PXXR7G3PCQTARXU",
+			rederive: func(t *testing.T, seed crypto.Digest) ([]byte, []byte) {
+				signer, err := crypto.GenerateFalcon1024Signer(crypto.FalconSeed(seed))
+				require.NoError(t, err)
+				return signer.PublicKey[:], signer.PrivateKey[:]
+			},
+		},
+		{
+			name:    "falcon-512",
+			scheme:  protocol.PQSchemeFalcon512,
+			address: "6XJVA45MCHLBBACBGN6ENAXFBDXCEYE5QIWA4R4LO5EY3UNAIP2UGP7ANI",
+			rederive: func(t *testing.T, seed crypto.Digest) ([]byte, []byte) {
+				signer, err := crypto.GenerateFalcon512Signer(crypto.FalconSeed(seed))
+				require.NoError(t, err)
+				return signer.PublicKey[:], signer.PrivateKey[:]
+			},
+		},
+	}
 
-	require.Equal(t, 1, rng.calls)
-	require.Equal(t, len(crypto.Seed{}), rng.bytes)
-	require.Equal(t, protocol.PQSchemeFalcon1024, signing.Public.Scheme)
-	require.Equal(t, crypto.Seed{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}, entropy)
-	require.True(t, signing.Public.address().IsPQCompliant())
-	require.Equal(t, "ZEJ4BLG3XWAUUZQGCEDJLYIC6D2NCWHRSX5DJMDPE54PXXR7G3PCQTARXU", signing.Public.address().String())
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	seed := derivePQKeySeed(protocol.PQSchemeFalcon1024, entropy)
-	signer, err := crypto.GenerateFalcon1024Signer(crypto.FalconSeed(seed))
-	require.NoError(t, err)
-	require.Equal(t, signer.PublicKey[:], signing.Public.PublicKey)
-	require.Equal(t, signer.PrivateKey[:], signing.PrivateKey)
+			rng := &countingRNG{}
+			entropy, signing, err := generatePQSigningMaterial(tc.scheme, rng)
+			require.NoError(t, err)
+
+			require.Equal(t, 1, rng.calls)
+			require.Equal(t, len(crypto.Seed{}), rng.bytes)
+			require.Equal(t, tc.scheme, signing.Public.Scheme)
+			require.Equal(t, crypto.Seed{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}, entropy)
+			require.True(t, signing.Public.address().IsPQCompliant())
+			require.Equal(t, tc.address, signing.Public.address().String())
+
+			seed := derivePQKeySeed(tc.scheme, entropy)
+			publicKey, privateKey := tc.rederive(t, seed)
+			require.Equal(t, publicKey, signing.Public.PublicKey)
+			require.Equal(t, privateKey, signing.PrivateKey)
+		})
+	}
 }
 
 func TestPQSchemeRegistriesConsistent(t *testing.T) {
@@ -138,7 +175,7 @@ func TestPQSchemeRegistriesConsistent(t *testing.T) {
 		require.True(t, ok, "algokey scheme %q missing from crypto registry", scheme)
 	}
 
-	for _, scheme := range []protocol.PQScheme{protocol.PQSchemeFalcon1024} {
+	for _, scheme := range []protocol.PQScheme{protocol.PQSchemeFalcon1024, protocol.PQSchemeFalcon512} {
 		_, ok := pqSchemeOpsByScheme[scheme]
 		require.True(t, ok, "basics scheme %q missing from algokey ops registry", scheme)
 	}
@@ -167,6 +204,23 @@ func TestParsePQSchemeAcceptsLongName(t *testing.T) {
 	scheme, err = parsePQScheme("f1")
 	require.NoError(t, err)
 	require.Equal(t, protocol.PQSchemeFalcon1024, scheme)
+
+	scheme, err = parsePQScheme("falcon-512")
+	require.NoError(t, err)
+	require.Equal(t, protocol.PQSchemeFalcon512, scheme)
+
+	scheme, err = parsePQScheme("f5")
+	require.NoError(t, err)
+	require.Equal(t, protocol.PQSchemeFalcon512, scheme)
+}
+
+func TestFormatPQScheme(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	require.Equal(t, pqSchemeFalcon1024Name, formatPQScheme(protocol.PQSchemeFalcon1024))
+	require.Equal(t, pqSchemeFalcon512Name, formatPQScheme(protocol.PQSchemeFalcon512))
+	require.Equal(t, protocol.PQScheme{'z', 'z'}.String(), formatPQScheme(protocol.PQScheme{'z', 'z'}))
 }
 
 func TestPQPrivateKeyFileStoresKeysNotEntropy(t *testing.T) {

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -718,7 +718,7 @@ func (proto ConsensusParams) PQSchemeEnabled(scheme protocol.PQScheme) bool {
 	}
 }
 
-// PQSigEnabled returns whether a post-quantum signatures are enabled
+// PQSigEnabled returns whether any post-quantum signatures are enabled
 // under these consensus parameters.
 func (proto ConsensusParams) PQSigEnabled() bool {
 	return proto.EnablePQSchemeFalcon1024 || proto.EnablePQSchemeFalcon512
@@ -733,7 +733,7 @@ func (proto ConsensusParams) PQSchemeFeeContribution(scheme protocol.PQScheme) b
 	case protocol.PQSchemeFalcon1024:
 		return 2e6
 	case protocol.PQSchemeFalcon512:
-		return 1e6 + 5e5 // kept below the Falcon-1024 contribution
+		return 1e6 // it is half of the Falcon-1024 contribution
 	default:
 		return 0
 	}

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -610,6 +610,10 @@ type ConsensusParams struct {
 	// EnableSelectF128 changes the sortition algorithm to use a 128-bit software
 	// floating point binomial CDF implementation for committee selection.
 	EnableSelectF128 bool
+
+	// EnablePQSchemeFalcon512 enables native Falcon-512 transaction
+	// authorization for the f5 PQ scheme.
+	EnablePQSchemeFalcon512 bool
 }
 
 // ProposerPayoutRules puts several related consensus parameters in one place. The same
@@ -707,15 +711,17 @@ func (proto ConsensusParams) PQSchemeEnabled(scheme protocol.PQScheme) bool {
 	switch scheme {
 	case protocol.PQSchemeFalcon1024:
 		return proto.EnablePQSchemeFalcon1024
+	case protocol.PQSchemeFalcon512:
+		return proto.EnablePQSchemeFalcon512
 	default:
 		return false
 	}
 }
 
-// PQSigEnabled returns whether a post-quantum signature scheme is enabled
+// PQSigEnabled returns whether a post-quantum signatures are enabled
 // under these consensus parameters.
 func (proto ConsensusParams) PQSigEnabled() bool {
-	return proto.EnablePQSchemeFalcon1024 // || proto.EnablePQSchemeFalcon512
+	return proto.EnablePQSchemeFalcon1024 || proto.EnablePQSchemeFalcon512
 }
 
 // PQSchemeFeeContribution is the additional fee factor charged for a transaction
@@ -727,7 +733,7 @@ func (proto ConsensusParams) PQSchemeFeeContribution(scheme protocol.PQScheme) b
 	case protocol.PQSchemeFalcon1024:
 		return 2e6
 	case protocol.PQSchemeFalcon512:
-		return 1e6 // kept below the Falcon-1024 contribution
+		return 1e6 + 5e5 // kept below the Falcon-1024 contribution
 	default:
 		return 0
 	}
@@ -1560,6 +1566,8 @@ func initConsensusProtocols() {
 	vFuture.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 
 	vFuture.LogicSigVersion = 14 // When moving this to a release, put a new higher LogicSigVersion here
+
+	vFuture.EnablePQSchemeFalcon512 = true
 
 	Consensus[protocol.ConsensusFuture] = vFuture
 

--- a/crypto/falconWrapper_test.go
+++ b/crypto/falconWrapper_test.go
@@ -26,160 +26,291 @@ import (
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
+// falconTestKey adapts a generated signer of one Falcon scheme to a
+// byte-oriented API so the tests below can run identically against both
+// schemes.
+type falconTestKey struct {
+	publicKey   []byte
+	sign        func(message Hashable) ([]byte, error)
+	signBytes   func(data []byte) ([]byte, error)
+	verify      func(message Hashable, sig []byte) error
+	verifyBytes func(data []byte, sig []byte) error
+	// verifierRepr is GetVerifyingKey().GetFixedLengthHashableRepresentation().
+	verifierRepr func() []byte
+}
+
+// falconTestScheme holds one Falcon scheme's constants and package-level
+// entry points.
+type falconTestScheme struct {
+	name               string
+	maxSignatureSize   int
+	currentSaltVersion byte
+	errSigInvalid      error
+	generate           func(seed FalconSeed) (falconTestKey, error)
+	verify             func(message Hashable, publicKey, signature []byte) error
+	// convertToCT converts a compressed signature to CT form via the falcon
+	// library directly, bypassing the wrapper.
+	convertToCT        func(sig []byte) ([]byte, error)
+	sigRepr            func(sig []byte) ([]byte, error)
+	isSaltVersionEqual func(sig []byte, version byte) bool
+}
+
+var falconTestSchemes = []falconTestScheme{
+	{
+		name:               "falcon-1024",
+		maxSignatureSize:   Falcon1024MaxSignatureSize,
+		currentSaltVersion: falcon.CurrentSaltVersion,
+		errSigInvalid:      ErrPQFalcon1024SigInvalid,
+		generate: func(seed FalconSeed) (falconTestKey, error) {
+			key, err := GenerateFalcon1024Signer(seed)
+			if err != nil {
+				return falconTestKey{}, err
+			}
+			verifier := key.GetVerifyingKey()
+			return falconTestKey{
+				publicKey:    key.PublicKey[:],
+				sign:         func(message Hashable) ([]byte, error) { return key.Sign(message) },
+				signBytes:    func(data []byte) ([]byte, error) { return key.SignBytes(data) },
+				verify:       func(message Hashable, sig []byte) error { return verifier.Verify(message, sig) },
+				verifyBytes:  func(data []byte, sig []byte) error { return verifier.VerifyBytes(data, sig) },
+				verifierRepr: verifier.GetFixedLengthHashableRepresentation,
+			}, nil
+		},
+		verify: VerifyFalcon1024,
+		convertToCT: func(sig []byte) ([]byte, error) {
+			falconSig := falcon.CompressedSignature(sig)
+			ct, err := falconSig.ConvertToCT()
+			return ct[:], err
+		},
+		sigRepr: func(sig []byte) ([]byte, error) {
+			return Falcon1024Signature(sig).GetFixedLengthHashableRepresentation()
+		},
+		isSaltVersionEqual: func(sig []byte, version byte) bool {
+			return Falcon1024Signature(sig).IsSaltVersionEqual(version)
+		},
+	},
+	{
+		name:               "falcon-512",
+		maxSignatureSize:   Falcon512MaxSignatureSize,
+		currentSaltVersion: falcon.Det512CurrentSaltVersion,
+		errSigInvalid:      ErrPQFalcon512SigInvalid,
+		generate: func(seed FalconSeed) (falconTestKey, error) {
+			key, err := GenerateFalcon512Signer(seed)
+			if err != nil {
+				return falconTestKey{}, err
+			}
+			verifier := key.GetVerifyingKey()
+			return falconTestKey{
+				publicKey:    key.PublicKey[:],
+				sign:         func(message Hashable) ([]byte, error) { return key.Sign(message) },
+				signBytes:    func(data []byte) ([]byte, error) { return key.SignBytes(data) },
+				verify:       func(message Hashable, sig []byte) error { return verifier.Verify(message, sig) },
+				verifyBytes:  func(data []byte, sig []byte) error { return verifier.VerifyBytes(data, sig) },
+				verifierRepr: verifier.GetFixedLengthHashableRepresentation,
+			}, nil
+		},
+		verify: VerifyFalcon512,
+		convertToCT: func(sig []byte) ([]byte, error) {
+			falconSig := falcon.Det512CompressedSignature(sig)
+			ct, err := falconSig.ConvertToCT()
+			return ct[:], err
+		},
+		sigRepr: func(sig []byte) ([]byte, error) {
+			return Falcon512Signature(sig).GetFixedLengthHashableRepresentation()
+		},
+		isSaltVersionEqual: func(sig []byte, version byte) bool {
+			return Falcon512Signature(sig).IsSaltVersionEqual(version)
+		},
+	},
+}
+
 func TestSignAndVerifyFalcon(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	a := require.New(t)
 
-	var seed FalconSeed
-	SystemRNG.RandBytes(seed[:])
-	key, err := GenerateFalcon1024Signer(seed)
-	a.NoError(err)
+	for _, scheme := range falconTestSchemes {
+		t.Run(scheme.name, func(t *testing.T) {
+			a := require.New(t)
 
-	msg := []byte("Neque porro quisquam est qui dolorem ipsum quia dolor sit amet")
-	byteSig, err := key.SignBytes(msg)
-	a.NoError(err)
+			var seed FalconSeed
+			SystemRNG.RandBytes(seed[:])
+			key, err := scheme.generate(seed)
+			a.NoError(err)
 
-	verifier := key.GetVerifyingKey()
-	err = verifier.VerifyBytes(msg, byteSig)
-	a.NoError(err)
+			msg := []byte("Neque porro quisquam est qui dolorem ipsum quia dolor sit amet")
+			byteSig, err := key.signBytes(msg)
+			a.NoError(err)
+
+			err = key.verifyBytes(msg, byteSig)
+			a.NoError(err)
+		})
+	}
 }
 
 func TestSignAndVerifyFalconHashable(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	a := require.New(t)
 
-	msg := TestingHashable{data: []byte("Neque porro quisquam est qui dolorem ipsum quia dolor sit amet")}
-	var seed FalconSeed
-	SystemRNG.RandBytes(seed[:])
-	key, err := GenerateFalcon1024Signer(seed)
-	a.NoError(err)
+	for _, scheme := range falconTestSchemes {
+		t.Run(scheme.name, func(t *testing.T) {
+			a := require.New(t)
 
-	byteSig, err := key.Sign(msg)
-	a.NoError(err)
+			msg := TestingHashable{data: []byte("Neque porro quisquam est qui dolorem ipsum quia dolor sit amet")}
+			var seed FalconSeed
+			SystemRNG.RandBytes(seed[:])
+			key, err := scheme.generate(seed)
+			a.NoError(err)
 
-	verifier := key.GetVerifyingKey()
-	err = verifier.Verify(msg, byteSig)
-	a.NoError(err)
+			byteSig, err := key.sign(msg)
+			a.NoError(err)
+
+			err = key.verify(msg, byteSig)
+			a.NoError(err)
+		})
+	}
 }
 
-func TestVerifyFalcon1024RejectsMalformedInputs(t *testing.T) {
+func TestVerifyFalconRejectsMalformedInputs(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	msg := TestingHashable{data: []byte("verify falcon-1024 malformed inputs")}
-	var seed FalconSeed
-	seed[0] = 1
-	signer, err := GenerateFalcon1024Signer(seed)
-	require.NoError(t, err)
-
-	signature, err := signer.Sign(msg)
-	require.NoError(t, err)
-
-	longPublicKey := append([]byte{}, signer.PublicKey[:]...)
-	longPublicKey = append(longPublicKey, 0)
-
-	tests := []struct {
-		name      string
-		publicKey []byte
-		signature []byte
-	}{
-		{
-			name:      "short public key",
-			publicKey: signer.PublicKey[:len(signer.PublicKey)-1],
-			signature: signature,
-		},
-		{
-			name:      "long public key",
-			publicKey: longPublicKey,
-			signature: signature,
-		},
-		{
-			name:      "empty signature",
-			publicKey: signer.PublicKey[:],
-			signature: nil,
-		},
-		{
-			name:      "oversized signature",
-			publicKey: signer.PublicKey[:],
-			signature: make([]byte, Falcon1024MaxSignatureSize+1),
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+	for _, scheme := range falconTestSchemes {
+		t.Run(scheme.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := VerifyFalcon1024(msg, test.publicKey, test.signature)
-			require.ErrorIs(t, err, ErrPQFalcon1024SigInvalid)
+			msg := TestingHashable{data: []byte("verify falcon malformed inputs")}
+			var seed FalconSeed
+			seed[0] = 1
+			key, err := scheme.generate(seed)
+			require.NoError(t, err)
+
+			signature, err := key.sign(msg)
+			require.NoError(t, err)
+
+			longPublicKey := append([]byte{}, key.publicKey...)
+			longPublicKey = append(longPublicKey, 0)
+
+			tests := []struct {
+				name      string
+				publicKey []byte
+				signature []byte
+			}{
+				{
+					name:      "short public key",
+					publicKey: key.publicKey[:len(key.publicKey)-1],
+					signature: signature,
+				},
+				{
+					name:      "long public key",
+					publicKey: longPublicKey,
+					signature: signature,
+				},
+				{
+					name:      "empty signature",
+					publicKey: key.publicKey,
+					signature: nil,
+				},
+				{
+					name:      "oversized signature",
+					publicKey: key.publicKey,
+					signature: make([]byte, scheme.maxSignatureSize+1),
+				},
+			}
+
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					t.Parallel()
+
+					err := scheme.verify(msg, test.publicKey, test.signature)
+					require.ErrorIs(t, err, scheme.errSigInvalid)
+				})
+			}
 		})
 	}
 }
 
 func TestFalconCanHandleNilSignature(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	a := require.New(t)
 
-	var seed FalconSeed
-	SystemRNG.RandBytes(seed[:])
-	key, err := GenerateFalcon1024Signer(seed)
-	a.NoError(err)
+	for _, scheme := range falconTestSchemes {
+		t.Run(scheme.name, func(t *testing.T) {
+			a := require.New(t)
 
-	err = key.GetVerifyingKey().VerifyBytes([]byte("Test"), nil)
-	require.ErrorIs(t, err, falcon.ErrVerifyFail)
+			var seed FalconSeed
+			SystemRNG.RandBytes(seed[:])
+			key, err := scheme.generate(seed)
+			a.NoError(err)
+
+			err = key.verifyBytes([]byte("Test"), nil)
+			a.ErrorIs(err, falcon.ErrVerifyFail)
+		})
+	}
 }
 
 func TestVerificationBytes(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	a := require.New(t)
 
-	var seed FalconSeed
-	SystemRNG.RandBytes(seed[:])
-	key, err := GenerateFalcon1024Signer(seed)
-	a.NoError(err)
+	for _, scheme := range falconTestSchemes {
+		t.Run(scheme.name, func(t *testing.T) {
+			a := require.New(t)
 
-	verifyingRawKey := key.GetVerifyingKey().GetFixedLengthHashableRepresentation()
+			var seed FalconSeed
+			SystemRNG.RandBytes(seed[:])
+			key, err := scheme.generate(seed)
+			a.NoError(err)
 
-	a.Equal(verifyingRawKey, key.PublicKey[:])
+			verifyingRawKey := key.verifierRepr()
+			a.Equal(verifyingRawKey, key.publicKey)
+		})
+	}
 }
 
 func TestFalconsFormatConversion(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	a := require.New(t)
 
-	var seed FalconSeed
-	SystemRNG.RandBytes(seed[:])
-	key, err := GenerateFalcon1024Signer(seed)
-	a.NoError(err)
+	for _, scheme := range falconTestSchemes {
+		t.Run(scheme.name, func(t *testing.T) {
+			a := require.New(t)
 
-	msg := []byte("Neque porro quisquam est qui dolorem ipsum quia dolor sit amet")
-	sig, err := key.SignBytes(msg)
-	a.NoError(err)
+			var seed FalconSeed
+			SystemRNG.RandBytes(seed[:])
+			key, err := scheme.generate(seed)
+			a.NoError(err)
 
-	falconSig := falcon.CompressedSignature(sig)
-	ctFormat, err := falconSig.ConvertToCT()
+			msg := []byte("Neque porro quisquam est qui dolorem ipsum quia dolor sit amet")
+			sig, err := key.signBytes(msg)
+			a.NoError(err)
 
-	rawFormat, err := sig.GetFixedLengthHashableRepresentation()
-	a.NoError(err)
-	a.NotEqual([]byte(sig), rawFormat)
+			ctFormat, err := scheme.convertToCT(sig)
+			a.NoError(err)
 
-	a.Equal(ctFormat[:], rawFormat)
+			rawFormat, err := scheme.sigRepr(sig)
+			a.NoError(err)
+			a.NotEqual(sig, rawFormat)
+
+			a.Equal(ctFormat, rawFormat)
+		})
+	}
 }
 
 func TestFalconSignature_ValidateVersion(t *testing.T) {
 	partitiontest.PartitionTest(t)
-	a := require.New(t)
 
-	msg := TestingHashable{data: []byte("Neque porro quisquam est qui dolorem ipsum quia dolor sit amet")}
-	var seed FalconSeed
-	SystemRNG.RandBytes(seed[:])
-	key, err := GenerateFalcon1024Signer(seed)
-	a.NoError(err)
+	for _, scheme := range falconTestSchemes {
+		t.Run(scheme.name, func(t *testing.T) {
+			a := require.New(t)
 
-	byteSig, err := key.Sign(msg)
-	a.NoError(err)
+			msg := TestingHashable{data: []byte("Neque porro quisquam est qui dolorem ipsum quia dolor sit amet")}
+			var seed FalconSeed
+			SystemRNG.RandBytes(seed[:])
+			key, err := scheme.generate(seed)
+			a.NoError(err)
 
-	a.True(byteSig.IsSaltVersionEqual(falcon.CurrentSaltVersion))
+			byteSig, err := key.sign(msg)
+			a.NoError(err)
 
-	byteSig[1]++
-	a.False(byteSig.IsSaltVersionEqual(falcon.CurrentSaltVersion))
+			a.True(scheme.isSaltVersionEqual(byteSig, scheme.currentSaltVersion))
+
+			byteSig[1]++
+			a.False(scheme.isSaltVersionEqual(byteSig, scheme.currentSaltVersion))
+		})
+	}
 }

--- a/crypto/pq_scheme.go
+++ b/crypto/pq_scheme.go
@@ -38,11 +38,11 @@ type PQVerifier interface {
 // MaxPQPublicKeySize and MaxPQSignatureSize are the largest public-key and
 // signature sizes over all supported PQ schemes; they are the PQ wire/decode
 // bounds (used for msgp allocbounds). Adding a scheme with a larger key or
-// signature means growing these; TestPQBoundsCoverFalcon1024 guards against
+// signature means growing these; TestPQBoundsCoverFalcon guards against
 // undersizing the current schemes.
 const (
-	MaxPQPublicKeySize = Falcon1024PublicKeySize
-	MaxPQSignatureSize = Falcon1024MaxSignatureSize
+	MaxPQPublicKeySize = max(Falcon1024PublicKeySize, Falcon512PublicKeySize)
+	MaxPQSignatureSize = max(Falcon1024MaxSignatureSize, Falcon512MaxSignatureSize)
 )
 
 // LookupPQScheme returns the verifier for a PQ scheme tag.
@@ -57,8 +57,8 @@ func LookupPQScheme(s protocol.PQScheme) (PQVerifier, bool) {
 	switch s {
 	case protocol.PQSchemeFalcon1024:
 		return falcon1024{}, true
-		// case protocol.PQSchemeFalcon512:
-		// 	return falcon512{}, true
+	case protocol.PQSchemeFalcon512:
+		return falcon512{}, true
 	}
 	return nil, false
 }
@@ -68,4 +68,11 @@ type falcon1024 struct{}
 
 func (falcon1024) Verify(message Hashable, publicKey, signature []byte) error {
 	return VerifyFalcon1024(message, publicKey, signature)
+}
+
+// falcon512 is the Falcon-512 (f5) scheme.
+type falcon512 struct{}
+
+func (falcon512) Verify(message Hashable, publicKey, signature []byte) error {
+	return VerifyFalcon512(message, publicKey, signature)
 }

--- a/crypto/pq_scheme_test.go
+++ b/crypto/pq_scheme_test.go
@@ -33,44 +33,66 @@ func TestLookupPQScheme(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, v)
 
+	v, ok = LookupPQScheme(protocol.PQSchemeFalcon512)
+	require.True(t, ok)
+	require.NotNil(t, v)
+
 	_, ok = LookupPQScheme(protocol.PQScheme{'x', '1'})
 	require.False(t, ok)
 }
 
-// TestPQBoundsCoverFalcon1024 guards against MaxPQ*Size being smaller than a
-// real Falcon-1024 public key or signature.
-func TestPQBoundsCoverFalcon1024(t *testing.T) {
+// TestPQBoundsCoverFalcon guards against MaxPQ*Size being smaller than a
+// real Falcon-1024/512 public key or signature.
+func TestPQBoundsCoverFalcon(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
 	var seed FalconSeed
 	seed[0] = 1
-	signer, err := GenerateFalcon1024Signer(seed)
+	signer1024, err := GenerateFalcon1024Signer(seed)
 	require.NoError(t, err)
-	require.LessOrEqual(t, uint64(len(signer.PublicKey)), uint64(MaxPQPublicKeySize))
+	require.LessOrEqual(t, uint64(len(signer1024.PublicKey)), uint64(MaxPQPublicKeySize))
+	signer512, err := GenerateFalcon512Signer(seed)
+	require.NoError(t, err)
+	require.LessOrEqual(t, uint64(len(signer512.PublicKey)), uint64(MaxPQPublicKeySize))
 
-	sig, err := signer.Sign(TestingHashable{data: []byte("pq bounds")})
+	sig1, err := signer1024.Sign(TestingHashable{data: []byte("pq bounds")})
 	require.NoError(t, err)
-	require.LessOrEqual(t, uint64(len(sig)), uint64(MaxPQSignatureSize))
+	require.LessOrEqual(t, uint64(len(sig1)), uint64(MaxPQSignatureSize))
+	sig5, err := signer512.Sign(TestingHashable{data: []byte("pq bounds")})
+	require.NoError(t, err)
+	require.LessOrEqual(t, uint64(len(sig5)), uint64(MaxPQSignatureSize))
 }
 
-// TestPQVerifierFalcon1024RoundTrip exercises the interface wiring; the
-// underlying verification is covered by the VerifyFalcon1024 tests.
-func TestPQVerifierFalcon1024RoundTrip(t *testing.T) {
+// TestPQVerifierFalconRoundTrip exercises the interface wiring; the
+// underlying verification is covered by the VerifyFalcon1024/512 tests.
+func TestPQVerifierFalconRoundTrip(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	v, ok := LookupPQScheme(protocol.PQSchemeFalcon1024)
+	v1, ok := LookupPQScheme(protocol.PQSchemeFalcon1024)
+	require.True(t, ok)
+	v5, ok := LookupPQScheme(protocol.PQSchemeFalcon512)
 	require.True(t, ok)
 
 	msg := TestingHashable{data: []byte("pq verifier round trip")}
 	var seed FalconSeed
 	seed[0] = 1
-	signer, err := GenerateFalcon1024Signer(seed)
+
+	signer1, err := GenerateFalcon1024Signer(seed)
 	require.NoError(t, err)
-	sig, err := signer.Sign(msg)
+	sig1, err := signer1.Sign(msg)
 	require.NoError(t, err)
 
-	require.NoError(t, v.Verify(msg, signer.PublicKey[:], sig))
-	require.Error(t, v.Verify(msg, signer.PublicKey[:], nil))
+	require.NoError(t, v1.Verify(msg, signer1.PublicKey[:], sig1))
+	require.Error(t, v1.Verify(msg, signer1.PublicKey[:], nil))
+
+	signer5, err := GenerateFalcon512Signer(seed)
+	require.NoError(t, err)
+	sig5, err := signer5.Sign(msg)
+	require.NoError(t, err)
+
+	require.NoError(t, v5.Verify(msg, signer5.PublicKey[:], sig5))
+	require.Error(t, v5.Verify(msg, signer5.PublicKey[:], nil))
+
 }

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/algorand/go-algorand/data"
 	"github.com/algorand/go-algorand/data/account"
 	"github.com/algorand/go-algorand/data/basics"
+	basics_testing "github.com/algorand/go-algorand/data/basics/testing"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/stateproofmsg"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -1164,45 +1165,13 @@ func enableDeveloperAPI() postTransactionOpt {
 	}
 }
 
-type testFalconSignFn func(t *testing.T, message crypto.Hashable) []byte
-
-func makePQSigWithAddressCompliance(t *testing.T, compliant bool) (testFalconSignFn, basics.Address, transactions.PQSig) {
+func makePQSigWithAddressCompliance(t *testing.T, compliant bool) (basics_testing.FalconSigner, basics.Address, transactions.PQSig) {
 	t.Helper()
 
 	// randomly choose between Falcon-512 and Falcon-1024 for the test
-	var falconRandSelector [1]byte
-	crypto.RandBytes(falconRandSelector[:])
-
-	var scheme protocol.PQScheme
-	if falconRandSelector[0]%2 == 0 {
-		scheme = protocol.PQSchemeFalcon1024
-	} else {
-		scheme = protocol.PQSchemeFalcon512
-	}
-
-	var seed crypto.FalconSeed
-	var publicKey []byte
-	var signFn testFalconSignFn
-
-	if scheme == protocol.PQSchemeFalcon1024 {
-		signer, err := crypto.GenerateFalcon1024Signer(seed)
-		require.NoError(t, err)
-		publicKey = slices.Clone(signer.PublicKey[:])
-		signFn = func(t *testing.T, message crypto.Hashable) []byte {
-			signature, err := signer.Sign(message)
-			require.NoError(t, err)
-			return signature
-		}
-	} else {
-		signer, err := crypto.GenerateFalcon512Signer(seed)
-		require.NoError(t, err)
-		publicKey = slices.Clone(signer.PublicKey[:])
-		signFn = func(t *testing.T, message crypto.Hashable) []byte {
-			signature, err := signer.Sign(message)
-			require.NoError(t, err)
-			return signature
-		}
-	}
+	scheme := basics_testing.RandomPQTestScheme().Scheme
+	signer := basics_testing.MakeFalconSigner(t, 0, scheme)
+	publicKey := signer.PublicKey()
 
 	var salt basics.PQAddressSalt
 	var authorizer basics.Address
@@ -1223,7 +1192,7 @@ func makePQSigWithAddressCompliance(t *testing.T, compliant bool) (testFalconSig
 		require.True(t, found, "unable to find non-compliant PQ address salt")
 	}
 
-	return signFn, authorizer, transactions.PQSig{
+	return signer, authorizer, transactions.PQSig{
 		Scheme:    scheme,
 		Salt:      salt,
 		PublicKey: publicKey,
@@ -1233,7 +1202,7 @@ func makePQSigWithAddressCompliance(t *testing.T, compliant bool) (testFalconSig
 func makePQSignedTxnWithAddressCompliance(t *testing.T, compliant bool) transactions.SignedTxn {
 	t.Helper()
 
-	signFn, authorizer, pqSig := makePQSigWithAddressCompliance(t, compliant)
+	signer, authorizer, pqSig := makePQSigWithAddressCompliance(t, compliant)
 	txn := transactions.Transaction{
 		Type: protocol.PaymentTx,
 		Header: transactions.Header{
@@ -1248,7 +1217,9 @@ func makePQSignedTxnWithAddressCompliance(t *testing.T, compliant bool) transact
 		},
 	}
 
-	pqSig.Signature = signFn(t, txn)
+	signature, err := signer.Sign(txn)
+	require.NoError(t, err)
+	pqSig.Signature = signature
 
 	return transactions.SignedTxn{
 		Txn:   txn,
@@ -1259,11 +1230,12 @@ func makePQSignedTxnWithAddressCompliance(t *testing.T, compliant bool) transact
 func makePQDelegatedLogicSigTxnWithAddressCompliance(t *testing.T, compliant bool) transactions.SignedTxn {
 	t.Helper()
 
-	signFn, authorizer, pqSig := makePQSigWithAddressCompliance(t, compliant)
+	signer, authorizer, pqSig := makePQSigWithAddressCompliance(t, compliant)
 	ops, err := logic.AssembleStringWithVersion("int 1", 1)
 	require.NoError(t, err)
 
-	pqSig.Signature = signFn(t, logic.PQDelegatedProgram{Addr: authorizer, Program: ops.Program})
+	pqSig.Signature, err = signer.Sign(logic.PQDelegatedProgram{Addr: authorizer, Program: ops.Program})
+	require.NoError(t, err)
 
 	txn := transactions.Transaction{
 		Type: protocol.PaymentTx,

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -1164,24 +1164,57 @@ func enableDeveloperAPI() postTransactionOpt {
 	}
 }
 
-func makePQSigWithAddressCompliance(t *testing.T, compliant bool) (crypto.Falcon1024Signer, basics.Address, transactions.PQSig) {
+type testFalconSignFn func(t *testing.T, message crypto.Hashable) []byte
+
+func makePQSigWithAddressCompliance(t *testing.T, compliant bool) (testFalconSignFn, basics.Address, transactions.PQSig) {
 	t.Helper()
 
+	// randomly choose between Falcon-512 and Falcon-1024 for the test
+	var falconRandSelector [1]byte
+	crypto.RandBytes(falconRandSelector[:])
+
+	var scheme protocol.PQScheme
+	if falconRandSelector[0]%2 == 0 {
+		scheme = protocol.PQSchemeFalcon1024
+	} else {
+		scheme = protocol.PQSchemeFalcon512
+	}
+
 	var seed crypto.FalconSeed
-	signer, err := crypto.GenerateFalcon1024Signer(seed)
-	require.NoError(t, err)
-	publicKey := slices.Clone(signer.PublicKey[:])
+	var publicKey []byte
+	var signFn testFalconSignFn
+
+	if scheme == protocol.PQSchemeFalcon1024 {
+		signer, err := crypto.GenerateFalcon1024Signer(seed)
+		require.NoError(t, err)
+		publicKey = slices.Clone(signer.PublicKey[:])
+		signFn = func(t *testing.T, message crypto.Hashable) []byte {
+			signature, err := signer.Sign(message)
+			require.NoError(t, err)
+			return signature
+		}
+	} else {
+		signer, err := crypto.GenerateFalcon512Signer(seed)
+		require.NoError(t, err)
+		publicKey = slices.Clone(signer.PublicKey[:])
+		signFn = func(t *testing.T, message crypto.Hashable) []byte {
+			signature, err := signer.Sign(message)
+			require.NoError(t, err)
+			return signature
+		}
+	}
 
 	var salt basics.PQAddressSalt
 	var authorizer basics.Address
 	if compliant {
-		salt, authorizer, err = basics.CanonicalPQAddressSalt(protocol.PQSchemeFalcon1024, publicKey)
+		var err error
+		salt, authorizer, err = basics.CanonicalPQAddressSalt(scheme, publicKey)
 		require.NoError(t, err)
 	} else {
 		found := false
 		for s := 0; s <= math.MaxUint8; s++ {
 			salt = basics.PQAddressSalt(s)
-			authorizer = basics.PQAddress(protocol.PQSchemeFalcon1024, salt, publicKey)
+			authorizer = basics.PQAddress(scheme, salt, publicKey)
 			if !authorizer.IsPQCompliant() {
 				found = true
 				break
@@ -1190,8 +1223,8 @@ func makePQSigWithAddressCompliance(t *testing.T, compliant bool) (crypto.Falcon
 		require.True(t, found, "unable to find non-compliant PQ address salt")
 	}
 
-	return signer, authorizer, transactions.PQSig{
-		Scheme:    protocol.PQSchemeFalcon1024,
+	return signFn, authorizer, transactions.PQSig{
+		Scheme:    scheme,
 		Salt:      salt,
 		PublicKey: publicKey,
 	}
@@ -1200,7 +1233,7 @@ func makePQSigWithAddressCompliance(t *testing.T, compliant bool) (crypto.Falcon
 func makePQSignedTxnWithAddressCompliance(t *testing.T, compliant bool) transactions.SignedTxn {
 	t.Helper()
 
-	signer, authorizer, pqSig := makePQSigWithAddressCompliance(t, compliant)
+	signFn, authorizer, pqSig := makePQSigWithAddressCompliance(t, compliant)
 	txn := transactions.Transaction{
 		Type: protocol.PaymentTx,
 		Header: transactions.Header{
@@ -1215,9 +1248,7 @@ func makePQSignedTxnWithAddressCompliance(t *testing.T, compliant bool) transact
 		},
 	}
 
-	signature, err := signer.Sign(txn)
-	require.NoError(t, err)
-	pqSig.Signature = signature
+	pqSig.Signature = signFn(t, txn)
 
 	return transactions.SignedTxn{
 		Txn:   txn,
@@ -1228,13 +1259,11 @@ func makePQSignedTxnWithAddressCompliance(t *testing.T, compliant bool) transact
 func makePQDelegatedLogicSigTxnWithAddressCompliance(t *testing.T, compliant bool) transactions.SignedTxn {
 	t.Helper()
 
-	signer, authorizer, pqSig := makePQSigWithAddressCompliance(t, compliant)
+	signFn, authorizer, pqSig := makePQSigWithAddressCompliance(t, compliant)
 	ops, err := logic.AssembleStringWithVersion("int 1", 1)
 	require.NoError(t, err)
 
-	signature, err := signer.Sign(logic.PQDelegatedProgram{Addr: authorizer, Program: ops.Program})
-	require.NoError(t, err)
-	pqSig.Signature = signature
+	pqSig.Signature = signFn(t, logic.PQDelegatedProgram{Addr: authorizer, Program: ops.Program})
 
 	txn := transactions.Transaction{
 		Type: protocol.PaymentTx,

--- a/data/basics/pq_address_test.go
+++ b/data/basics/pq_address_test.go
@@ -17,7 +17,6 @@
 package basics
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,11 +33,11 @@ func falconPublicKeyForPQAddressTest(t *testing.T, scheme protocol.PQScheme, fir
 	case protocol.PQSchemeFalcon1024:
 		signer, err := crypto.GenerateFalcon1024Signer(seed)
 		require.NoError(t, err)
-		return slices.Clone(signer.PublicKey[:])
+		return signer.PublicKey[:]
 	case protocol.PQSchemeFalcon512:
 		signer, err := crypto.GenerateFalcon512Signer(seed)
 		require.NoError(t, err)
-		return slices.Clone(signer.PublicKey[:])
+		return signer.PublicKey[:]
 	}
 	t.Fatalf("unknown scheme %s", scheme)
 	return nil

--- a/data/basics/pq_address_test.go
+++ b/data/basics/pq_address_test.go
@@ -27,93 +27,187 @@ import (
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
-func falconPublicKeyForPQAddressTest(t *testing.T, firstSeedByte byte) []byte {
+func falconPublicKeyForPQAddressTest(t *testing.T, scheme protocol.PQScheme, firstSeedByte byte) []byte {
 	var seed crypto.FalconSeed
 	seed[0] = firstSeedByte
-	signer, err := crypto.GenerateFalcon1024Signer(seed)
-	require.NoError(t, err)
-	return slices.Clone(signer.PublicKey[:])
+	switch scheme {
+	case protocol.PQSchemeFalcon1024:
+		signer, err := crypto.GenerateFalcon1024Signer(seed)
+		require.NoError(t, err)
+		return slices.Clone(signer.PublicKey[:])
+	case protocol.PQSchemeFalcon512:
+		signer, err := crypto.GenerateFalcon512Signer(seed)
+		require.NoError(t, err)
+		return slices.Clone(signer.PublicKey[:])
+	}
+	t.Fatalf("unknown scheme %s", scheme)
+	return nil
 }
 
 func TestPQAddressPreimage(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	preimage := pqAddressPreimage{
-		scheme: protocol.PQSchemeFalcon1024,
-		salt:   PQAddressSalt(0x7f),
-		pk:     []byte{0xab, 0xcd, 0xef},
-	}
-
-	hashID, payload := preimage.ToBeHashed()
-	require.Equal(t, protocol.PostQuantumAddress, hashID)
-	require.Equal(t, []byte{'f', '1', 0x7f, 0xab, 0xcd, 0xef}, payload)
-}
-
-func TestPQAddressKnownAnswers(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
 	testCases := []struct {
 		name            string
-		firstSeedByte   byte
-		salt            PQAddressSalt
-		expectedAddress string
-		compliant       bool
+		scheme          protocol.PQScheme
+		expectedPayload []byte
 	}{
 		{
-			name:            "zero salt",
-			firstSeedByte:   3,
-			salt:            0,
-			expectedAddress: "KJGJA2DTCQH6LT2I2OH2YO5GIIBFC6JHX5O6UPA5ZZ5ZURFT3LHKMTRCEM",
-			compliant:       true,
+			name:            "falcon-1024",
+			scheme:          protocol.PQSchemeFalcon1024,
+			expectedPayload: []byte{'f', '1', 0x7f, 0xab, 0xcd, 0xef},
 		},
 		{
-			name:            "nonzero salt",
-			firstSeedByte:   1,
-			salt:            1,
-			expectedAddress: "GYBWVYVQIQF6CO7BUMG4UQ66DQYHASFOCA2P7PBYOIPKGWUZIBX4KA3TP4",
-			compliant:       true,
-		},
-		{
-			name:            "max salt",
-			firstSeedByte:   0,
-			salt:            255,
-			expectedAddress: "YJFADDEP6Z3WAWY6ZMLN6MF4T4NK3BXKCVLPCYB6C4SQHE76LLQSZ5JG7Q",
-			compliant:       true,
-		},
-		{
-			name:            "different seed",
-			firstSeedByte:   2,
-			salt:            2,
-			expectedAddress: "II4DO6IIP3EAEQMWJEOLOUU3VBRVCH3WF4MX6UCRUD36DOQJ3YSHA2DV5A",
-			compliant:       true,
-		},
-		{
-			name:            "max seed and salt",
-			firstSeedByte:   255,
-			salt:            255,
-			expectedAddress: "3JXWI6BYYEO6WO6M7TC4SOZAZUWAD4RQO5GJ2ED6MYIEVVLOVJOETMGG4A",
-			compliant:       true,
-		},
-		{
-			name:            "non-compliant on-curve address",
-			firstSeedByte:   1,
-			salt:            0,
-			expectedAddress: "FLX4VRWXQ65HD5G5BI2EPHJWMERHA2EBBQ7XMTZLATXH4XEOWPQSIYVIF4",
-			compliant:       false,
+			name:            "falcon-512",
+			scheme:          protocol.PQSchemeFalcon512,
+			expectedPayload: []byte{'f', '5', 0x7f, 0xab, 0xcd, 0xef},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			publicKey := falconPublicKeyForPQAddressTest(t, tc.firstSeedByte)
+			preimage := pqAddressPreimage{
+				scheme: tc.scheme,
+				salt:   PQAddressSalt(0x7f),
+				pk:     []byte{0xab, 0xcd, 0xef},
+			}
 
-			addr := PQAddress(protocol.PQSchemeFalcon1024, tc.salt, publicKey)
-			require.Equal(t, tc.expectedAddress, addr.String())
-			require.Equal(t, tc.compliant, addr.IsPQCompliant())
-			require.Equal(t, !tc.compliant, crypto.IsEdwards25519Point(addr[:]))
+			hashID, payload := preimage.ToBeHashed()
+			require.Equal(t, protocol.PostQuantumAddress, hashID)
+			require.Equal(t, tc.expectedPayload, payload)
+		})
+	}
+}
 
-			addrAgain := PQAddress(protocol.PQSchemeFalcon1024, tc.salt, publicKey)
-			require.Equal(t, addr, addrAgain)
+func TestPQAddressKnownAnswers(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	type knownAnswer struct {
+		name            string
+		firstSeedByte   byte
+		salt            PQAddressSalt
+		expectedAddress string
+		compliant       bool
+	}
+
+	testCases := []struct {
+		name    string
+		scheme  protocol.PQScheme
+		answers []knownAnswer
+	}{
+		{
+			name:   "falcon-1024",
+			scheme: protocol.PQSchemeFalcon1024,
+			answers: []knownAnswer{
+				{
+					name:            "zero salt",
+					firstSeedByte:   3,
+					salt:            0,
+					expectedAddress: "KJGJA2DTCQH6LT2I2OH2YO5GIIBFC6JHX5O6UPA5ZZ5ZURFT3LHKMTRCEM",
+					compliant:       true,
+				},
+				{
+					name:            "nonzero salt",
+					firstSeedByte:   1,
+					salt:            1,
+					expectedAddress: "GYBWVYVQIQF6CO7BUMG4UQ66DQYHASFOCA2P7PBYOIPKGWUZIBX4KA3TP4",
+					compliant:       true,
+				},
+				{
+					name:            "max salt",
+					firstSeedByte:   0,
+					salt:            255,
+					expectedAddress: "YJFADDEP6Z3WAWY6ZMLN6MF4T4NK3BXKCVLPCYB6C4SQHE76LLQSZ5JG7Q",
+					compliant:       true,
+				},
+				{
+					name:            "different seed",
+					firstSeedByte:   2,
+					salt:            2,
+					expectedAddress: "II4DO6IIP3EAEQMWJEOLOUU3VBRVCH3WF4MX6UCRUD36DOQJ3YSHA2DV5A",
+					compliant:       true,
+				},
+				{
+					name:            "max seed and salt",
+					firstSeedByte:   255,
+					salt:            255,
+					expectedAddress: "3JXWI6BYYEO6WO6M7TC4SOZAZUWAD4RQO5GJ2ED6MYIEVVLOVJOETMGG4A",
+					compliant:       true,
+				},
+				{
+					name:            "non-compliant on-curve address",
+					firstSeedByte:   1,
+					salt:            0,
+					expectedAddress: "FLX4VRWXQ65HD5G5BI2EPHJWMERHA2EBBQ7XMTZLATXH4XEOWPQSIYVIF4",
+					compliant:       false,
+				},
+			},
+		},
+		{
+			name:   "falcon-512",
+			scheme: protocol.PQSchemeFalcon512,
+			answers: []knownAnswer{
+				{
+					name:            "zero salt",
+					firstSeedByte:   3,
+					salt:            0,
+					expectedAddress: "L3E466XEV24FAQ3GYW4NDWNVVQG5SKNW4P7FO7JB72AL35WU4BYIUBWFLQ",
+					compliant:       true,
+				},
+				{
+					name:            "nonzero salt",
+					firstSeedByte:   1,
+					salt:            1,
+					expectedAddress: "NQHOCVCR45XKZ5LMJSBDWGPZ6QZQIDKQU26KNQ3O4A3EGIRR7BPIX4CW3A",
+					compliant:       true,
+				},
+				{
+					name:            "max salt",
+					firstSeedByte:   0,
+					salt:            255,
+					expectedAddress: "6SNBFGF6MKPQZMP5QFTXJQVMNB2VYT4DCKVTGH3UN3KDSF3BXSNX75ZTJE",
+					compliant:       true,
+				},
+				{
+					name:            "different seed",
+					firstSeedByte:   2,
+					salt:            2,
+					expectedAddress: "WZMDFDVTJIFGANZKOIHUDI2TIATEIMGA7RPGAOGURFWOH6KTN3DHTLXCBU",
+					compliant:       false,
+				},
+				{
+					name:            "max seed and salt",
+					firstSeedByte:   255,
+					salt:            255,
+					expectedAddress: "HIUU22OZWNLI6MBXNQ4DFUUXMG4ASF7CIUIWRLQC4WDTUGNCAXSCRUHUME",
+					compliant:       true,
+				},
+				{
+					name:            "non-compliant on-curve address",
+					firstSeedByte:   1,
+					salt:            0,
+					expectedAddress: "AFNGS72MUDN72N5MQREE57URNHIH3MSDZZS42WGNPAXKTC3JZSC22S7CBA",
+					compliant:       false,
+				},
+			},
+		},
+	}
+
+	for _, sc := range testCases {
+		t.Run(sc.name, func(t *testing.T) {
+			for _, tc := range sc.answers {
+				t.Run(tc.name, func(t *testing.T) {
+					publicKey := falconPublicKeyForPQAddressTest(t, sc.scheme, tc.firstSeedByte)
+
+					addr := PQAddress(sc.scheme, tc.salt, publicKey)
+					require.Equal(t, tc.expectedAddress, addr.String())
+					require.Equal(t, tc.compliant, addr.IsPQCompliant())
+					require.Equal(t, !tc.compliant, crypto.IsEdwards25519Point(addr[:]))
+
+					addrAgain := PQAddress(sc.scheme, tc.salt, publicKey)
+					require.Equal(t, addr, addrAgain)
+				})
+			}
 		})
 	}
 }
@@ -121,17 +215,41 @@ func TestPQAddressKnownAnswers(t *testing.T) {
 func TestCanonicalPQAddressSalt(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	publicKey := falconPublicKeyForPQAddressTest(t, 1)
+	testCases := []struct {
+		name            string
+		scheme          protocol.PQScheme
+		expectedSalt    PQAddressSalt
+		expectedAddress string
+	}{
+		{
+			name:            "falcon-1024",
+			scheme:          protocol.PQSchemeFalcon1024,
+			expectedSalt:    1,
+			expectedAddress: "GYBWVYVQIQF6CO7BUMG4UQ66DQYHASFOCA2P7PBYOIPKGWUZIBX4KA3TP4",
+		},
+		{
+			name:            "falcon-512",
+			scheme:          protocol.PQSchemeFalcon512,
+			expectedSalt:    1,
+			expectedAddress: "NQHOCVCR45XKZ5LMJSBDWGPZ6QZQIDKQU26KNQ3O4A3EGIRR7BPIX4CW3A",
+		},
+	}
 
-	salt, addr, err := CanonicalPQAddressSalt(protocol.PQSchemeFalcon1024, publicKey)
-	require.NoError(t, err)
-	require.Equal(t, PQAddressSalt(1), salt)
-	require.Equal(t, "GYBWVYVQIQF6CO7BUMG4UQ66DQYHASFOCA2P7PBYOIPKGWUZIBX4KA3TP4", addr.String())
-	require.True(t, addr.IsPQCompliant())
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			publicKey := falconPublicKeyForPQAddressTest(t, tc.scheme, 1)
 
-	for lowerSalt := 0; lowerSalt < int(salt); lowerSalt++ {
-		lowerAddr := PQAddress(protocol.PQSchemeFalcon1024, PQAddressSalt(lowerSalt), publicKey)
-		require.False(t, lowerAddr.IsPQCompliant())
+			salt, addr, err := CanonicalPQAddressSalt(tc.scheme, publicKey)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedSalt, salt)
+			require.Equal(t, tc.expectedAddress, addr.String())
+			require.True(t, addr.IsPQCompliant())
+
+			for lowerSalt := 0; lowerSalt < int(salt); lowerSalt++ {
+				lowerAddr := PQAddress(tc.scheme, PQAddressSalt(lowerSalt), publicKey)
+				require.False(t, lowerAddr.IsPQCompliant())
+			}
+		})
 	}
 }
 

--- a/data/basics/testing/pqsigner.go
+++ b/data/basics/testing/pqsigner.go
@@ -1,0 +1,173 @@
+// Copyright (C) 2019-2026 Algorand Foundation Ltd.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package testing
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+// FalconSigner adapts one PQ scheme's concrete signer (crypto.Falcon1024Signer
+// or crypto.Falcon512Signer) to a byte-oriented API so tests can treat both
+// schemes uniformly.
+type FalconSigner interface {
+	Sign(message crypto.Hashable) ([]byte, error)
+	SignBytes(data []byte) ([]byte, error)
+	Verify(message crypto.Hashable, sig []byte) error
+	VerifyBytes(data []byte, sig []byte) error
+	PublicKey() []byte
+}
+
+type falcon1024Signer struct{ crypto.Falcon1024Signer }
+
+func (s falcon1024Signer) Sign(message crypto.Hashable) ([]byte, error) {
+	return s.Falcon1024Signer.Sign(message)
+}
+func (s falcon1024Signer) SignBytes(data []byte) ([]byte, error) {
+	return s.Falcon1024Signer.SignBytes(data)
+}
+func (s falcon1024Signer) Verify(message crypto.Hashable, sig []byte) error {
+	return s.GetVerifyingKey().Verify(message, sig)
+}
+func (s falcon1024Signer) VerifyBytes(data []byte, sig []byte) error {
+	return s.GetVerifyingKey().VerifyBytes(data, sig)
+}
+func (s falcon1024Signer) PublicKey() []byte {
+	return slices.Clone(s.Falcon1024Signer.PublicKey[:])
+}
+
+type falcon512Signer struct{ crypto.Falcon512Signer }
+
+func (s falcon512Signer) Sign(message crypto.Hashable) ([]byte, error) {
+	return s.Falcon512Signer.Sign(message)
+}
+func (s falcon512Signer) SignBytes(data []byte) ([]byte, error) {
+	return s.Falcon512Signer.SignBytes(data)
+}
+func (s falcon512Signer) Verify(message crypto.Hashable, sig []byte) error {
+	return s.GetVerifyingKey().Verify(message, sig)
+}
+func (s falcon512Signer) VerifyBytes(data []byte, sig []byte) error {
+	return s.GetVerifyingKey().VerifyBytes(data, sig)
+}
+func (s falcon512Signer) PublicKey() []byte {
+	return slices.Clone(s.Falcon512Signer.PublicKey[:])
+}
+
+// PQTestScheme carries one PQ scheme's test metadata.
+type PQTestScheme struct {
+	// Name is a human-readable scheme name, suitable for subtest names.
+	Name             string
+	Scheme           protocol.PQScheme
+	ErrSigInvalid    error
+	MaxSignatureSize int
+}
+
+// PQTestSchemes lists the supported PQ schemes with their test metadata, for
+// tests that exercise every scheme.
+var PQTestSchemes = []PQTestScheme{
+	{
+		Name:             "falcon-1024",
+		Scheme:           protocol.PQSchemeFalcon1024,
+		ErrSigInvalid:    crypto.ErrPQFalcon1024SigInvalid,
+		MaxSignatureSize: crypto.Falcon1024MaxSignatureSize,
+	},
+	{
+		Name:             "falcon-512",
+		Scheme:           protocol.PQSchemeFalcon512,
+		ErrSigInvalid:    crypto.ErrPQFalcon512SigInvalid,
+		MaxSignatureSize: crypto.Falcon512MaxSignatureSize,
+	},
+}
+
+// PQTestSchemeInfo returns the PQTestSchemes entry for scheme, failing the
+// test on an unknown scheme.
+func PQTestSchemeInfo(t testing.TB, scheme protocol.PQScheme) PQTestScheme {
+	t.Helper()
+
+	for _, tc := range PQTestSchemes {
+		if tc.Scheme == scheme {
+			return tc
+		}
+	}
+	t.Fatalf("unknown scheme %s", scheme)
+	return PQTestScheme{}
+}
+
+// RandomPQTestScheme randomly picks one of PQTestSchemes.
+func RandomPQTestScheme() PQTestScheme {
+	var selector [1]byte
+	crypto.RandBytes(selector[:])
+	return PQTestSchemes[int(selector[0])%len(PQTestSchemes)]
+}
+
+// MakeFalconSigner builds a wrapped Falcon signer for the given scheme from a
+// deterministic seed.
+func MakeFalconSigner(t testing.TB, firstSeedByte byte, scheme protocol.PQScheme) FalconSigner {
+	t.Helper()
+
+	var seed crypto.FalconSeed
+	seed[0] = firstSeedByte
+	switch scheme {
+	case protocol.PQSchemeFalcon1024:
+		signer, err := crypto.GenerateFalcon1024Signer(seed)
+		require.NoError(t, err)
+		return falcon1024Signer{signer}
+	case protocol.PQSchemeFalcon512:
+		signer, err := crypto.GenerateFalcon512Signer(seed)
+		require.NoError(t, err)
+		return falcon512Signer{signer}
+	}
+	t.Fatalf("unknown scheme %s", scheme)
+	return nil
+}
+
+// PQTestAccount is a PQ-addressed test account: a wrapped signer plus its
+// canonical PQ address derivation.
+type PQTestAccount struct {
+	Signer    FalconSigner
+	Scheme    protocol.PQScheme
+	Address   basics.Address
+	Salt      basics.PQAddressSalt
+	PublicKey []byte
+}
+
+// MakePQTestAccount builds a PQTestAccount for the given scheme from a
+// deterministic seed, deriving the canonical salt and address for its public
+// key.
+func MakePQTestAccount(t testing.TB, firstSeedByte byte, scheme protocol.PQScheme) PQTestAccount {
+	t.Helper()
+
+	signer := MakeFalconSigner(t, firstSeedByte, scheme)
+	publicKey := signer.PublicKey()
+	salt, address, err := basics.CanonicalPQAddressSalt(scheme, publicKey)
+	require.NoError(t, err)
+
+	return PQTestAccount{
+		Signer:    signer,
+		Scheme:    scheme,
+		Address:   address,
+		Salt:      salt,
+		PublicKey: publicKey,
+	}
+}

--- a/data/transactions/logicsig_test.go
+++ b/data/transactions/logicsig_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/algorand/msgp/msgp"
 
 	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
@@ -33,7 +34,7 @@ func TestLogicSigBlankAndHasProgram(t *testing.T) {
 	nonblankSig := crypto.Signature{}
 	nonblankSig[0] = 1
 
-	pqFixture := makePQSigTestFixture(t, 13)
+	pqFixture := makePQSigTestFixture(t, 13, protocol.PQSchemeFalcon1024)
 
 	tests := []struct {
 		name       string
@@ -83,18 +84,21 @@ func TestLogicSigBlankAndHasProgram(t *testing.T) {
 func TestLogicSigPQSigMsgpackRoundTrip(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 11)
-	lsig := LogicSig{
-		Logic: []byte{1, 32, 1},
-		Args:  [][]byte{{2, 3}},
-		PQsig: fixture.pqSig,
-	}
+	for _, fixture := range makePQSigTestFixtures(t, 11) {
+		t.Run(fixture.name, func(t *testing.T) {
+			lsig := LogicSig{
+				Logic: []byte{1, 32, 1},
+				Args:  [][]byte{{2, 3}},
+				PQsig: fixture.pqSig,
+			}
 
-	var decoded LogicSig
-	left, err := decoded.UnmarshalMsg(lsig.MarshalMsg(nil))
-	require.NoError(t, err)
-	require.Empty(t, left)
-	require.True(t, lsig.Equal(&decoded))
+			var decoded LogicSig
+			left, err := decoded.UnmarshalMsg(lsig.MarshalMsg(nil))
+			require.NoError(t, err)
+			require.Empty(t, left)
+			require.True(t, lsig.Equal(&decoded))
+		})
+	}
 }
 
 func TestLogicSigBlankPQSigOmitted(t *testing.T) {

--- a/data/transactions/pqsig_test.go
+++ b/data/transactions/pqsig_test.go
@@ -33,22 +33,102 @@ import (
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
-type pqSigTestFixture struct {
-	signer     crypto.Falcon1024Signer
-	proto      config.ConsensusParams
-	txn        Transaction
-	authorizer basics.Address
-	pqSig      PQSig
+// pqSigTestSigner adapts one scheme's concrete signer to the byte-oriented
+// operations the tests need.
+type pqSigTestSigner interface {
+	sign(message crypto.Hashable) ([]byte, error)
+	signBytes(data []byte) ([]byte, error)
+	verify(message crypto.Hashable, sig []byte) error
+	verifyBytes(data []byte, sig []byte) error
 }
 
-func makePQSigTestFixture(t *testing.T, firstSeedByte byte) pqSigTestFixture {
+type falcon1024TestSigner struct{ crypto.Falcon1024Signer }
+
+func (s falcon1024TestSigner) sign(message crypto.Hashable) ([]byte, error) {
+	return s.Sign(message)
+}
+func (s falcon1024TestSigner) signBytes(data []byte) ([]byte, error) {
+	return s.SignBytes(data)
+}
+func (s falcon1024TestSigner) verify(message crypto.Hashable, sig []byte) error {
+	return s.GetVerifyingKey().Verify(message, sig)
+}
+func (s falcon1024TestSigner) verifyBytes(data []byte, sig []byte) error {
+	return s.GetVerifyingKey().VerifyBytes(data, sig)
+}
+
+type falcon512TestSigner struct{ crypto.Falcon512Signer }
+
+func (s falcon512TestSigner) sign(message crypto.Hashable) ([]byte, error) {
+	return s.Sign(message)
+}
+func (s falcon512TestSigner) signBytes(data []byte) ([]byte, error) {
+	return s.SignBytes(data)
+}
+func (s falcon512TestSigner) verify(message crypto.Hashable, sig []byte) error {
+	return s.GetVerifyingKey().Verify(message, sig)
+}
+func (s falcon512TestSigner) verifyBytes(data []byte, sig []byte) error {
+	return s.GetVerifyingKey().VerifyBytes(data, sig)
+}
+
+type pqSigTestFixture struct {
+	name             string
+	signer           pqSigTestSigner
+	proto            config.ConsensusParams
+	txn              Transaction
+	authorizer       basics.Address
+	pqSig            PQSig
+	errSigInvalid    error
+	maxSignatureSize int
+}
+
+// protoWithSchemeDisabled returns a copy of the fixture's consensus params
+// with the fixture's scheme turned off.
+func (f pqSigTestFixture) protoWithSchemeDisabled(t *testing.T) config.ConsensusParams {
+	proto := f.proto
+	switch f.pqSig.Scheme {
+	case protocol.PQSchemeFalcon1024:
+		proto.EnablePQSchemeFalcon1024 = false
+	case protocol.PQSchemeFalcon512:
+		proto.EnablePQSchemeFalcon512 = false
+	default:
+		t.Fatalf("unknown scheme %s", f.pqSig.Scheme)
+	}
+	return proto
+}
+
+func makePQSigTestFixture(t *testing.T, firstSeedByte byte, scheme protocol.PQScheme) pqSigTestFixture {
 	var seed crypto.FalconSeed
 	seed[0] = firstSeedByte
-	signer, err := crypto.GenerateFalcon1024Signer(seed)
-	require.NoError(t, err)
 
-	publicKey := slices.Clone(signer.PublicKey[:])
-	salt, authorizer, err := basics.CanonicalPQAddressSalt(protocol.PQSchemeFalcon1024, publicKey)
+	var name string
+	var signer pqSigTestSigner
+	var publicKey []byte
+	var errSigInvalid error
+	var maxSignatureSize int
+	switch scheme {
+	case protocol.PQSchemeFalcon1024:
+		s, err := crypto.GenerateFalcon1024Signer(seed)
+		require.NoError(t, err)
+		name = "falcon-1024"
+		signer = falcon1024TestSigner{s}
+		publicKey = slices.Clone(s.PublicKey[:])
+		errSigInvalid = crypto.ErrPQFalcon1024SigInvalid
+		maxSignatureSize = crypto.Falcon1024MaxSignatureSize
+	case protocol.PQSchemeFalcon512:
+		s, err := crypto.GenerateFalcon512Signer(seed)
+		require.NoError(t, err)
+		name = "falcon-512"
+		signer = falcon512TestSigner{s}
+		publicKey = slices.Clone(s.PublicKey[:])
+		errSigInvalid = crypto.ErrPQFalcon512SigInvalid
+		maxSignatureSize = crypto.Falcon512MaxSignatureSize
+	default:
+		t.Fatalf("unknown scheme %s", scheme)
+	}
+
+	salt, authorizer, err := basics.CanonicalPQAddressSalt(scheme, publicKey)
 	require.NoError(t, err)
 
 	txn := Transaction{
@@ -61,23 +141,33 @@ func makePQSigTestFixture(t *testing.T, firstSeedByte byte) pqSigTestFixture {
 		},
 	}
 
-	signature, err := signer.Sign(txn)
+	signature, err := signer.sign(txn)
 	require.NoError(t, err)
 
 	proto := config.Consensus[protocol.ConsensusFuture]
-	require.True(t, proto.EnablePQSchemeFalcon1024)
+	require.True(t, proto.PQSchemeEnabled(scheme))
 
 	return pqSigTestFixture{
+		name:       name,
 		signer:     signer,
 		proto:      proto,
 		txn:        txn,
 		authorizer: authorizer,
 		pqSig: PQSig{
-			Scheme:    protocol.PQSchemeFalcon1024,
+			Scheme:    scheme,
 			Salt:      salt,
 			PublicKey: publicKey,
 			Signature: signature,
 		},
+		errSigInvalid:    errSigInvalid,
+		maxSignatureSize: maxSignatureSize,
+	}
+}
+
+func makePQSigTestFixtures(t *testing.T, firstSeedByte byte) []pqSigTestFixture {
+	return []pqSigTestFixture{
+		makePQSigTestFixture(t, firstSeedByte, protocol.PQSchemeFalcon1024),
+		makePQSigTestFixture(t, firstSeedByte, protocol.PQSchemeFalcon512),
 	}
 }
 
@@ -120,6 +210,7 @@ func TestPQSigBlank(t *testing.T) {
 
 	require.False(t, (PQSig{Salt: 1}).Blank())
 	require.False(t, (PQSig{Scheme: protocol.PQSchemeFalcon1024}).Blank())
+	require.False(t, (PQSig{Scheme: protocol.PQSchemeFalcon512}).Blank())
 	require.False(t, (PQSig{PublicKey: []byte{1}}).Blank())
 	require.False(t, (PQSig{Signature: []byte{1}}).Blank())
 }
@@ -127,227 +218,253 @@ func TestPQSigBlank(t *testing.T) {
 func TestPQSigEqual(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 0)
-	same := fixture.pqSig
-	same.PublicKey = slices.Clone(same.PublicKey)
-	same.Signature = slices.Clone(same.Signature)
+	for _, fixture := range makePQSigTestFixtures(t, 0) {
+		t.Run(fixture.name, func(t *testing.T) {
+			same := fixture.pqSig
+			same.PublicKey = slices.Clone(same.PublicKey)
+			same.Signature = slices.Clone(same.Signature)
 
-	require.True(t, fixture.pqSig.Equal(same))
+			require.True(t, fixture.pqSig.Equal(same))
 
-	changedScheme := fixture.pqSig
-	changedScheme.Scheme = protocol.PQScheme{'x', '1'}
-	require.False(t, fixture.pqSig.Equal(changedScheme))
+			changedScheme := fixture.pqSig
+			changedScheme.Scheme = protocol.PQScheme{'x', '1'}
+			require.False(t, fixture.pqSig.Equal(changedScheme))
 
-	changedSalt := fixture.pqSig
-	changedSalt.Salt++
-	require.False(t, fixture.pqSig.Equal(changedSalt))
+			changedSalt := fixture.pqSig
+			changedSalt.Salt++
+			require.False(t, fixture.pqSig.Equal(changedSalt))
 
-	changedPublicKey := fixture.pqSig
-	changedPublicKey.PublicKey = slices.Clone(changedPublicKey.PublicKey)
-	changedPublicKey.PublicKey[0] ^= 1
-	require.False(t, fixture.pqSig.Equal(changedPublicKey))
+			changedPublicKey := fixture.pqSig
+			changedPublicKey.PublicKey = slices.Clone(changedPublicKey.PublicKey)
+			changedPublicKey.PublicKey[0] ^= 1
+			require.False(t, fixture.pqSig.Equal(changedPublicKey))
 
-	changedSignature := fixture.pqSig
-	changedSignature.Signature = slices.Clone(changedSignature.Signature)
-	changedSignature.Signature[0] ^= 1
-	require.False(t, fixture.pqSig.Equal(changedSignature))
+			changedSignature := fixture.pqSig
+			changedSignature.Signature = slices.Clone(changedSignature.Signature)
+			changedSignature.Signature[0] ^= 1
+			require.False(t, fixture.pqSig.Equal(changedSignature))
 
-	blank := PQSig{}
-	require.True(t, blank.Equal(PQSig{}))
-	require.False(t, blank.Equal(fixture.pqSig))
+			blank := PQSig{}
+			require.True(t, blank.Equal(PQSig{}))
+			require.False(t, blank.Equal(fixture.pqSig))
+		})
+	}
 }
 
 func TestPQSigAuthorizerAddress(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 0)
-
-	require.Equal(t, fixture.authorizer, fixture.pqSig.Address())
-	require.Equal(t, basics.PQAddress(fixture.pqSig.Scheme, fixture.pqSig.Salt, fixture.pqSig.PublicKey), fixture.pqSig.Address())
+	for _, fixture := range makePQSigTestFixtures(t, 0) {
+		t.Run(fixture.name, func(t *testing.T) {
+			require.Equal(t, fixture.authorizer, fixture.pqSig.Address())
+			require.Equal(t, basics.PQAddress(fixture.pqSig.Scheme, fixture.pqSig.Salt, fixture.pqSig.PublicKey), fixture.pqSig.Address())
+		})
+	}
 }
 
 func TestPQSigValidateEnvelope(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 0)
+	for _, fixture := range makePQSigTestFixtures(t, 0) {
+		t.Run(fixture.name, func(t *testing.T) {
+			require.NoError(t, fixture.pqSig.ValidateScheme(fixture.proto))
 
-	require.NoError(t, fixture.pqSig.ValidateScheme(fixture.proto))
+			schemeOnly := PQSig{Scheme: fixture.pqSig.Scheme}
+			require.NoError(t, schemeOnly.ValidateScheme(fixture.proto))
 
-	schemeOnly := PQSig{Scheme: protocol.PQSchemeFalcon1024}
-	require.NoError(t, schemeOnly.ValidateScheme(fixture.proto))
+			require.NoError(t, fixture.pqSig.ValidateEnvelope(fixture.proto, fixture.authorizer))
 
-	require.NoError(t, fixture.pqSig.ValidateEnvelope(fixture.proto, fixture.authorizer))
+			noSignature := fixture.pqSig
+			noSignature.Signature = nil
+			require.NoError(t, noSignature.ValidateEnvelope(fixture.proto, fixture.authorizer))
 
-	noSignature := fixture.pqSig
-	noSignature.Signature = nil
-	require.NoError(t, noSignature.ValidateEnvelope(fixture.proto, fixture.authorizer))
+			disabledProto := fixture.protoWithSchemeDisabled(t)
+			require.ErrorIs(t, fixture.pqSig.ValidateScheme(disabledProto), crypto.ErrPQSchemeNotEnabled)
+			require.ErrorIs(t, fixture.pqSig.ValidateEnvelope(disabledProto, fixture.authorizer), crypto.ErrPQSchemeNotEnabled)
 
-	disabledProto := fixture.proto
-	disabledProto.EnablePQSchemeFalcon1024 = false
-	require.ErrorIs(t, fixture.pqSig.ValidateScheme(disabledProto), crypto.ErrPQSchemeNotEnabled)
-	require.ErrorIs(t, fixture.pqSig.ValidateEnvelope(disabledProto, fixture.authorizer), crypto.ErrPQSchemeNotEnabled)
+			unknownScheme := fixture.pqSig
+			unknownScheme.Scheme = protocol.PQScheme{'x', '1'}
+			require.ErrorIs(t, unknownScheme.ValidateScheme(fixture.proto), crypto.ErrPQSchemeNotSupported)
+			require.ErrorIs(t, unknownScheme.ValidateEnvelope(fixture.proto, unknownScheme.Address()), crypto.ErrPQSchemeNotSupported)
 
-	unknownScheme := fixture.pqSig
-	unknownScheme.Scheme = protocol.PQScheme{'x', '1'}
-	require.ErrorIs(t, unknownScheme.ValidateScheme(fixture.proto), crypto.ErrPQSchemeNotSupported)
-	require.ErrorIs(t, unknownScheme.ValidateEnvelope(fixture.proto, unknownScheme.Address()), crypto.ErrPQSchemeNotSupported)
+			malformedPublicKey := fixture.pqSig
+			malformedPublicKey.PublicKey = malformedPublicKey.PublicKey[:len(malformedPublicKey.PublicKey)-1]
+			require.NoError(t, malformedPublicKey.ValidateEnvelope(fixture.proto, malformedPublicKey.Address()))
+			require.ErrorIs(t, malformedPublicKey.Verify(fixture.proto, fixture.txn, malformedPublicKey.Address()), fixture.errSigInvalid)
 
-	malformedPublicKey := fixture.pqSig
-	malformedPublicKey.PublicKey = malformedPublicKey.PublicKey[:len(malformedPublicKey.PublicKey)-1]
-	require.NoError(t, malformedPublicKey.ValidateEnvelope(fixture.proto, malformedPublicKey.Address()))
-	require.ErrorIs(t, malformedPublicKey.Verify(fixture.proto, fixture.txn, malformedPublicKey.Address()), crypto.ErrPQFalcon1024SigInvalid)
+			var wrongAuthorizer basics.Address
+			wrongAuthorizer[0] = 1
+			require.ErrorIs(t, fixture.pqSig.ValidateEnvelope(fixture.proto, wrongAuthorizer), errPQSigAuthorizerMismatch)
 
-	var wrongAuthorizer basics.Address
-	wrongAuthorizer[0] = 1
-	require.ErrorIs(t, fixture.pqSig.ValidateEnvelope(fixture.proto, wrongAuthorizer), errPQSigAuthorizerMismatch)
+			corruptSignature := fixture.pqSig
+			corruptSignature.Signature = slices.Clone(corruptSignature.Signature)
+			corruptSignature.Signature[0] ^= 1
+			require.NoError(t, corruptSignature.ValidateEnvelope(fixture.proto, fixture.authorizer))
+			require.Error(t, corruptSignature.Verify(fixture.proto, fixture.txn, fixture.authorizer))
 
-	corruptSignature := fixture.pqSig
-	corruptSignature.Signature = slices.Clone(corruptSignature.Signature)
-	corruptSignature.Signature[0] ^= 1
-	require.NoError(t, corruptSignature.ValidateEnvelope(fixture.proto, fixture.authorizer))
-	require.Error(t, corruptSignature.Verify(fixture.proto, fixture.txn, fixture.authorizer))
-
-	require.ErrorIs(t, (PQSig{}).ValidateEnvelope(fixture.proto, fixture.authorizer), errPQSigBlank)
-	require.ErrorIs(t, (PQSig{}).ValidateScheme(fixture.proto), errPQSigBlank)
+			require.ErrorIs(t, (PQSig{}).ValidateEnvelope(fixture.proto, fixture.authorizer), errPQSigBlank)
+			require.ErrorIs(t, (PQSig{}).ValidateScheme(fixture.proto), errPQSigBlank)
+		})
+	}
 }
 
 func TestPQSigVerify(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 0)
-
-	require.NoError(t, fixture.pqSig.Verify(fixture.proto, fixture.txn, fixture.authorizer))
+	for _, fixture := range makePQSigTestFixtures(t, 0) {
+		t.Run(fixture.name, func(t *testing.T) {
+			require.NoError(t, fixture.pqSig.Verify(fixture.proto, fixture.txn, fixture.authorizer))
+		})
+	}
 }
 
 func TestPQSigVerifyAcceptsSignatureOverRawTxn(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 0) // uses signer.Sign()
+	for _, fixture := range makePQSigTestFixtures(t, 0) { // fixture uses signer.sign()
+		t.Run(fixture.name, func(t *testing.T) {
+			rawTxnSignature, err := fixture.signer.signBytes(crypto.HashRep(fixture.txn))
+			require.NoError(t, err)
 
-	rawTxnSignature, err := fixture.signer.SignBytes(crypto.HashRep(fixture.txn))
-	require.NoError(t, err)
+			// Sign(txn) applies HashRep internally, so it must produce the same sig as SignBytes(HashRep(txn))
+			require.Equal(t, fixture.pqSig.Signature, rawTxnSignature)
 
-	// Sign(txn) applies HashRep internally, so it must produce the same sig as SignBytes(HashRep(txn))
-	require.Equal(t, fixture.pqSig.Signature, []byte(rawTxnSignature))
+			pqSig := fixture.pqSig
+			pqSig.Signature = rawTxnSignature
+			require.NoError(t, pqSig.Verify(fixture.proto, fixture.txn, fixture.authorizer))
 
-	pqSig := fixture.pqSig
-	pqSig.Signature = rawTxnSignature
-	require.NoError(t, pqSig.Verify(fixture.proto, fixture.txn, fixture.authorizer))
+			require.NoError(t, fixture.signer.verify(fixture.txn, rawTxnSignature))
+			require.NoError(t, fixture.signer.verifyBytes(crypto.HashRep(fixture.txn), rawTxnSignature))
 
-	verifier := fixture.signer.GetVerifyingKey()
-	require.NoError(t, verifier.Verify(fixture.txn, rawTxnSignature))
-	require.NoError(t, verifier.VerifyBytes(crypto.HashRep(fixture.txn), rawTxnSignature))
+			// A signature over the txid (the pre-hashed payload) must not verify:
+			// the payload is the raw canonical encoding, not its digest.
+			txid := crypto.Digest(fixture.txn.ID())
+			txidSignature, err := fixture.signer.signBytes(txid[:])
+			require.NoError(t, err)
+			require.False(t, bytes.Equal(txidSignature, rawTxnSignature))
 
-	// A signature over the txid (the pre-hashed payload) must not verify:
-	// the payload is the raw canonical encoding, not its digest.
-	txid := crypto.Digest(fixture.txn.ID())
-	txidSignature, err := fixture.signer.SignBytes(txid[:])
-	require.NoError(t, err)
-	require.False(t, bytes.Equal(txidSignature, rawTxnSignature))
-
-	pqSig.Signature = txidSignature
-	require.ErrorIs(t, pqSig.Verify(fixture.proto, fixture.txn, fixture.authorizer), crypto.ErrPQFalcon1024SigInvalid)
+			pqSig.Signature = txidSignature
+			require.ErrorIs(t, pqSig.Verify(fixture.proto, fixture.txn, fixture.authorizer), fixture.errSigInvalid)
+		})
+	}
 }
 
 func TestPQSigVerifyChecksConsensusParams(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 0)
+	for _, fixture := range makePQSigTestFixtures(t, 0) {
+		t.Run(fixture.name, func(t *testing.T) {
+			require.NoError(t, fixture.pqSig.Verify(fixture.proto, fixture.txn, fixture.authorizer))
 
-	require.NoError(t, fixture.pqSig.Verify(fixture.proto, fixture.txn, fixture.authorizer))
-
-	disabledProto := fixture.proto
-	disabledProto.EnablePQSchemeFalcon1024 = false
-	require.ErrorIs(t, fixture.pqSig.Verify(disabledProto, fixture.txn, fixture.authorizer), crypto.ErrPQSchemeNotEnabled)
+			disabledProto := fixture.protoWithSchemeDisabled(t)
+			require.ErrorIs(t, fixture.pqSig.Verify(disabledProto, fixture.txn, fixture.authorizer), crypto.ErrPQSchemeNotEnabled)
+		})
+	}
 }
 
 func TestPQSigVerifyRejectsBlank(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 0)
-
-	require.ErrorIs(t, (PQSig{}).Verify(fixture.proto, fixture.txn, fixture.authorizer), errPQSigBlank)
+	for _, fixture := range makePQSigTestFixtures(t, 0) {
+		t.Run(fixture.name, func(t *testing.T) {
+			require.ErrorIs(t, (PQSig{}).Verify(fixture.proto, fixture.txn, fixture.authorizer), errPQSigBlank)
+		})
+	}
 }
 
 func TestPQSigVerifyRejectsEmptySignature(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 0)
+	for _, fixture := range makePQSigTestFixtures(t, 0) {
+		t.Run(fixture.name, func(t *testing.T) {
+			pqSig := fixture.pqSig
+			pqSig.Signature = nil
 
-	pqSig := fixture.pqSig
-	pqSig.Signature = nil
-
-	require.ErrorIs(t, pqSig.Verify(fixture.proto, fixture.txn, fixture.authorizer), errPQSigEmpty)
+			require.ErrorIs(t, pqSig.Verify(fixture.proto, fixture.txn, fixture.authorizer), errPQSigEmpty)
+		})
+	}
 }
 
 func TestPQSigVerifyRejectsUnsupportedScheme(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 0)
+	for _, fixture := range makePQSigTestFixtures(t, 0) {
+		t.Run(fixture.name, func(t *testing.T) {
+			pqSig := fixture.pqSig
+			pqSig.Scheme = protocol.PQScheme{'x', '1'}
+			pqSig.Signature = []byte{1}
 
-	pqSig := fixture.pqSig
-	pqSig.Scheme = protocol.PQScheme{'x', '1'}
-	pqSig.Signature = []byte{1}
-
-	require.ErrorIs(t, pqSig.Verify(fixture.proto, fixture.txn, pqSig.Address()), crypto.ErrPQSchemeNotSupported)
+			require.ErrorIs(t, pqSig.Verify(fixture.proto, fixture.txn, pqSig.Address()), crypto.ErrPQSchemeNotSupported)
+		})
+	}
 }
 
 func TestPQSigVerifyRejectsAuthorizerMismatch(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 0)
+	for _, fixture := range makePQSigTestFixtures(t, 0) {
+		t.Run(fixture.name, func(t *testing.T) {
+			var wrongAuthorizer basics.Address
+			wrongAuthorizer[0] = 1
+			require.NotEqual(t, fixture.authorizer, wrongAuthorizer)
 
-	var wrongAuthorizer basics.Address
-	wrongAuthorizer[0] = 1
-	require.NotEqual(t, fixture.authorizer, wrongAuthorizer)
-
-	require.ErrorIs(t, fixture.pqSig.Verify(fixture.proto, fixture.txn, wrongAuthorizer), errPQSigAuthorizerMismatch)
+			require.ErrorIs(t, fixture.pqSig.Verify(fixture.proto, fixture.txn, wrongAuthorizer), errPQSigAuthorizerMismatch)
+		})
+	}
 }
 
 func TestPQSigVerifyRejectsMalformedPublicKey(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 0)
+	for _, fixture := range makePQSigTestFixtures(t, 0) {
+		t.Run(fixture.name, func(t *testing.T) {
+			pqSig := fixture.pqSig
+			pqSig.PublicKey = pqSig.PublicKey[:len(pqSig.PublicKey)-1]
 
-	pqSig := fixture.pqSig
-	pqSig.PublicKey = pqSig.PublicKey[:len(pqSig.PublicKey)-1]
-
-	err := pqSig.Verify(fixture.proto, fixture.txn, pqSig.Address())
-	require.Error(t, err)
-	require.NotErrorIs(t, err, errPQSigAuthorizerMismatch)
+			err := pqSig.Verify(fixture.proto, fixture.txn, pqSig.Address())
+			require.Error(t, err)
+			require.NotErrorIs(t, err, errPQSigAuthorizerMismatch)
+		})
+	}
 }
 
 func TestPQSigVerifyRejectsMalformedSignature(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 0)
+	for _, fixture := range makePQSigTestFixtures(t, 0) {
+		t.Run(fixture.name, func(t *testing.T) {
+			pqSig := fixture.pqSig
+			pqSig.Signature = make([]byte, fixture.maxSignatureSize+1)
 
-	pqSig := fixture.pqSig
-	pqSig.Signature = make([]byte, crypto.Falcon1024MaxSignatureSize+1)
-
-	err := pqSig.Verify(fixture.proto, fixture.txn, fixture.authorizer)
-	require.ErrorIs(t, err, crypto.ErrPQFalcon1024SigInvalid)
+			err := pqSig.Verify(fixture.proto, fixture.txn, fixture.authorizer)
+			require.ErrorIs(t, err, fixture.errSigInvalid)
+		})
+	}
 }
 
 func TestPQSigVerifyRejectsChangedTransaction(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 0)
+	for _, fixture := range makePQSigTestFixtures(t, 0) {
+		t.Run(fixture.name, func(t *testing.T) {
+			txn := fixture.txn
+			txn.Note = []byte("changed")
 
-	txn := fixture.txn
-	txn.Note = []byte("changed")
-
-	require.ErrorIs(t, fixture.pqSig.Verify(fixture.proto, txn, fixture.authorizer), crypto.ErrPQFalcon1024SigInvalid)
+			require.ErrorIs(t, fixture.pqSig.Verify(fixture.proto, txn, fixture.authorizer), fixture.errSigInvalid)
+		})
+	}
 }
 
 func TestPQSigVerifyRejectsChangedSignature(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 0)
+	for _, fixture := range makePQSigTestFixtures(t, 0) {
+		t.Run(fixture.name, func(t *testing.T) {
+			pqSig := fixture.pqSig
+			pqSig.Signature = slices.Clone(pqSig.Signature)
+			pqSig.Signature[len(pqSig.Signature)-1] ^= 1
 
-	pqSig := fixture.pqSig
-	pqSig.Signature = slices.Clone(pqSig.Signature)
-	pqSig.Signature[len(pqSig.Signature)-1] ^= 1
-
-	require.ErrorIs(t, pqSig.Verify(fixture.proto, fixture.txn, fixture.authorizer), crypto.ErrPQFalcon1024SigInvalid)
+			require.ErrorIs(t, pqSig.Verify(fixture.proto, fixture.txn, fixture.authorizer), fixture.errSigInvalid)
+		})
+	}
 }

--- a/data/transactions/pqsig_test.go
+++ b/data/transactions/pqsig_test.go
@@ -29,52 +29,14 @@ import (
 	"github.com/algorand/go-algorand/config/bounds"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
+	basics_testing "github.com/algorand/go-algorand/data/basics/testing"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
 
-// pqSigTestSigner adapts one scheme's concrete signer to the byte-oriented
-// operations the tests need.
-type pqSigTestSigner interface {
-	sign(message crypto.Hashable) ([]byte, error)
-	signBytes(data []byte) ([]byte, error)
-	verify(message crypto.Hashable, sig []byte) error
-	verifyBytes(data []byte, sig []byte) error
-}
-
-type falcon1024TestSigner struct{ crypto.Falcon1024Signer }
-
-func (s falcon1024TestSigner) sign(message crypto.Hashable) ([]byte, error) {
-	return s.Sign(message)
-}
-func (s falcon1024TestSigner) signBytes(data []byte) ([]byte, error) {
-	return s.SignBytes(data)
-}
-func (s falcon1024TestSigner) verify(message crypto.Hashable, sig []byte) error {
-	return s.GetVerifyingKey().Verify(message, sig)
-}
-func (s falcon1024TestSigner) verifyBytes(data []byte, sig []byte) error {
-	return s.GetVerifyingKey().VerifyBytes(data, sig)
-}
-
-type falcon512TestSigner struct{ crypto.Falcon512Signer }
-
-func (s falcon512TestSigner) sign(message crypto.Hashable) ([]byte, error) {
-	return s.Sign(message)
-}
-func (s falcon512TestSigner) signBytes(data []byte) ([]byte, error) {
-	return s.SignBytes(data)
-}
-func (s falcon512TestSigner) verify(message crypto.Hashable, sig []byte) error {
-	return s.GetVerifyingKey().Verify(message, sig)
-}
-func (s falcon512TestSigner) verifyBytes(data []byte, sig []byte) error {
-	return s.GetVerifyingKey().VerifyBytes(data, sig)
-}
-
 type pqSigTestFixture struct {
 	name             string
-	signer           pqSigTestSigner
+	signer           basics_testing.FalconSigner
 	proto            config.ConsensusParams
 	txn              Transaction
 	authorizer       basics.Address
@@ -99,76 +61,48 @@ func (f pqSigTestFixture) protoWithSchemeDisabled(t *testing.T) config.Consensus
 }
 
 func makePQSigTestFixture(t *testing.T, firstSeedByte byte, scheme protocol.PQScheme) pqSigTestFixture {
-	var seed crypto.FalconSeed
-	seed[0] = firstSeedByte
-
-	var name string
-	var signer pqSigTestSigner
-	var publicKey []byte
-	var errSigInvalid error
-	var maxSignatureSize int
-	switch scheme {
-	case protocol.PQSchemeFalcon1024:
-		s, err := crypto.GenerateFalcon1024Signer(seed)
-		require.NoError(t, err)
-		name = "falcon-1024"
-		signer = falcon1024TestSigner{s}
-		publicKey = slices.Clone(s.PublicKey[:])
-		errSigInvalid = crypto.ErrPQFalcon1024SigInvalid
-		maxSignatureSize = crypto.Falcon1024MaxSignatureSize
-	case protocol.PQSchemeFalcon512:
-		s, err := crypto.GenerateFalcon512Signer(seed)
-		require.NoError(t, err)
-		name = "falcon-512"
-		signer = falcon512TestSigner{s}
-		publicKey = slices.Clone(s.PublicKey[:])
-		errSigInvalid = crypto.ErrPQFalcon512SigInvalid
-		maxSignatureSize = crypto.Falcon512MaxSignatureSize
-	default:
-		t.Fatalf("unknown scheme %s", scheme)
-	}
-
-	salt, authorizer, err := basics.CanonicalPQAddressSalt(scheme, publicKey)
-	require.NoError(t, err)
+	schemeInfo := basics_testing.PQTestSchemeInfo(t, scheme)
+	acct := basics_testing.MakePQTestAccount(t, firstSeedByte, scheme)
 
 	txn := Transaction{
 		Type: protocol.PaymentTx,
 		Header: Header{
-			Sender: authorizer,
+			Sender: acct.Address,
 		},
 		PaymentTxnFields: PaymentTxnFields{
-			Receiver: authorizer,
+			Receiver: acct.Address,
 		},
 	}
 
-	signature, err := signer.sign(txn)
+	signature, err := acct.Signer.Sign(txn)
 	require.NoError(t, err)
 
 	proto := config.Consensus[protocol.ConsensusFuture]
 	require.True(t, proto.PQSchemeEnabled(scheme))
 
 	return pqSigTestFixture{
-		name:       name,
-		signer:     signer,
+		name:       schemeInfo.Name,
+		signer:     acct.Signer,
 		proto:      proto,
 		txn:        txn,
-		authorizer: authorizer,
+		authorizer: acct.Address,
 		pqSig: PQSig{
-			Scheme:    scheme,
-			Salt:      salt,
-			PublicKey: publicKey,
+			Scheme:    acct.Scheme,
+			Salt:      acct.Salt,
+			PublicKey: acct.PublicKey,
 			Signature: signature,
 		},
-		errSigInvalid:    errSigInvalid,
-		maxSignatureSize: maxSignatureSize,
+		errSigInvalid:    schemeInfo.ErrSigInvalid,
+		maxSignatureSize: schemeInfo.MaxSignatureSize,
 	}
 }
 
 func makePQSigTestFixtures(t *testing.T, firstSeedByte byte) []pqSigTestFixture {
-	return []pqSigTestFixture{
-		makePQSigTestFixture(t, firstSeedByte, protocol.PQSchemeFalcon1024),
-		makePQSigTestFixture(t, firstSeedByte, protocol.PQSchemeFalcon512),
+	fixtures := make([]pqSigTestFixture, 0, len(basics_testing.PQTestSchemes))
+	for _, scheme := range basics_testing.PQTestSchemes {
+		fixtures = append(fixtures, makePQSigTestFixture(t, firstSeedByte, scheme.Scheme))
 	}
+	return fixtures
 }
 
 func TestPQDecodeBoundsFeedSignedTxnMaxSize(t *testing.T) {
@@ -323,7 +257,7 @@ func TestPQSigVerifyAcceptsSignatureOverRawTxn(t *testing.T) {
 
 	for _, fixture := range makePQSigTestFixtures(t, 0) { // fixture uses signer.sign()
 		t.Run(fixture.name, func(t *testing.T) {
-			rawTxnSignature, err := fixture.signer.signBytes(crypto.HashRep(fixture.txn))
+			rawTxnSignature, err := fixture.signer.SignBytes(crypto.HashRep(fixture.txn))
 			require.NoError(t, err)
 
 			// Sign(txn) applies HashRep internally, so it must produce the same sig as SignBytes(HashRep(txn))
@@ -333,13 +267,13 @@ func TestPQSigVerifyAcceptsSignatureOverRawTxn(t *testing.T) {
 			pqSig.Signature = rawTxnSignature
 			require.NoError(t, pqSig.Verify(fixture.proto, fixture.txn, fixture.authorizer))
 
-			require.NoError(t, fixture.signer.verify(fixture.txn, rawTxnSignature))
-			require.NoError(t, fixture.signer.verifyBytes(crypto.HashRep(fixture.txn), rawTxnSignature))
+			require.NoError(t, fixture.signer.Verify(fixture.txn, rawTxnSignature))
+			require.NoError(t, fixture.signer.VerifyBytes(crypto.HashRep(fixture.txn), rawTxnSignature))
 
 			// A signature over the txid (the pre-hashed payload) must not verify:
 			// the payload is the raw canonical encoding, not its digest.
 			txid := crypto.Digest(fixture.txn.ID())
-			txidSignature, err := fixture.signer.signBytes(txid[:])
+			txidSignature, err := fixture.signer.SignBytes(txid[:])
 			require.NoError(t, err)
 			require.False(t, bytes.Equal(txidSignature, rawTxnSignature))
 

--- a/data/transactions/signedtxn_test.go
+++ b/data/transactions/signedtxn_test.go
@@ -180,7 +180,7 @@ func TestSignedTxnFeeFactorPQSignatureContribution(t *testing.T) {
 		require.Equal(t, basics.Micros(1e6), stxn.FeeFactor(proto))
 	}
 	require.Equal(t, basics.Micros(2e6), proto.PQSchemeFeeContribution(protocol.PQSchemeFalcon1024))
-	require.Equal(t, basics.Micros(1e6+5e5), proto.PQSchemeFeeContribution(protocol.PQSchemeFalcon512))
+	require.Equal(t, basics.Micros(1e6), proto.PQSchemeFeeContribution(protocol.PQSchemeFalcon512))
 	require.Equal(t, basics.Micros(1e6), unknownPQSigned.FeeFactor(proto))
 	require.Equal(t, basics.Micros(1e6), unknownDelegatedPQSigned.FeeFactor(proto))
 	require.Equal(t, basics.Micros(3e6), pqSigned.FeeFactor(proto))

--- a/data/transactions/signedtxn_test.go
+++ b/data/transactions/signedtxn_test.go
@@ -94,7 +94,7 @@ func TestSignedTxnInBlockHash(t *testing.T) {
 func TestSignedTxnHasSignature(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	fixture := makePQSigTestFixture(t, 14)
+	fixture := makePQSigTestFixture(t, 14, protocol.PQSchemeFalcon1024)
 	nonblankSig := crypto.Signature{}
 	nonblankSig[0] = 1
 
@@ -122,7 +122,7 @@ func TestSignedTxnFeeFactorPQSignatureContribution(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	proto := config.Consensus[protocol.ConsensusFuture]
-	fixture := makePQSigTestFixture(t, 0)
+	fixture := makePQSigTestFixture(t, 0, protocol.PQSchemeFalcon1024)
 
 	baseTxn := SignedTxn{Txn: fixture.txn}
 	regularSigned := baseTxn
@@ -180,6 +180,7 @@ func TestSignedTxnFeeFactorPQSignatureContribution(t *testing.T) {
 		require.Equal(t, basics.Micros(1e6), stxn.FeeFactor(proto))
 	}
 	require.Equal(t, basics.Micros(2e6), proto.PQSchemeFeeContribution(protocol.PQSchemeFalcon1024))
+	require.Equal(t, basics.Micros(1e6+5e5), proto.PQSchemeFeeContribution(protocol.PQSchemeFalcon512))
 	require.Equal(t, basics.Micros(1e6), unknownPQSigned.FeeFactor(proto))
 	require.Equal(t, basics.Micros(1e6), unknownDelegatedPQSigned.FeeFactor(proto))
 	require.Equal(t, basics.Micros(3e6), pqSigned.FeeFactor(proto))

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -102,7 +102,13 @@ func keypair() *crypto.SignatureSecrets {
 func makePQSignedTxn(t *testing.T, firstSeedByte byte) transactions.SignedTxn {
 	t.Helper()
 
-	signer, authorizer, pqSig := makePQSigFields(t, firstSeedByte)
+	return makePQSignedTxnForScheme(t, firstSeedByte, basics_testing.RandomPQTestScheme().Scheme)
+}
+
+func makePQSignedTxnForScheme(t *testing.T, firstSeedByte byte, scheme protocol.PQScheme) transactions.SignedTxn {
+	t.Helper()
+
+	signer, authorizer, pqSig := makePQSigFieldsForScheme(t, firstSeedByte, scheme)
 
 	var receiver basics.Address
 	receiver[0] = 1
@@ -144,7 +150,12 @@ func makePQSigFields(t *testing.T, firstSeedByte byte) (basics_testing.FalconSig
 	t.Helper()
 
 	// randomly choose between Falcon-512 and Falcon-1024 for the test
-	scheme := basics_testing.RandomPQTestScheme().Scheme
+	return makePQSigFieldsForScheme(t, firstSeedByte, basics_testing.RandomPQTestScheme().Scheme)
+}
+
+func makePQSigFieldsForScheme(t *testing.T, firstSeedByte byte, scheme protocol.PQScheme) (basics_testing.FalconSigner, basics.Address, transactions.PQSig) {
+	t.Helper()
+
 	acct := basics_testing.MakePQTestAccount(t, firstSeedByte, scheme)
 
 	return acct.Signer, acct.Address, transactions.PQSig{
@@ -157,7 +168,13 @@ func makePQSigFields(t *testing.T, firstSeedByte byte) (basics_testing.FalconSig
 func makePQDelegatedLogicSigTxn(t *testing.T, firstSeedByte byte) transactions.SignedTxn {
 	t.Helper()
 
-	signer, authorizer, pqSig := makePQSigFields(t, firstSeedByte)
+	return makePQDelegatedLogicSigTxnForScheme(t, firstSeedByte, basics_testing.RandomPQTestScheme().Scheme)
+}
+
+func makePQDelegatedLogicSigTxnForScheme(t *testing.T, firstSeedByte byte, scheme protocol.PQScheme) transactions.SignedTxn {
+	t.Helper()
+
+	signer, authorizer, pqSig := makePQSigFieldsForScheme(t, firstSeedByte, scheme)
 	ops, err := logic.AssembleStringWithVersion("int 1", 1)
 	require.NoError(t, err)
 
@@ -379,6 +396,52 @@ func TestTxnValidationPQSig(t *testing.T) {
 	_, err = TxnGroup([]transactions.SignedTxn{stxn}, &disabledBlkHdr, nil, &dummyLedger)
 	require.ErrorContains(t, err, "pq signature not enabled")
 	requireTxGroupErrorReason(t, err, TxGroupErrorReasonSigNotWellFormed)
+}
+
+// TestTxnValidationPQSigSchemeBoundary pins the per-scheme enablement boundary
+// at the released ConsensusV42, where falcon-1024 is enabled but falcon-512 is not
+func TestTxnValidationPQSigSchemeBoundary(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	v42 := config.Consensus[protocol.ConsensusV42]
+	require.True(t, v42.PQSigEnabled())
+	require.True(t, v42.PQSchemeEnabled(protocol.PQSchemeFalcon1024))
+	require.False(t, v42.PQSchemeEnabled(protocol.PQSchemeFalcon512))
+
+	blkHdr := createDummyBlockHeader(protocol.ConsensusV42)
+	dummyLedger := DummyLedgerForSignature{}
+
+	t.Run("falcon-1024-txn", func(t *testing.T) {
+		stxn := makePQSignedTxnForScheme(t, 0, protocol.PQSchemeFalcon1024)
+
+		_, err := TxnGroup([]transactions.SignedTxn{stxn}, &blkHdr, nil, &dummyLedger)
+		require.NoError(t, err)
+	})
+
+	t.Run("falcon-1024-lsig", func(t *testing.T) {
+		stxn := makePQDelegatedLogicSigTxnForScheme(t, 1, protocol.PQSchemeFalcon1024)
+
+		_, err := TxnGroup([]transactions.SignedTxn{stxn}, &blkHdr, nil, &dummyLedger)
+		require.NoError(t, err)
+	})
+
+	t.Run("falcon-512-txn", func(t *testing.T) {
+		stxn := makePQSignedTxnForScheme(t, 2, protocol.PQSchemeFalcon512)
+
+		_, err := TxnGroup([]transactions.SignedTxn{stxn}, &blkHdr, nil, &dummyLedger)
+		require.ErrorContains(t, err, "pq signature validation failed")
+		require.ErrorIs(t, err, crypto.ErrPQSchemeNotEnabled)
+		requireTxGroupErrorReason(t, err, TxGroupErrorReasonSigNotWellFormed)
+	})
+
+	t.Run("falcon-512-lsig", func(t *testing.T) {
+		stxn := makePQDelegatedLogicSigTxnForScheme(t, 3, protocol.PQSchemeFalcon512)
+
+		_, err := TxnGroup([]transactions.SignedTxn{stxn}, &blkHdr, nil, &dummyLedger)
+		require.ErrorContains(t, err, "pq delegated logic signature validation failed")
+		require.ErrorIs(t, err, crypto.ErrPQSchemeNotEnabled)
+		requireTxGroupErrorReason(t, err, TxGroupErrorReasonLogicSigFailed)
+	})
 }
 
 func TestTxnValidationPQSigWithAuthAddr(t *testing.T) {

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
+	basics_testing "github.com/algorand/go-algorand/data/basics/testing"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/committee"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -107,7 +108,7 @@ func makePQSignedTxn(t *testing.T, firstSeedByte byte) transactions.SignedTxn {
 	receiver[0] = 1
 	txn := createPayTransaction(config.Consensus[protocol.ConsensusFuture].MinTxnFee, 40, 60, 1, authorizer, receiver)
 
-	signature, err := signer.sign(txn)
+	signature, err := signer.Sign(txn)
 	require.NoError(t, err)
 	pqSig.Signature = signature
 
@@ -117,56 +118,10 @@ func makePQSignedTxn(t *testing.T, firstSeedByte byte) transactions.SignedTxn {
 	}
 }
 
-// falconTestSigner adapts one scheme's concrete signer to the operations
-// these tests need.
-type falconTestSigner interface {
-	sign(message crypto.Hashable) ([]byte, error)
-	signBytes(data []byte) ([]byte, error)
-	publicKey() []byte
-}
-
-type falcon1024TestSigner struct{ crypto.Falcon1024Signer }
-
-func (s falcon1024TestSigner) sign(message crypto.Hashable) ([]byte, error) { return s.Sign(message) }
-func (s falcon1024TestSigner) signBytes(data []byte) ([]byte, error)        { return s.SignBytes(data) }
-func (s falcon1024TestSigner) publicKey() []byte                            { return s.PublicKey[:] }
-
-type falcon512TestSigner struct{ crypto.Falcon512Signer }
-
-func (s falcon512TestSigner) sign(message crypto.Hashable) ([]byte, error) { return s.Sign(message) }
-func (s falcon512TestSigner) signBytes(data []byte) ([]byte, error)        { return s.SignBytes(data) }
-func (s falcon512TestSigner) publicKey() []byte                            { return s.PublicKey[:] }
-
-func makeFalconSigner(t *testing.T, firstSeedByte byte, scheme protocol.PQScheme) falconTestSigner {
-	t.Helper()
-
-	var seed crypto.FalconSeed
-	seed[0] = firstSeedByte
-	switch scheme {
-	case protocol.PQSchemeFalcon1024:
-		signer, err := crypto.GenerateFalcon1024Signer(seed)
-		require.NoError(t, err)
-		return falcon1024TestSigner{signer}
-	case protocol.PQSchemeFalcon512:
-		signer, err := crypto.GenerateFalcon512Signer(seed)
-		require.NoError(t, err)
-		return falcon512TestSigner{signer}
-	}
-	t.Fatalf("unknown scheme %s", scheme)
-	return nil
-}
-
 // invalidFalconSigErrText is the scheme-specific verification failure message
 // for signatures produced by makePQSigFields' randomly selected scheme.
 func invalidFalconSigErrText(t *testing.T, scheme protocol.PQScheme) string {
-	switch scheme {
-	case protocol.PQSchemeFalcon1024:
-		return crypto.ErrPQFalcon1024SigInvalid.Error()
-	case protocol.PQSchemeFalcon512:
-		return crypto.ErrPQFalcon512SigInvalid.Error()
-	}
-	t.Fatalf("unknown scheme %s", scheme)
-	return ""
+	return basics_testing.PQTestSchemeInfo(t, scheme).ErrSigInvalid.Error()
 }
 
 func makePQSigForTxn(t *testing.T, firstSeedByte byte, txn *transactions.Transaction) (basics.Address, transactions.PQSig) {
@@ -177,7 +132,7 @@ func makePQSigForTxn(t *testing.T, firstSeedByte byte, txn *transactions.Transac
 	var signature []byte
 	var err error
 	if txn != nil {
-		signature, err = signer.sign(*txn)
+		signature, err = signer.Sign(*txn)
 		require.NoError(t, err)
 	}
 	pqSig.Signature = signature
@@ -185,29 +140,17 @@ func makePQSigForTxn(t *testing.T, firstSeedByte byte, txn *transactions.Transac
 	return authorizer, pqSig
 }
 
-func makePQSigFields(t *testing.T, firstSeedByte byte) (falconTestSigner, basics.Address, transactions.PQSig) {
+func makePQSigFields(t *testing.T, firstSeedByte byte) (basics_testing.FalconSigner, basics.Address, transactions.PQSig) {
 	t.Helper()
 
 	// randomly choose between Falcon-512 and Falcon-1024 for the test
-	var falconRandSelector [1]byte
-	crypto.RandBytes(falconRandSelector[:])
+	scheme := basics_testing.RandomPQTestScheme().Scheme
+	acct := basics_testing.MakePQTestAccount(t, firstSeedByte, scheme)
 
-	var scheme protocol.PQScheme
-	if falconRandSelector[0]%2 == 0 {
-		scheme = protocol.PQSchemeFalcon1024
-	} else {
-		scheme = protocol.PQSchemeFalcon512
-	}
-
-	signer := makeFalconSigner(t, firstSeedByte, scheme)
-	publicKey := signer.publicKey()
-	salt, authorizer, err := basics.CanonicalPQAddressSalt(scheme, publicKey)
-	require.NoError(t, err)
-
-	return signer, authorizer, transactions.PQSig{
-		Scheme:    scheme,
-		Salt:      salt,
-		PublicKey: publicKey,
+	return acct.Signer, acct.Address, transactions.PQSig{
+		Scheme:    acct.Scheme,
+		Salt:      acct.Salt,
+		PublicKey: acct.PublicKey,
 	}
 }
 
@@ -218,7 +161,7 @@ func makePQDelegatedLogicSigTxn(t *testing.T, firstSeedByte byte) transactions.S
 	ops, err := logic.AssembleStringWithVersion("int 1", 1)
 	require.NoError(t, err)
 
-	signature, err := signer.sign(logic.PQDelegatedProgram{Addr: authorizer, Program: ops.Program})
+	signature, err := signer.Sign(logic.PQDelegatedProgram{Addr: authorizer, Program: ops.Program})
 	require.NoError(t, err)
 	pqSig.Signature = signature
 
@@ -641,12 +584,12 @@ func TestTxnValidationPQDelegatedLogicSigSignsRawProgram(t *testing.T) {
 	require.NoError(t, err)
 
 	delegation := logic.PQDelegatedProgram{Addr: authorizer, Program: ops.Program}
-	rawSignature, err := signer.signBytes(crypto.HashRep(delegation))
+	rawSignature, err := signer.SignBytes(crypto.HashRep(delegation))
 	require.NoError(t, err)
 
 	// Sign(delegation) applies HashRep internally, so it must produce the same
 	// deterministic Falcon signature as SignBytes(HashRep(delegation))
-	viaSign, err := signer.sign(delegation)
+	viaSign, err := signer.Sign(delegation)
 	require.NoError(t, err)
 	require.Equal(t, viaSign, rawSignature)
 
@@ -665,7 +608,7 @@ func TestTxnValidationPQDelegatedLogicSigSignsRawProgram(t *testing.T) {
 	// pre-hashed form) must not verify: the payload is the raw
 	// "PQProgram" || authorizer || program bytes, not their digest.
 	digest := crypto.HashObj(delegation)
-	digestSignature, err := signer.signBytes(digest[:])
+	digestSignature, err := signer.SignBytes(digest[:])
 	require.NoError(t, err)
 	require.NotEqual(t, digestSignature, rawSignature)
 

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -107,7 +107,7 @@ func makePQSignedTxn(t *testing.T, firstSeedByte byte) transactions.SignedTxn {
 	receiver[0] = 1
 	txn := createPayTransaction(config.Consensus[protocol.ConsensusFuture].MinTxnFee, 40, 60, 1, authorizer, receiver)
 
-	signature, err := signer.Sign(txn)
+	signature, err := signer.sign(txn)
 	require.NoError(t, err)
 	pqSig.Signature = signature
 
@@ -117,15 +117,56 @@ func makePQSignedTxn(t *testing.T, firstSeedByte byte) transactions.SignedTxn {
 	}
 }
 
-func makeFalconSigner(t *testing.T, firstSeedByte byte) crypto.Falcon1024Signer {
+// falconTestSigner adapts one scheme's concrete signer to the operations
+// these tests need.
+type falconTestSigner interface {
+	sign(message crypto.Hashable) ([]byte, error)
+	signBytes(data []byte) ([]byte, error)
+	publicKey() []byte
+}
+
+type falcon1024TestSigner struct{ crypto.Falcon1024Signer }
+
+func (s falcon1024TestSigner) sign(message crypto.Hashable) ([]byte, error) { return s.Sign(message) }
+func (s falcon1024TestSigner) signBytes(data []byte) ([]byte, error)        { return s.SignBytes(data) }
+func (s falcon1024TestSigner) publicKey() []byte                            { return s.PublicKey[:] }
+
+type falcon512TestSigner struct{ crypto.Falcon512Signer }
+
+func (s falcon512TestSigner) sign(message crypto.Hashable) ([]byte, error) { return s.Sign(message) }
+func (s falcon512TestSigner) signBytes(data []byte) ([]byte, error)        { return s.SignBytes(data) }
+func (s falcon512TestSigner) publicKey() []byte                            { return s.PublicKey[:] }
+
+func makeFalconSigner(t *testing.T, firstSeedByte byte, scheme protocol.PQScheme) falconTestSigner {
 	t.Helper()
 
 	var seed crypto.FalconSeed
 	seed[0] = firstSeedByte
-	signer, err := crypto.GenerateFalcon1024Signer(seed)
-	require.NoError(t, err)
+	switch scheme {
+	case protocol.PQSchemeFalcon1024:
+		signer, err := crypto.GenerateFalcon1024Signer(seed)
+		require.NoError(t, err)
+		return falcon1024TestSigner{signer}
+	case protocol.PQSchemeFalcon512:
+		signer, err := crypto.GenerateFalcon512Signer(seed)
+		require.NoError(t, err)
+		return falcon512TestSigner{signer}
+	}
+	t.Fatalf("unknown scheme %s", scheme)
+	return nil
+}
 
-	return signer
+// invalidFalconSigErrText is the scheme-specific verification failure message
+// for signatures produced by makePQSigFields' randomly selected scheme.
+func invalidFalconSigErrText(t *testing.T, scheme protocol.PQScheme) string {
+	switch scheme {
+	case protocol.PQSchemeFalcon1024:
+		return crypto.ErrPQFalcon1024SigInvalid.Error()
+	case protocol.PQSchemeFalcon512:
+		return crypto.ErrPQFalcon512SigInvalid.Error()
+	}
+	t.Fatalf("unknown scheme %s", scheme)
+	return ""
 }
 
 func makePQSigForTxn(t *testing.T, firstSeedByte byte, txn *transactions.Transaction) (basics.Address, transactions.PQSig) {
@@ -136,7 +177,7 @@ func makePQSigForTxn(t *testing.T, firstSeedByte byte, txn *transactions.Transac
 	var signature []byte
 	var err error
 	if txn != nil {
-		signature, err = signer.Sign(*txn)
+		signature, err = signer.sign(*txn)
 		require.NoError(t, err)
 	}
 	pqSig.Signature = signature
@@ -144,16 +185,27 @@ func makePQSigForTxn(t *testing.T, firstSeedByte byte, txn *transactions.Transac
 	return authorizer, pqSig
 }
 
-func makePQSigFields(t *testing.T, firstSeedByte byte) (crypto.Falcon1024Signer, basics.Address, transactions.PQSig) {
+func makePQSigFields(t *testing.T, firstSeedByte byte) (falconTestSigner, basics.Address, transactions.PQSig) {
 	t.Helper()
 
-	signer := makeFalconSigner(t, firstSeedByte)
-	publicKey := signer.PublicKey[:]
-	salt, authorizer, err := basics.CanonicalPQAddressSalt(protocol.PQSchemeFalcon1024, publicKey)
+	// randomly choose between Falcon-512 and Falcon-1024 for the test
+	var falconRandSelector [1]byte
+	crypto.RandBytes(falconRandSelector[:])
+
+	var scheme protocol.PQScheme
+	if falconRandSelector[0]%2 == 0 {
+		scheme = protocol.PQSchemeFalcon1024
+	} else {
+		scheme = protocol.PQSchemeFalcon512
+	}
+
+	signer := makeFalconSigner(t, firstSeedByte, scheme)
+	publicKey := signer.publicKey()
+	salt, authorizer, err := basics.CanonicalPQAddressSalt(scheme, publicKey)
 	require.NoError(t, err)
 
 	return signer, authorizer, transactions.PQSig{
-		Scheme:    protocol.PQSchemeFalcon1024,
+		Scheme:    scheme,
 		Salt:      salt,
 		PublicKey: publicKey,
 	}
@@ -166,7 +218,7 @@ func makePQDelegatedLogicSigTxn(t *testing.T, firstSeedByte byte) transactions.S
 	ops, err := logic.AssembleStringWithVersion("int 1", 1)
 	require.NoError(t, err)
 
-	signature, err := signer.Sign(logic.PQDelegatedProgram{Addr: authorizer, Program: ops.Program})
+	signature, err := signer.sign(logic.PQDelegatedProgram{Addr: authorizer, Program: ops.Program})
 	require.NoError(t, err)
 	pqSig.Signature = signature
 
@@ -379,7 +431,7 @@ func TestTxnValidationPQSig(t *testing.T) {
 	require.NoError(t, err)
 
 	disabledBlkHdr := createDummyBlockHeader(protocol.ConsensusV41)
-	require.False(t, config.Consensus[disabledBlkHdr.CurrentProtocol].EnablePQSchemeFalcon1024)
+	require.False(t, config.Consensus[disabledBlkHdr.CurrentProtocol].PQSigEnabled())
 
 	_, err = TxnGroup([]transactions.SignedTxn{stxn}, &disabledBlkHdr, nil, &dummyLedger)
 	require.ErrorContains(t, err, "pq signature not enabled")
@@ -523,7 +575,7 @@ func TestTxnValidationPQDelegatedLogicSigRejectsInvalidProof(t *testing.T) {
 		stxn.Lsig.Logic = ops.Program
 
 		_, err = TxnGroup([]transactions.SignedTxn{stxn}, &blkHdr, nil, &dummyLedger)
-		requireLogicPQSigError(t, err, "invalid falcon-1024 signature")
+		requireLogicPQSigError(t, err, invalidFalconSigErrText(t, stxn.Lsig.PQsig.Scheme))
 	})
 
 	t.Run("wrong-signature", func(t *testing.T) {
@@ -531,7 +583,7 @@ func TestTxnValidationPQDelegatedLogicSigRejectsInvalidProof(t *testing.T) {
 		stxn.Lsig.PQsig.Signature[0] ^= 1
 
 		_, err := TxnGroup([]transactions.SignedTxn{stxn}, &blkHdr, nil, &dummyLedger)
-		requireLogicPQSigError(t, err, "invalid falcon-1024 signature")
+		requireLogicPQSigError(t, err, invalidFalconSigErrText(t, stxn.Lsig.PQsig.Scheme))
 	})
 
 	t.Run("malformed-public-key", func(t *testing.T) {
@@ -555,7 +607,7 @@ func TestTxnValidationPQDelegatedLogicSigRejectsInvalidProof(t *testing.T) {
 		stxn.Lsig.PQsig.Signature = make([]byte, crypto.MaxPQSignatureSize+1)
 
 		_, err := TxnGroup([]transactions.SignedTxn{stxn}, &blkHdr, nil, &dummyLedger)
-		requireLogicPQSigError(t, err, "invalid falcon-1024 signature")
+		requireLogicPQSigError(t, err, invalidFalconSigErrText(t, stxn.Lsig.PQsig.Scheme))
 	})
 
 	t.Run("disabled-scheme", func(t *testing.T) {
@@ -574,7 +626,7 @@ func TestTxnValidationPQDelegatedLogicSigRejectsInvalidProof(t *testing.T) {
 		require.NotEqual(t, originalAuthorizer, stxn.Txn.Sender)
 
 		_, err := TxnGroup([]transactions.SignedTxn{stxn}, &blkHdr, nil, &dummyLedger)
-		requireLogicPQSigError(t, err, "invalid falcon-1024 signature")
+		requireLogicPQSigError(t, err, invalidFalconSigErrText(t, stxn.Lsig.PQsig.Scheme))
 	})
 }
 
@@ -589,14 +641,14 @@ func TestTxnValidationPQDelegatedLogicSigSignsRawProgram(t *testing.T) {
 	require.NoError(t, err)
 
 	delegation := logic.PQDelegatedProgram{Addr: authorizer, Program: ops.Program}
-	rawSignature, err := signer.SignBytes(crypto.HashRep(delegation))
+	rawSignature, err := signer.signBytes(crypto.HashRep(delegation))
 	require.NoError(t, err)
 
 	// Sign(delegation) applies HashRep internally, so it must produce the same
-	// deterministic (det1024) signature as SignBytes(HashRep(delegation))
-	viaSign, err := signer.Sign(delegation)
+	// deterministic Falcon signature as SignBytes(HashRep(delegation))
+	viaSign, err := signer.sign(delegation)
 	require.NoError(t, err)
-	require.Equal(t, []byte(viaSign), []byte(rawSignature))
+	require.Equal(t, viaSign, rawSignature)
 
 	pqSig.Signature = rawSignature
 	stxn := transactions.SignedTxn{
@@ -613,14 +665,14 @@ func TestTxnValidationPQDelegatedLogicSigSignsRawProgram(t *testing.T) {
 	// pre-hashed form) must not verify: the payload is the raw
 	// "PQProgram" || authorizer || program bytes, not their digest.
 	digest := crypto.HashObj(delegation)
-	digestSignature, err := signer.SignBytes(digest[:])
+	digestSignature, err := signer.signBytes(digest[:])
 	require.NoError(t, err)
-	require.NotEqual(t, []byte(digestSignature), []byte(rawSignature))
+	require.NotEqual(t, digestSignature, rawSignature)
 
 	stxn.Lsig.PQsig.Signature = digestSignature
 	_, err = TxnGroup([]transactions.SignedTxn{stxn}, &blkHdr, nil, &dummyLedger)
 	requireTxGroupErrorReason(t, err, TxGroupErrorReasonLogicSigFailed)
-	require.ErrorContains(t, err, "invalid falcon-1024 signature")
+	require.ErrorContains(t, err, invalidFalconSigErrText(t, pqSig.Scheme))
 }
 
 func TestTxnValidationEmptySig(t *testing.T) {

--- a/ledger/eval_simple_test.go
+++ b/ledger/eval_simple_test.go
@@ -1427,86 +1427,19 @@ func TestRekeying(t *testing.T) {
 	// TODO: More tests
 }
 
-// falconTestSigner adapts one scheme's concrete signer to the operations
-// these tests need.
-type falconTestSigner interface {
-	sign(message crypto.Hashable) ([]byte, error)
-	publicKey() []byte
-}
-
-type falcon1024TestSigner struct{ crypto.Falcon1024Signer }
-
-func (s falcon1024TestSigner) sign(message crypto.Hashable) ([]byte, error) { return s.Sign(message) }
-func (s falcon1024TestSigner) publicKey() []byte                            { return s.PublicKey[:] }
-
-type falcon512TestSigner struct{ crypto.Falcon512Signer }
-
-func (s falcon512TestSigner) sign(message crypto.Hashable) ([]byte, error) { return s.Sign(message) }
-func (s falcon512TestSigner) publicKey() []byte                            { return s.PublicKey[:] }
-
-type pqRekeyTestAccount struct {
-	signer    falconTestSigner
-	scheme    protocol.PQScheme
-	address   basics.Address
-	salt      basics.PQAddressSalt
-	publicKey []byte
-}
-
-// pqTestSchemes lists the PQ schemes the ledger tests below exercise.
-var pqTestSchemes = []struct {
-	name   string
-	scheme protocol.PQScheme
-}{
-	{"falcon-1024", protocol.PQSchemeFalcon1024},
-	{"falcon-512", protocol.PQSchemeFalcon512},
-}
-
-func makePQRekeyTestAccount(t *testing.T, firstSeedByte byte, scheme protocol.PQScheme) pqRekeyTestAccount {
+func signPQRekeyTestTxn(t *testing.T, acct basics_testing.PQTestAccount, txn transactions.Transaction, authAddr basics.Address) transactions.SignedTxn {
 	t.Helper()
 
-	var seed crypto.FalconSeed
-	seed[0] = firstSeedByte
-
-	var signer falconTestSigner
-	switch scheme {
-	case protocol.PQSchemeFalcon1024:
-		s, err := crypto.GenerateFalcon1024Signer(seed)
-		require.NoError(t, err)
-		signer = falcon1024TestSigner{s}
-	case protocol.PQSchemeFalcon512:
-		s, err := crypto.GenerateFalcon512Signer(seed)
-		require.NoError(t, err)
-		signer = falcon512TestSigner{s}
-	default:
-		t.Fatalf("unknown scheme %s", scheme)
-	}
-
-	publicKey := signer.publicKey()
-	salt, address, err := basics.CanonicalPQAddressSalt(scheme, publicKey)
-	require.NoError(t, err)
-
-	return pqRekeyTestAccount{
-		signer:    signer,
-		scheme:    scheme,
-		address:   address,
-		salt:      salt,
-		publicKey: publicKey,
-	}
-}
-
-func signPQRekeyTestTxn(t *testing.T, acct pqRekeyTestAccount, txn transactions.Transaction, authAddr basics.Address) transactions.SignedTxn {
-	t.Helper()
-
-	signature, err := acct.signer.sign(txn)
+	signature, err := acct.Signer.Sign(txn)
 	require.NoError(t, err)
 
 	return transactions.SignedTxn{
 		Txn:      txn,
 		AuthAddr: authAddr,
 		PQsig: transactions.PQSig{
-			Scheme:    acct.scheme,
-			Salt:      acct.salt,
-			PublicKey: acct.publicKey,
+			Scheme:    acct.Scheme,
+			Salt:      acct.Salt,
+			PublicKey: acct.PublicKey,
 			Signature: signature,
 		},
 	}
@@ -1516,20 +1449,20 @@ func TestPQRekeyedAddressAuthorization(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	for _, tc := range pqTestSchemes {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, tc := range basics_testing.PQTestSchemes {
+		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
 			genesisInitState, addrs, keys := ledgertesting.GenesisWithProto(10, protocol.ConsensusFuture)
 
-			pqAcct := makePQRekeyTestAccount(t, 0, tc.scheme)
+			pqAcct := basics_testing.MakePQTestAccount(t, 0, tc.Scheme)
 
 			proto := config.Consensus[protocol.ConsensusFuture]
-			require.True(t, proto.PQSchemeEnabled(pqAcct.scheme))
-			pqFee, _, overflow := proto.MinFee().FeeForUsage(basics.Micros(1e6)+proto.PQSchemeFeeContribution(pqAcct.scheme), 1e6, 0)
+			require.True(t, proto.PQSchemeEnabled(pqAcct.Scheme))
+			pqFee, _, overflow := proto.MinFee().FeeForUsage(basics.Micros(1e6)+proto.PQSchemeFeeContribution(pqAcct.Scheme), 1e6, 0)
 			require.False(t, overflow)
 
-			genesisInitState.Accounts[pqAcct.address] = basics.AccountData{
+			genesisInitState.Accounts[pqAcct.Address] = basics.AccountData{
 				MicroAlgos: basics.MicroAlgos{Raw: 10_000_000},
 				Status:     basics.Offline,
 			}
@@ -1585,16 +1518,16 @@ func TestPQRekeyedAddressAuthorization(t *testing.T) {
 				return err
 			}
 
-			edRekeyToPQ := makePayTxn(addrs[0], addrs[0], minFee, pqAcct.address, 1).Sign(keys[0])
+			edRekeyToPQ := makePayTxn(addrs[0], addrs[0], minFee, pqAcct.Address, 1).Sign(keys[0])
 			edSpendByPQTxn := makePayTxn(addrs[0], addrs[1], pqFee, basics.Address{}, 2)
-			edSpendByPQ := signPQRekeyTestTxn(t, pqAcct, edSpendByPQTxn, pqAcct.address)
+			edSpendByPQ := signPQRekeyTestTxn(t, pqAcct, edSpendByPQTxn, pqAcct.Address)
 
 			require.NoError(t, tryBlock([]transactions.SignedTxn{edRekeyToPQ, edSpendByPQ}))
 			require.ErrorContains(t, tryBlock([]transactions.SignedTxn{edSpendByPQ}), "should have been authorized by")
 
-			pqRekeyToEdTxn := makePayTxn(pqAcct.address, addrs[1], pqFee, addrs[2], 3)
+			pqRekeyToEdTxn := makePayTxn(pqAcct.Address, addrs[1], pqFee, addrs[2], 3)
 			pqRekeyToEd := signPQRekeyTestTxn(t, pqAcct, pqRekeyToEdTxn, basics.Address{})
-			pqSpendByEd := makePayTxn(pqAcct.address, addrs[1], minFee, basics.Address{}, 4).Sign(keys[2])
+			pqSpendByEd := makePayTxn(pqAcct.Address, addrs[1], minFee, basics.Address{}, 4).Sign(keys[2])
 
 			require.NoError(t, tryBlock([]transactions.SignedTxn{pqRekeyToEd, pqSpendByEd}))
 			require.ErrorContains(t, tryBlock([]transactions.SignedTxn{pqSpendByEd}), "should have been authorized by")
@@ -1612,19 +1545,19 @@ func TestPQChallengedAccountCanHeartbeatForZeroFee(t *testing.T) {
 	require.NotZero(t, proto.Payouts.ChallengeInterval)
 	require.NotZero(t, proto.Payouts.ChallengeGracePeriod)
 
-	for _, tc := range pqTestSchemes {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, tc := range basics_testing.PQTestSchemes {
+		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
 			const keyDilution = 777
 			otss := crypto.GenerateOneTimeSignatureSecrets(1, 10)
-			pqAcct := makePQRekeyTestAccount(t, 1, tc.scheme)
-			require.True(t, proto.PQSchemeEnabled(pqAcct.scheme))
+			pqAcct := basics_testing.MakePQTestAccount(t, 1, tc.Scheme)
+			require.True(t, proto.PQSchemeEnabled(pqAcct.Scheme))
 
 			genBalances, _, _ := ledgertesting.NewTestGenesis(func(cfg *ledgertesting.GenesisCfg) {
 				cfg.OnlineCount = 5
 			})
-			genBalances.Balances[pqAcct.address] = basics.AccountData{
+			genBalances.Balances[pqAcct.Address] = basics.AccountData{
 				MicroAlgos:        basics.MicroAlgos{Raw: 100_000_000},
 				Status:            basics.Online,
 				VoteID:            otss.OneTimeSignatureVerifier,
@@ -1636,9 +1569,9 @@ func TestPQChallengedAccountCanHeartbeatForZeroFee(t *testing.T) {
 				IncentiveEligible: true,
 			}
 
-			seedAndProp := pqAcct.address
+			seedAndProp := pqAcct.Address
 			seedAndProp[31] ^= 1
-			require.NotEqual(t, pqAcct.address, seedAndProp)
+			require.NotEqual(t, pqAcct.Address, seedAndProp)
 			genBalances.Balances[seedAndProp] = basics.AccountData{
 				MicroAlgos:        basics.MicroAlgos{Raw: 100_000_000},
 				Status:            basics.Online,
@@ -1692,7 +1625,7 @@ int 1`)
 					GenesisHash: dl.generator.GenesisHash(),
 				},
 				HeartbeatTxnFields: &transactions.HeartbeatTxnFields{
-					HbAddress:           pqAcct.address,
+					HbAddress:           pqAcct.Address,
 					HbProof:             otss.Sign(id, lastHdr.Seed).ToHeartbeatProof(),
 					HbSeed:              lastHdr.Seed,
 					HbVoteID:            otss.OneTimeSignatureVerifier,
@@ -1708,7 +1641,7 @@ int 1`)
 			vb := dl.endBlock()
 			require.Equal(t, heartbeatRound, vb.Block().Round())
 
-			after := lookup(t, dl.generator, pqAcct.address)
+			after := lookup(t, dl.generator, pqAcct.Address)
 			require.Equal(t, heartbeatRound, after.LastHeartbeat)
 		})
 	}

--- a/ledger/eval_simple_test.go
+++ b/ledger/eval_simple_test.go
@@ -1427,27 +1427,67 @@ func TestRekeying(t *testing.T) {
 	// TODO: More tests
 }
 
+// falconTestSigner adapts one scheme's concrete signer to the operations
+// these tests need.
+type falconTestSigner interface {
+	sign(message crypto.Hashable) ([]byte, error)
+	publicKey() []byte
+}
+
+type falcon1024TestSigner struct{ crypto.Falcon1024Signer }
+
+func (s falcon1024TestSigner) sign(message crypto.Hashable) ([]byte, error) { return s.Sign(message) }
+func (s falcon1024TestSigner) publicKey() []byte                            { return s.PublicKey[:] }
+
+type falcon512TestSigner struct{ crypto.Falcon512Signer }
+
+func (s falcon512TestSigner) sign(message crypto.Hashable) ([]byte, error) { return s.Sign(message) }
+func (s falcon512TestSigner) publicKey() []byte                            { return s.PublicKey[:] }
+
 type pqRekeyTestAccount struct {
-	signer    crypto.Falcon1024Signer
+	signer    falconTestSigner
+	scheme    protocol.PQScheme
 	address   basics.Address
 	salt      basics.PQAddressSalt
 	publicKey []byte
 }
 
-func makePQRekeyTestAccount(t *testing.T, firstSeedByte byte) pqRekeyTestAccount {
+// pqTestSchemes lists the PQ schemes the ledger tests below exercise.
+var pqTestSchemes = []struct {
+	name   string
+	scheme protocol.PQScheme
+}{
+	{"falcon-1024", protocol.PQSchemeFalcon1024},
+	{"falcon-512", protocol.PQSchemeFalcon512},
+}
+
+func makePQRekeyTestAccount(t *testing.T, firstSeedByte byte, scheme protocol.PQScheme) pqRekeyTestAccount {
 	t.Helper()
 
 	var seed crypto.FalconSeed
 	seed[0] = firstSeedByte
-	signer, err := crypto.GenerateFalcon1024Signer(seed)
-	require.NoError(t, err)
 
-	publicKey := signer.PublicKey[:]
-	salt, address, err := basics.CanonicalPQAddressSalt(protocol.PQSchemeFalcon1024, publicKey)
+	var signer falconTestSigner
+	switch scheme {
+	case protocol.PQSchemeFalcon1024:
+		s, err := crypto.GenerateFalcon1024Signer(seed)
+		require.NoError(t, err)
+		signer = falcon1024TestSigner{s}
+	case protocol.PQSchemeFalcon512:
+		s, err := crypto.GenerateFalcon512Signer(seed)
+		require.NoError(t, err)
+		signer = falcon512TestSigner{s}
+	default:
+		t.Fatalf("unknown scheme %s", scheme)
+	}
+
+	publicKey := signer.publicKey()
+	salt, address, err := basics.CanonicalPQAddressSalt(scheme, publicKey)
 	require.NoError(t, err)
 
 	return pqRekeyTestAccount{
 		signer:    signer,
+		scheme:    scheme,
 		address:   address,
 		salt:      salt,
 		publicKey: publicKey,
@@ -1457,14 +1497,14 @@ func makePQRekeyTestAccount(t *testing.T, firstSeedByte byte) pqRekeyTestAccount
 func signPQRekeyTestTxn(t *testing.T, acct pqRekeyTestAccount, txn transactions.Transaction, authAddr basics.Address) transactions.SignedTxn {
 	t.Helper()
 
-	signature, err := acct.signer.Sign(txn)
+	signature, err := acct.signer.sign(txn)
 	require.NoError(t, err)
 
 	return transactions.SignedTxn{
 		Txn:      txn,
 		AuthAddr: authAddr,
 		PQsig: transactions.PQSig{
-			Scheme:    protocol.PQSchemeFalcon1024,
+			Scheme:    acct.scheme,
 			Salt:      acct.salt,
 			PublicKey: acct.publicKey,
 			Signature: signature,
@@ -1476,83 +1516,90 @@ func TestPQRekeyedAddressAuthorization(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	genesisInitState, addrs, keys := ledgertesting.GenesisWithProto(10, protocol.ConsensusFuture)
+	for _, tc := range pqTestSchemes {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	proto := config.Consensus[protocol.ConsensusFuture]
-	require.True(t, proto.EnablePQSchemeFalcon1024)
-	pqFee, _, overflow := proto.MinFee().FeeForUsage(basics.Micros(1e6)+proto.PQSchemeFeeContribution(protocol.PQSchemeFalcon1024), 1e6, 0)
-	require.False(t, overflow)
+			genesisInitState, addrs, keys := ledgertesting.GenesisWithProto(10, protocol.ConsensusFuture)
 
-	pqAcct := makePQRekeyTestAccount(t, 0)
-	genesisInitState.Accounts[pqAcct.address] = basics.AccountData{
-		MicroAlgos: basics.MicroAlgos{Raw: 10_000_000},
-		Status:     basics.Offline,
-	}
+			pqAcct := makePQRekeyTestAccount(t, 0, tc.scheme)
 
-	l, err := OpenLedger(logging.TestingLog(t), t.Name(), true, genesisInitState, config.GetDefaultLocal())
-	require.NoError(t, err)
-	defer l.Close()
+			proto := config.Consensus[protocol.ConsensusFuture]
+			require.True(t, proto.PQSchemeEnabled(pqAcct.scheme))
+			pqFee, _, overflow := proto.MinFee().FeeForUsage(basics.Micros(1e6)+proto.PQSchemeFeeContribution(pqAcct.scheme), 1e6, 0)
+			require.False(t, overflow)
 
-	nextRound := l.Latest() + basics.Round(1)
-	genHash := l.GenesisHash()
+			genesisInitState.Accounts[pqAcct.address] = basics.AccountData{
+				MicroAlgos: basics.MicroAlgos{Raw: 10_000_000},
+				Status:     basics.Offline,
+			}
 
-	makePayTxn := func(sender, receiver basics.Address, fee basics.MicroAlgos, rekeyTo basics.Address, uniq uint8) transactions.Transaction {
-		return transactions.Transaction{
-			Type: protocol.PaymentTx,
-			Header: transactions.Header{
-				Sender:      sender,
-				Fee:         fee,
-				FirstValid:  nextRound,
-				LastValid:   nextRound,
-				GenesisHash: genHash,
-				RekeyTo:     rekeyTo,
-				Note:        []byte{uniq},
-			},
-			PaymentTxnFields: transactions.PaymentTxnFields{
-				Receiver: receiver,
-				Amount:   basics.MicroAlgos{Raw: 1},
-			},
-		}
-	}
+			l, err := OpenLedger(logging.TestingLog(t), t.Name(), true, genesisInitState, config.GetDefaultLocal())
+			require.NoError(t, err)
+			defer l.Close()
 
-	tryBlock := func(stxns []transactions.SignedTxn) error {
-		genesisHdr, err := l.BlockHdr(basics.Round(0))
-		require.NoError(t, err)
-		newBlock := bookkeeping.MakeBlock(genesisHdr)
-		eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0, nil)
-		require.NoError(t, err)
+			nextRound := l.Latest() + basics.Round(1)
+			genHash := l.GenesisHash()
 
-		for _, stxn := range stxns {
-			err = eval.TransactionGroup(stxn.WithAD())
-			if err != nil {
+			makePayTxn := func(sender, receiver basics.Address, fee basics.MicroAlgos, rekeyTo basics.Address, uniq uint8) transactions.Transaction {
+				return transactions.Transaction{
+					Type: protocol.PaymentTx,
+					Header: transactions.Header{
+						Sender:      sender,
+						Fee:         fee,
+						FirstValid:  nextRound,
+						LastValid:   nextRound,
+						GenesisHash: genHash,
+						RekeyTo:     rekeyTo,
+						Note:        []byte{uniq},
+					},
+					PaymentTxnFields: transactions.PaymentTxnFields{
+						Receiver: receiver,
+						Amount:   basics.MicroAlgos{Raw: 1},
+					},
+				}
+			}
+
+			tryBlock := func(stxns []transactions.SignedTxn) error {
+				genesisHdr, err := l.BlockHdr(basics.Round(0))
+				require.NoError(t, err)
+				newBlock := bookkeeping.MakeBlock(genesisHdr)
+				eval, err := l.StartEvaluator(newBlock.BlockHeader, 0, 0, nil)
+				require.NoError(t, err)
+
+				for _, stxn := range stxns {
+					err = eval.TransactionGroup(stxn.WithAD())
+					if err != nil {
+						return err
+					}
+				}
+				unfinishedBlock, err := eval.GenerateBlock(nil)
+				if err != nil {
+					return err
+				}
+				fb := unfinishedBlock.FinishBlock(committee.Seed{0x01}, basics.Address{0x01}, false)
+
+				backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
+				defer backlogPool.Shutdown()
+				_, err = l.Validate(context.Background(), fb, backlogPool)
 				return err
 			}
-		}
-		unfinishedBlock, err := eval.GenerateBlock(nil)
-		if err != nil {
-			return err
-		}
-		fb := unfinishedBlock.FinishBlock(committee.Seed{0x01}, basics.Address{0x01}, false)
 
-		backlogPool := execpool.MakeBacklog(nil, 0, execpool.LowPriority, nil)
-		defer backlogPool.Shutdown()
-		_, err = l.Validate(context.Background(), fb, backlogPool)
-		return err
+			edRekeyToPQ := makePayTxn(addrs[0], addrs[0], minFee, pqAcct.address, 1).Sign(keys[0])
+			edSpendByPQTxn := makePayTxn(addrs[0], addrs[1], pqFee, basics.Address{}, 2)
+			edSpendByPQ := signPQRekeyTestTxn(t, pqAcct, edSpendByPQTxn, pqAcct.address)
+
+			require.NoError(t, tryBlock([]transactions.SignedTxn{edRekeyToPQ, edSpendByPQ}))
+			require.ErrorContains(t, tryBlock([]transactions.SignedTxn{edSpendByPQ}), "should have been authorized by")
+
+			pqRekeyToEdTxn := makePayTxn(pqAcct.address, addrs[1], pqFee, addrs[2], 3)
+			pqRekeyToEd := signPQRekeyTestTxn(t, pqAcct, pqRekeyToEdTxn, basics.Address{})
+			pqSpendByEd := makePayTxn(pqAcct.address, addrs[1], minFee, basics.Address{}, 4).Sign(keys[2])
+
+			require.NoError(t, tryBlock([]transactions.SignedTxn{pqRekeyToEd, pqSpendByEd}))
+			require.ErrorContains(t, tryBlock([]transactions.SignedTxn{pqSpendByEd}), "should have been authorized by")
+		})
 	}
-
-	edRekeyToPQ := makePayTxn(addrs[0], addrs[0], minFee, pqAcct.address, 1).Sign(keys[0])
-	edSpendByPQTxn := makePayTxn(addrs[0], addrs[1], pqFee, basics.Address{}, 2)
-	edSpendByPQ := signPQRekeyTestTxn(t, pqAcct, edSpendByPQTxn, pqAcct.address)
-
-	require.NoError(t, tryBlock([]transactions.SignedTxn{edRekeyToPQ, edSpendByPQ}))
-	require.ErrorContains(t, tryBlock([]transactions.SignedTxn{edSpendByPQ}), "should have been authorized by")
-
-	pqRekeyToEdTxn := makePayTxn(pqAcct.address, addrs[1], pqFee, addrs[2], 3)
-	pqRekeyToEd := signPQRekeyTestTxn(t, pqAcct, pqRekeyToEdTxn, basics.Address{})
-	pqSpendByEd := makePayTxn(pqAcct.address, addrs[1], minFee, basics.Address{}, 4).Sign(keys[2])
-
-	require.NoError(t, tryBlock([]transactions.SignedTxn{pqRekeyToEd, pqSpendByEd}))
-	require.ErrorContains(t, tryBlock([]transactions.SignedTxn{pqSpendByEd}), "should have been authorized by")
 }
 
 func TestPQChallengedAccountCanHeartbeatForZeroFee(t *testing.T) {
@@ -1560,105 +1607,111 @@ func TestPQChallengedAccountCanHeartbeatForZeroFee(t *testing.T) {
 	t.Parallel()
 
 	proto := config.Consensus[protocol.ConsensusFuture]
-	require.True(t, proto.EnablePQSchemeFalcon1024)
 	require.True(t, proto.Heartbeat)
 	require.True(t, proto.Payouts.Enabled)
 	require.NotZero(t, proto.Payouts.ChallengeInterval)
 	require.NotZero(t, proto.Payouts.ChallengeGracePeriod)
 
-	const keyDilution = 777
-	otss := crypto.GenerateOneTimeSignatureSecrets(1, 10)
-	pqAcct := makePQRekeyTestAccount(t, 1)
+	for _, tc := range pqTestSchemes {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	genBalances, _, _ := ledgertesting.NewTestGenesis(func(cfg *ledgertesting.GenesisCfg) {
-		cfg.OnlineCount = 5
-	})
-	genBalances.Balances[pqAcct.address] = basics.AccountData{
-		MicroAlgos:        basics.MicroAlgos{Raw: 100_000_000},
-		Status:            basics.Online,
-		VoteID:            otss.OneTimeSignatureVerifier,
-		SelectionID:       crypto.VRFVerifier{1},
-		StateProofID:      merklesignature.Commitment{1},
-		VoteFirstValid:    0,
-		VoteLastValid:     1_000_000,
-		VoteKeyDilution:   keyDilution,
-		IncentiveEligible: true,
-	}
+			const keyDilution = 777
+			otss := crypto.GenerateOneTimeSignatureSecrets(1, 10)
+			pqAcct := makePQRekeyTestAccount(t, 1, tc.scheme)
+			require.True(t, proto.PQSchemeEnabled(pqAcct.scheme))
 
-	seedAndProp := pqAcct.address
-	seedAndProp[31] ^= 1
-	require.NotEqual(t, pqAcct.address, seedAndProp)
-	genBalances.Balances[seedAndProp] = basics.AccountData{
-		MicroAlgos:        basics.MicroAlgos{Raw: 100_000_000},
-		Status:            basics.Online,
-		VoteID:            crypto.OneTimeSignatureVerifier{1},
-		SelectionID:       crypto.VRFVerifier{1},
-		StateProofID:      merklesignature.Commitment{1},
-		VoteFirstValid:    0,
-		VoteLastValid:     1_000_000,
-		VoteKeyDilution:   1,
-		IncentiveEligible: true,
-	}
+			genBalances, _, _ := ledgertesting.NewTestGenesis(func(cfg *ledgertesting.GenesisCfg) {
+				cfg.OnlineCount = 5
+			})
+			genBalances.Balances[pqAcct.address] = basics.AccountData{
+				MicroAlgos:        basics.MicroAlgos{Raw: 100_000_000},
+				Status:            basics.Online,
+				VoteID:            otss.OneTimeSignatureVerifier,
+				SelectionID:       crypto.VRFVerifier{1},
+				StateProofID:      merklesignature.Commitment{1},
+				VoteFirstValid:    0,
+				VoteLastValid:     1_000_000,
+				VoteKeyDilution:   keyDilution,
+				IncentiveEligible: true,
+			}
 
-	dl := NewDoubleLedger(t, genBalances, protocol.ConsensusFuture, config.GetDefaultLocal())
-	defer dl.Close()
+			seedAndProp := pqAcct.address
+			seedAndProp[31] ^= 1
+			require.NotEqual(t, pqAcct.address, seedAndProp)
+			genBalances.Balances[seedAndProp] = basics.AccountData{
+				MicroAlgos:        basics.MicroAlgos{Raw: 100_000_000},
+				Status:            basics.Online,
+				VoteID:            crypto.OneTimeSignatureVerifier{1},
+				SelectionID:       crypto.VRFVerifier{1},
+				StateProofID:      merklesignature.Commitment{1},
+				VoteFirstValid:    0,
+				VoteLastValid:     1_000_000,
+				VoteKeyDilution:   1,
+				IncentiveEligible: true,
+			}
 
-	challengeRound := basics.Round(proto.Payouts.ChallengeInterval)
-	for vb := dl.fullBlock(); vb.Block().Round() < challengeRound-1; vb = dl.fullBlock() {
-		// Advance to the round before the challenge.
-	}
-	dl.beginBlock()
-	dl.endBlock(seedAndProp)
+			dl := NewDoubleLedger(t, genBalances, protocol.ConsensusFuture, config.GetDefaultLocal())
+			defer dl.Close()
 
-	heartbeatRound := challengeRound + basics.Round(proto.Payouts.ChallengeGracePeriod)/2 + 1
-	for vb := dl.fullBlock(); vb.Block().Round() < heartbeatRound-1; vb = dl.fullBlock() {
-		// Advance into the risky challenge period, before suspension is active.
-	}
+			challengeRound := basics.Round(proto.Payouts.ChallengeInterval)
+			for vb := dl.fullBlock(); vb.Block().Round() < challengeRound-1; vb = dl.fullBlock() {
+				// Advance to the round before the challenge.
+			}
+			dl.beginBlock()
+			dl.endBlock(seedAndProp)
 
-	lastHdr, err := dl.generator.BlockHdr(dl.generator.Latest())
-	require.NoError(t, err)
-	eval := dl.beginBlock()
-	require.Equal(t, heartbeatRound, eval.Round())
+			heartbeatRound := challengeRound + basics.Round(proto.Payouts.ChallengeGracePeriod)/2 + 1
+			for vb := dl.fullBlock(); vb.Block().Round() < heartbeatRound-1; vb = dl.fullBlock() {
+				// Advance into the risky challenge period, before suspension is active.
+			}
 
-	// A PQ account never pays for a PQ signature on its heartbeat. A heartbeat's
-	// sender is irrelevant to what it proves (onlineness is proven by HbProof,
-	// signed with the account's participation key), so it is sent by the same
-	// ordinary accepting logicsig everyone uses. That sender carries no PQ
-	// surcharge, and the challenge discount covers the base fee, so the account
-	// stays online for free despite authorizing spends with an expensive PQ key.
-	acceptingProgram := logic.MustAssemble(`#pragma version 11
+			lastHdr, err := dl.generator.BlockHdr(dl.generator.Latest())
+			require.NoError(t, err)
+			eval := dl.beginBlock()
+			require.Equal(t, heartbeatRound, eval.Round())
+
+			// A PQ account never pays for a PQ signature on its heartbeat. A heartbeat's
+			// sender is irrelevant to what it proves (onlineness is proven by HbProof,
+			// signed with the account's participation key), so it is sent by the same
+			// ordinary accepting logicsig everyone uses. That sender carries no PQ
+			// surcharge, and the challenge discount covers the base fee, so the account
+			// stays online for free despite authorizing spends with an expensive PQ key.
+			acceptingProgram := logic.MustAssemble(`#pragma version 11
 int 1`)
-	sender := basics.Address(logic.HashProgram(acceptingProgram))
+			sender := basics.Address(logic.HashProgram(acceptingProgram))
 
-	lastValid := eval.Round() + 10
-	id := basics.OneTimeIDForRound(lastValid, keyDilution)
-	txn := transactions.Transaction{
-		Type: protocol.HeartbeatTx,
-		Header: transactions.Header{
-			Sender:      sender,
-			FirstValid:  lastHdr.Round,
-			LastValid:   lastValid,
-			GenesisHash: dl.generator.GenesisHash(),
-		},
-		HeartbeatTxnFields: &transactions.HeartbeatTxnFields{
-			HbAddress:           pqAcct.address,
-			HbProof:             otss.Sign(id, lastHdr.Seed).ToHeartbeatProof(),
-			HbSeed:              lastHdr.Seed,
-			HbVoteID:            otss.OneTimeSignatureVerifier,
-			HbKeyDilution:       keyDilution,
-			HbChallengeDiscount: true,
-		},
+			lastValid := eval.Round() + 10
+			id := basics.OneTimeIDForRound(lastValid, keyDilution)
+			txn := transactions.Transaction{
+				Type: protocol.HeartbeatTx,
+				Header: transactions.Header{
+					Sender:      sender,
+					FirstValid:  lastHdr.Round,
+					LastValid:   lastValid,
+					GenesisHash: dl.generator.GenesisHash(),
+				},
+				HeartbeatTxnFields: &transactions.HeartbeatTxnFields{
+					HbAddress:           pqAcct.address,
+					HbProof:             otss.Sign(id, lastHdr.Seed).ToHeartbeatProof(),
+					HbSeed:              lastHdr.Seed,
+					HbVoteID:            otss.OneTimeSignatureVerifier,
+					HbKeyDilution:       keyDilution,
+					HbChallengeDiscount: true,
+				},
+			}
+			stxn := transactions.SignedTxn{Txn: txn, Lsig: transactions.LogicSig{Logic: acceptingProgram}}
+			txgroup := []transactions.SignedTxn{stxn}
+
+			require.NoError(t, eval.TestTransactionGroup(txgroup))
+			require.NoError(t, eval.TransactionGroup(transactions.WrapSignedTxnsWithAD(txgroup)...))
+			vb := dl.endBlock()
+			require.Equal(t, heartbeatRound, vb.Block().Round())
+
+			after := lookup(t, dl.generator, pqAcct.address)
+			require.Equal(t, heartbeatRound, after.LastHeartbeat)
+		})
 	}
-	stxn := transactions.SignedTxn{Txn: txn, Lsig: transactions.LogicSig{Logic: acceptingProgram}}
-	txgroup := []transactions.SignedTxn{stxn}
-
-	require.NoError(t, eval.TestTransactionGroup(txgroup))
-	require.NoError(t, eval.TransactionGroup(transactions.WrapSignedTxnsWithAD(txgroup)...))
-	vb := dl.endBlock()
-	require.Equal(t, heartbeatRound, vb.Block().Round())
-
-	after := lookup(t, dl.generator, pqAcct.address)
-	require.Equal(t, heartbeatRound, after.LastHeartbeat)
 }
 
 func testEvalAppPoolingGroup(t *testing.T, schema basics.StateSchema, approvalProgram string, consensusVersion protocol.ConsensusVersion) error {

--- a/protocol/pq_scheme.go
+++ b/protocol/pq_scheme.go
@@ -32,6 +32,6 @@ var (
 	// PQSchemeFalcon1024 - f1: Falcon-1024 using a deterministic signing profile.
 	PQSchemeFalcon1024 = PQScheme{'f', '1'}
 
-	// PQSchemeFalcon512 - f2: Falcon-512 using a deterministic signing profile.
-	PQSchemeFalcon512 = PQScheme{'f', '2'} // reserved, not used
+	// PQSchemeFalcon512 - f5: Falcon-512 using a deterministic signing profile.
+	PQSchemeFalcon512 = PQScheme{'f', '5'}
 )

--- a/test/scripts/e2e_subs/pq-falcon.sh
+++ b/test/scripts/e2e_subs/pq-falcon.sh
@@ -61,3 +61,44 @@ if [ "$BALANCE" -ne "$EXPECT" ]; then
     date "+${scriptname} FAIL wanted balance=${EXPECT} but got ${BALANCE} %Y%m%d_%H%M%S"
     false
 fi
+
+# Repeat with falcon-512, generated with an explicit scheme. Its fee surcharge
+# is half of falcon-1024's, so the required min fee is 2mA instead of 3mA.
+algokey pq generate -S falcon-512 -k pq512.sk > generate512.out
+
+grep 'PQ scheme: falcon-512' < generate512.out
+PQ512MNEMONIC=$(grep 'PQ private key mnemonic:' < generate512.out | sed 's/PQ private key mnemonic: //')
+PQ512ADDRESS=$(grep 'PQ address:' < generate512.out | sed 's/PQ address: //')
+
+echo "$PQ512MNEMONIC"
+echo "$PQ512ADDRESS"
+
+# Restoring from mnemonic reproduces the key file.
+algokey pq import -m "$PQ512MNEMONIC" -S falcon-512 -k pq512-restored.sk
+cmp pq512.sk pq512-restored.sk
+
+# Fund pq-512 account
+${gcmd} clerk send -a 10000000 -f "${ACCOUNT}" -t "${PQ512ADDRESS}"
+
+## Show the usual min fee is insufficient
+${gcmd} clerk send -a 5555 -f "${PQ512ADDRESS}" -t "${ACCOUNT}" --fee 1000 -o low512.tx
+algokey pq sign -t low512.tx -k pq512.sk -o low512-signed.tx
+set +o pipefail
+${gcmd} clerk rawsend -f low512-signed.tx 2>&1 | grep "1mA fees is less than 2mA" || exit 1
+set -o pipefail
+
+## Show that 2000 min fee is sufficient
+${gcmd} clerk send -a 6666 -f "${PQ512ADDRESS}" -t "${ACCOUNT}" --fee 2000 -o enough512.tx
+algokey pq sign -t enough512.tx -k pq512.sk -o enough512-signed.tx
+${gcmd} clerk rawsend -f enough512-signed.tx
+
+## Show that a delegated LogicSig signed by the PQ-512 account can authorize a txn
+algokey pq sign-program -k pq512.sk -p pq-true.tok -o pq-true512.lsig
+${gcmd} clerk send -a 7777 -f "${PQ512ADDRESS}" -t "${ACCOUNT}" --fee 2000 -L pq-true512.lsig
+
+BALANCE512=$(${gcmd} account balance -a "${PQ512ADDRESS}" | awk '{ print $1 }')
+EXPECT512=$((10000000 - 6666 - 2000 - 7777 - 2000))
+if [ "$BALANCE512" -ne "$EXPECT512" ]; then
+    date "+${scriptname} FAIL wanted falcon-512 balance=${EXPECT512} but got ${BALANCE512} %Y%m%d_%H%M%S"
+    false
+fi


### PR DESCRIPTION
## Summary

1. Add `EnablePQSchemeFalcon512` consensus params
2. Set pq fee contribution for 512 to 1e6
3. Enable `protocol.PQSchemeFalcon512` scheme
4. algokey support
5. Upgraded tests to exercise both 1024 and 512 - these are most of the PR lines
6. New TestTxnValidationPQSigSchemeBoundary test verifies f512 is disabled in v42.

## Test Plan

One new TestTxnValidationPQSigSchemeBoundary test, all test upgraded:
1. Most to run both 512 and 1024 existing checks
2. handlers_test and verify/txn_test are random - based on a seed they are either 512 or 1024 per run (rationale: 1) minimize changes in handlers_test 2) txn_test is 42s already, do not want add any extra run time)

Test helpers were generalized into basic_testing (the last commit) but it only marginally decreased the diff (~40 lines, not a couple hundred I hoped for)