### PR TITLE
chore: add fnet5 proto

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1634,6 +1634,24 @@ func initConsensusProtocols() {
 	vFnet3.ApprovedUpgrades[protocol.ConsensusVFnet4] = 10000
 
 	vFnet4.ApprovedUpgrades[protocol.ConsensusV40] = 10000
+
+	// vFnet5 was the v42 preview on FNet
+	vFnet5 := v41
+	vFnet5.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
+
+	vFnet5.LogicSigVersion = 13
+	vFnet5.AppSizeUpdates = true
+	vFnet5.AllowZeroLocalAppRef = true
+	vFnet5.EnforceAuthAddrSenderDiff = true
+	vFnet5.EnablePQSchemeFalcon1024 = true
+	vFnet5.LoadTracking = true
+	vFnet5.MaxAbsoluteTxnNoteBytes = 4096   // same as largest AVM value
+	vFnet5.MaxAbsoluteExtraProgramPages = 7 // Allow larger programs with extra fees
+	vFnet5.MaxAbsoluteTotalArgLen = 16384   // We _could_ make this as high as 16*4k
+	vFnet5.PerByteTxnSurcharge = 100        // Each charged byte adds 0.000100 of min fee
+	vFnet5.EnableSelectF128 = true
+
+	Consensus[protocol.ConsensusVFnet5] = vFnet5
 }
 
 // Global defines global Algorand protocol parameters which should not be overridden.

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -274,6 +274,10 @@ const ConsensusVFnet3 = ConsensusVersion("fnet3")
 // ConsensusV40.
 const ConsensusVFnet4 = ConsensusVersion("fnet4")
 
+// ConsensusVFnet5 is the protocol AF's FNet runs, with the same parameters as
+// ConsensusV42
+const ConsensusVFnet5 = ConsensusVersion("fnet5")
+
 // !!! ********************* !!!
 // !!! *** Please update ConsensusCurrentVersion when adding new protocol versions *** !!!
 // !!! ********************* !!!


### PR DESCRIPTION
## Summary

Adding fnet5 proto, which runs as a V42 clone on FNet.

Intentionally leaving out upgrade paths from v41 to fnet5. Upgrade paths between mainline and fnet protos will be handled by custom consensus.json overrides deployed on FNet nodes.