### PR TITLE
passphrase: fix empty trailing line

### DIFF
--- a/crypto/passphrase/passphrase_test.go
+++ b/crypto/passphrase/passphrase_test.go
@@ -158,3 +158,9 @@ func TestUint11Array(t *testing.T) {
 		require.True(t, len(b)*8 >= len(a)*11)
 	}
 }
+
+func TestWordlist(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	require.Equal(t, 2048, len(wordlist))
+}

--- a/crypto/passphrase/wordlist.go
+++ b/crypto/passphrase/wordlist.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 // This wordlist was taken from https://git.io/fhZUO
-var wordlist = strings.Split(wordlistRaw, "\n")
+var wordlist = strings.Split(strings.TrimSpace(wordlistRaw), "\n")
 var wordlistRaw = `abandon
 ability
 able

--- a/crypto/passphrase/wordlist.go
+++ b/crypto/passphrase/wordlist.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 // This wordlist was taken from https://git.io/fhZUO
-var wordlist = strings.Split(strings.TrimSpace(wordlistRaw), "\n")
+var wordlist = strings.Split(strings.TrimRight(wordlistRaw, "\r\n"), "\n")
 var wordlistRaw = `abandon
 ability
 able


### PR DESCRIPTION
## Summary

Fix for this [test failure](https://github.com/algorand/go-algorand-private/actions/runs/32064173255/job/95492142386).

```
=== FAIL: crypto/passphrase TestCorruptedChecksum (0.00s)
    passphrase_test.go:80: 
        	Error Trace:	/home/runner/work/go-algorand-private/go-algorand-private/crypto/passphrase/passphrase_test.go:80
        	Error:      	Target error should be in err chain:
        	            	expected: "checksum failed to validate"
        	            	in chain: "mnemonic must be 25 words"
        	Test:       	TestCorruptedChecksum

```

This is rare failure when a list in the test wraps around, and instead of wrapping hits 2049 element in the test. It is easy to see the original split produces 2049 elements:

```
func TestWordlist(t *testing.T) {
	wl := strings.Split(wordlistRaw, "\n")
	require.Equal(t, len(wl), 2048)
}

--- FAIL: TestWordlist (0.00s)
    passphrase_test.go:164:
        	Error Trace:	/Users/pzbitskiy/src/go-algorand/crypto/passphrase/passphrase_test.go:164
        	Error:      	Not equal:
        	            	expected: 2049
        	            	actual  : 2048
        	Test:       	TestWordlist

```

This is safe because:
1. `MnemonicToKey` ignores empty words from input
2. `applyWords` uses indices from `toUint11Array` forcing them to be in 0-2047 range.

## Test Plan

1. Added a test verifying `wordlist` is 2048 items.
2. Existing tests pass