### PR TITLE
Simulate: fix AppBudgetAdded accounting for inner groups

### DIFF
--- a/data/transactions/logic/mocktracer/scenarios.go
+++ b/data/transactions/logic/mocktracer/scenarios.go
@@ -351,6 +351,9 @@ type TestScenarioGenerator func(info TestScenarioInfo) TestScenario
 // possible during each inner transaction, as well as before all inners, between the two inner
 // groups, and after all inners. For app call failures, there are scenarios for both rejection and
 // runtime errors, which should invoke tracer hooks slightly differently.
+//
+// A scenario's AppBudgetAdded counts only its app calls: the calling txn, plus inner (a) once it has
+// been submitted. The payments in the second inner group grant no opcode budget.
 func GetTestScenarios() map[string]TestScenarioGenerator {
 	successInnerProgramBytes := []byte{0x06, 0x80, 0x01, 0x78, 0xb0, 0x81, 0x01} // #pragma version 6; pushbytes "x"; log; pushint 1
 	successInnerProgram := "0x" + hex.EncodeToString(successInnerProgramBytes)
@@ -404,7 +407,7 @@ func GetTestScenarios() map[string]TestScenarioGenerator {
 			}),
 			ExpectedSimulationAD: expectedAD,
 			ExpectedStateDelta:   expectedDelta,
-			AppBudgetAdded:       2100,
+			AppBudgetAdded:       1400,
 			AppBudgetConsumed:    35,
 			TxnAppBudgetConsumed: []int{0, 35},
 		}
@@ -646,7 +649,7 @@ func GetTestScenarios() map[string]TestScenarioGenerator {
 					}),
 					ExpectedSimulationAD: expectedAD,
 					ExpectedStateDelta:   expectedDelta,
-					AppBudgetAdded:       2100,
+					AppBudgetAdded:       1400,
 					AppBudgetConsumed:    32,
 					TxnAppBudgetConsumed: []int{0, 32},
 				}
@@ -714,7 +717,7 @@ func GetTestScenarios() map[string]TestScenarioGenerator {
 					}),
 					ExpectedSimulationAD: expectedAD,
 					ExpectedStateDelta:   expectedDelta,
-					AppBudgetAdded:       2100,
+					AppBudgetAdded:       1400,
 					AppBudgetConsumed:    32,
 					TxnAppBudgetConsumed: []int{0, 32},
 				}
@@ -780,7 +783,7 @@ func GetTestScenarios() map[string]TestScenarioGenerator {
 				}),
 				ExpectedSimulationAD: expectedAD,
 				ExpectedStateDelta:   expectedDelta,
-				AppBudgetAdded:       2100,
+				AppBudgetAdded:       1400,
 				AppBudgetConsumed:    35,
 				TxnAppBudgetConsumed: []int{0, 35},
 			}

--- a/ledger/simulation/simulation_eval_test.go
+++ b/ledger/simulation/simulation_eval_test.go
@@ -1755,6 +1755,103 @@ int 1`,
 	})
 }
 
+// TestExtraBudgetWithInner checks that a requested ExtraOpcodeBudget is granted
+// once for the whole group, not again for every inner group. Inner groups share
+// the one pool, so re-applying it would hand out a multiple of what was asked
+// for, and let simulate approve a group that would run out of budget on chain.
+func TestExtraBudgetWithInner(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	// Costs 700 and invokes an inner transaction, so the group has two app calls
+	// granting 700 each, and exactly one inner group to be tempted by.
+	exactly700AndCallInner := fmt.Sprintf(`#pragma version 6
+pushint 1
+cover 0 // This is a noop, just to fix an odd number of ops
+%s
+itxn_begin
+int appl
+itxn_field TypeEnum
+byte 0x068101
+dup
+itxn_field ClearStateProgram
+itxn_field ApprovalProgram
+itxn_submit
+`, strings.Repeat(`pushint 1
+pop
+`, 345))
+
+	const extraBudget = 1000
+
+	simulationTest(t, func(env simulationtesting.Environment) simulationTestCase {
+		sender := env.Accounts[0]
+
+		futureAppID := basics.AppIndex(1002)
+		fund := env.TxnInfo.NewTxn(txntest.Txn{
+			Type:     protocol.PaymentTx,
+			Sender:   sender.Addr,
+			Receiver: futureAppID.Address(),
+			Amount:   401_000,
+		})
+		appCall := env.TxnInfo.NewTxn(txntest.Txn{
+			Type:            protocol.ApplicationCallTx,
+			Sender:          sender.Addr,
+			ApprovalProgram: exactly700AndCallInner,
+			ClearStateProgram: `#pragma version 6
+int 1`,
+		})
+
+		txntest.Group(&fund, &appCall)
+
+		signedFundTxn := fund.Txn().Sign(sender.Sk)
+		signedAppCall := appCall.Txn().Sign(sender.Sk)
+
+		return simulationTestCase{
+			input: simulation.Request{
+				TxnGroups: [][]transactions.SignedTxn{
+					{signedFundTxn, signedAppCall},
+				},
+				ExtraOpcodeBudget: extraBudget,
+			},
+			expected: simulation.Result{
+				Version:       simulation.ResultLatestVersion,
+				LastRound:     env.TxnInfo.LatestRound(),
+				EvalOverrides: simulation.ResultEvalOverrides{ExtraOpcodeBudget: extraBudget},
+				TxnGroups: []simulation.TxnGroupResult{
+					{
+						Txns: []simulation.TxnResult{
+							{FeesPaid: signedFundTxn.Txn.Fee},
+							{
+								Txn: transactions.SignedTxnWithAD{
+									ApplyData: transactions.ApplyData{
+										ApplicationID: futureAppID,
+										EvalDelta: transactions.EvalDelta{
+											InnerTxns: []transactions.SignedTxnWithAD{
+												{
+													ApplyData: transactions.ApplyData{
+														ApplicationID: futureAppID + 1,
+													},
+												},
+											},
+										},
+									},
+								},
+								AppBudgetConsumed: 701,
+								FeesPaid:          basics.MicroAlgos{Raw: 2 * signedAppCall.Txn.Fee.Raw},
+							},
+						},
+						// 700 per app call, plus the extra once, not once per group
+						AppBudgetAdded:    1400 + extraBudget,
+						AppBudgetConsumed: 701,
+						GroupUsage:        3e6,
+						GroupFeesPaid:     basics.MicroAlgos{Raw: 3 * signedFundTxn.Txn.Fee.Raw},
+					},
+				},
+			},
+		}
+	})
+}
+
 func TestStartRound(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
@@ -2561,7 +2658,7 @@ func TestMaxDepthAppWithPCTrace(t *testing.T) {
 								},
 							},
 						},
-						AppBudgetAdded:    4200,
+						AppBudgetAdded:    7000, // 2 top-level app calls plus 8 inner app calls
 						AppBudgetConsumed: 385,
 					},
 				},
@@ -7573,7 +7670,7 @@ int 1`,
 								AppBudgetConsumed: 23,
 							},
 						},
-						AppBudgetAdded:    2100,
+						AppBudgetAdded:    1400, // only the app calls grant budget; the inner acfg grants none
 						AppBudgetConsumed: 23,
 						FailedAt:          simulation.TxnPath{1, 1},
 					},
@@ -7669,7 +7766,7 @@ int 1`,
 								AppBudgetConsumed: 17,
 							},
 						},
-						AppBudgetAdded:    2100,
+						AppBudgetAdded:    700, // the inner acfg txns grant no opcode budget
 						AppBudgetConsumed: 17,
 						FailedAt:          simulation.TxnPath{1, 1},
 					},
@@ -7838,6 +7935,9 @@ func TestUnnamedResources(t *testing.T) {
 				}
 
 				var innerCount int
+				// Only inner app calls grant opcode budget, so they are counted
+				// separately from the pay and axfer inners.
+				var innerAppCount int
 
 				program := fmt.Sprintf("#pragma version %d\n", v)
 
@@ -7901,6 +8001,7 @@ func TestUnnamedResources(t *testing.T) {
 				if v >= 6 { // contract to contract itxn calls introduced
 					program += fmt.Sprintf("itxn_begin; int appl; itxn_field TypeEnum; int %d; itxn_field ApplicationID; itxn_submit;", otherAppID)
 					innerCount++
+					innerAppCount++
 				}
 				expectedResources.Accounts[otherAppUser] = struct{}{}
 				if v >= 9 {
@@ -8021,7 +8122,7 @@ func TestUnnamedResources(t *testing.T) {
 										UnnamedResourcesAccessed: expectedUnnamedResourceTxnAssignment,
 									},
 								},
-								AppBudgetAdded:           700 + 700*innerCount,
+								AppBudgetAdded:           700 + 700*innerAppCount,
 								AppBudgetConsumed:        ignoreAppBudgetConsumed,
 								UnnamedResourcesAccessed: expectedUnnamedResourceGroupAssignment,
 							},
@@ -10265,7 +10366,7 @@ func TestFixSigners(t *testing.T) {
 								{FeesPaid: inputs.txgroup[4].Txn.Fee}, // pay3
 							},
 							AppBudgetConsumed: ignoreAppBudgetConsumed,
-							AppBudgetAdded:    2800,
+							AppBudgetAdded:    1400,
 							GroupUsage:        8e6,
 							GroupFeesPaid:     basics.MicroAlgos{Raw: 8 * inputs.txgroup[0].Txn.Fee.Raw},
 						},
@@ -10359,7 +10460,7 @@ func TestFixSigners(t *testing.T) {
 								{FeesPaid: inputs.txgroup[4].Txn.Fee}, // pay3
 							},
 							AppBudgetConsumed: ignoreAppBudgetConsumed,
-							AppBudgetAdded:    2800,
+							AppBudgetAdded:    1400,
 							GroupUsage:        8e6,
 							GroupFeesPaid:     basics.MicroAlgos{Raw: 8 * inputs.txgroup[0].Txn.Fee.Raw},
 						},

--- a/ledger/simulation/tracer.go
+++ b/ledger/simulation/tracer.go
@@ -153,7 +153,14 @@ func (tracer *evalTracer) BeforeTxnGroup(ep *logic.EvalParams) {
 	if ep.GetCaller() != nil {
 		// If this is an inner txn group, save the txns
 		tracer.populateInnerTransactions(ep.TxnGroup)
-		tracer.result.TxnGroups[0].AppBudgetAdded += ep.Proto.MaxAppProgramCost
+		// Report a grant for each app call, not one for the whole group. The AVM
+		// grants budget per inner app call, so a group of payments adds nothing,
+		// while a group of several app calls adds several grants.
+		for i := range ep.TxnGroup {
+			if ep.TxnGroup[i].Txn.Type == protocol.ApplicationCallTx {
+				tracer.result.TxnGroups[0].AppBudgetAdded += ep.Proto.MaxAppProgramCost
+			}
+		}
 	}
 	tracer.cursorEvalTracer.BeforeTxnGroup(ep)
 
@@ -162,8 +169,11 @@ func (tracer *evalTracer) BeforeTxnGroup(ep *logic.EvalParams) {
 		tracer.result.TxnGroups[0].AppBudgetAdded = *ep.PooledApplicationBudget
 	}
 
-	// Override transaction group budget if specified in request, retrieve from tracer.result
-	if ep.PooledApplicationBudget != nil {
+	// Override transaction group budget if specified in request, retrieve from
+	// tracer.result. Only for the top-level group: inner groups share the same
+	// pool, so granting the extra again for each of them would hand out a
+	// multiple of what was asked for.
+	if ep.PooledApplicationBudget != nil && ep.GetCaller() == nil {
 		tracer.result.TxnGroups[0].AppBudgetAdded += tracer.result.EvalOverrides.ExtraOpcodeBudget
 		*ep.PooledApplicationBudget += tracer.result.EvalOverrides.ExtraOpcodeBudget
 	}


### PR DESCRIPTION
`BeforeTxnGroup` mirrors the budget the AVM grants, but it has never matched what `NewInnerEvalParams` actually does. Two independent errors, both present since the lines were first written.

### Budget credited per inner group, not per inner app call

The AVM grants `MaxAppProgramCost` for each inner *app call*. The tracer credited it once per inner *group*, whatever that group held:

| Inner group contains | Real grant | Reported |
| --- | --- | --- |
| 0 app calls (e.g. payments) | 0 | 700 |
| 1 app call | 700 | 700 |
| N app calls | N×700 | 700 |

So it over-reported for groups of non-app inners and under-reported for groups holding several app calls. This only ever affected the reported figure, not the budget the group really ran with. Introduced in 9a0f374be (#5221), the commit that added `AppBudgetAdded`.

### ExtraOpcodeBudget granted once per group, recursively

`ExtraOpcodeBudget` from a simulate request was applied on every call to `BeforeTxnGroup`, and inner groups enter it too, so a group with N inner groups was granted it N+1 times:

```
extra=1000, one inner group -> AppBudgetAdded=3400   (should be 2400)
```

Unlike the first error, this one adds to `PooledApplicationBudget` itself, so simulate handed out a multiple of the budget that was asked for and could approve a group that would run out of budget on chain. Introduced in 9e980d3ec (#5354). The PR title there says "per transaction group", which was the right intent — but "group" silently became "group, recursively".

### Why neither was caught

The tests exercise extra budget and inner groups on separate axes and never cross them, and every inner group in them holds exactly one app call, which is the single case where the first error is invisible. `TestExtraBudgetWithInner` covers the missing cell; it fails if either fix is reverted.

The corrected expectations in existing tests are all consequences of the first fix: 2100→700 and 2100→1400 where inners are `acfg` or payments, 4200→7000 where four inner groups hold eight app calls between them, and 2800→1400 in `TestFixSigners`. `TestUnnamedResources` now counts inner app calls separately from inner payments and asset transfers.
