### PR TITLE
transactions: memory efficient verified transaction caching

### DIFF
--- a/data/transactions/verify/verifiedTxnCache.go
+++ b/data/transactions/verify/verifiedTxnCache.go
@@ -18,6 +18,7 @@ package verify
 
 import (
 	"errors"
+	"unique"
 
 	"github.com/algorand/go-deadlock"
 
@@ -99,19 +100,25 @@ type txnAuth struct {
 // report a hit where a full comparison would not. Never written to.
 var emptyLogicSig transactions.LogicSig
 
-type verifiedTxnCtx struct {
+// verificationContext is the external state a past verification depended on,
+// both fields move together and are shared by every entry so they are interned as a unit.
+// This makes the entry as a single 8-byte handle and reduces the comparison in matches() to a pointer equality.
+type verificationContext struct {
 	specAddrs        transactions.SpecialAddresses
 	consensusVersion protocol.ConsensusVersion
-	sigs             txnAuth
+}
+
+type verifiedTxnCtx struct {
+	vctx unique.Handle[verificationContext]
+	sigs txnAuth
 }
 
 // matches reports whether this cached entry records a verification that still applies to
 // txn. Both halves are required: the entry must have been verified under the same
 // specAddrs and consensus version, and txn must carry the same authorization material
 // that was verified back then.
-func (v *verifiedTxnCtx) matches(specAddrs transactions.SpecialAddresses, consensusVersion protocol.ConsensusVersion, txn *transactions.SignedTxn) bool {
-	isEqual := v.specAddrs == specAddrs &&
-		v.consensusVersion == consensusVersion &&
+func (v *verifiedTxnCtx) matches(vctx unique.Handle[verificationContext], txn *transactions.SignedTxn) bool {
+	isEqual := v.vctx == vctx &&
 		v.sigs.sig == txn.Sig &&
 		v.sigs.msig.Equal(txn.Msig) &&
 		v.sigs.authAddr == txn.AuthAddr
@@ -175,6 +182,8 @@ func (v *verifiedTransactionCache) AddPayset(groupCtxs []*GroupContext) {
 
 // GetUnverifiedTransactionGroups compares the provided payset against the currently cached transactions and figure which transaction groups aren't fully cached.
 func (v *verifiedTransactionCache) GetUnverifiedTransactionGroups(txnGroups [][]transactions.SignedTxn, currSpecAddrs transactions.SpecialAddresses, currProto protocol.ConsensusVersion) (unverifiedGroups [][]transactions.SignedTxn) {
+	vctx := unique.Make(verificationContext{specAddrs: currSpecAddrs, consensusVersion: currProto})
+
 	v.bucketsLock.Lock()
 	defer v.bucketsLock.Unlock()
 	unverifiedGroups = make([][]transactions.SignedTxn, 0, len(txnGroups))
@@ -206,7 +215,7 @@ func (v *verifiedTransactionCache) GetUnverifiedTransactionGroups(txnGroups [][]
 			if entryTxnCtx == nil {
 				break
 			}
-			if !entryTxnCtx.matches(currSpecAddrs, currProto, txn) {
+			if !entryTxnCtx.matches(vctx, txn) {
 				break
 			}
 			verifiedTxn++
@@ -300,10 +309,13 @@ func (v *verifiedTransactionCache) add(groupCtx *GroupContext) {
 		v.buckets[v.base] = make(map[transactions.Txid]*verifiedTxnCtx, v.entriesPerBucket)
 	}
 	currentBucket := v.buckets[v.base]
+	vctx := unique.Make(verificationContext{
+		specAddrs:        groupCtx.specAddrs,
+		consensusVersion: groupCtx.consensusVersion,
+	})
 	for _, txn := range groupCtx.signedGroupTxns {
 		entry := &verifiedTxnCtx{
-			specAddrs:        groupCtx.specAddrs,
-			consensusVersion: groupCtx.consensusVersion,
+			vctx: vctx,
 			sigs: txnAuth{
 				sig:      txn.Sig,
 				msig:     txn.Msig,

--- a/data/transactions/verify/verifiedTxnCache.go
+++ b/data/transactions/verify/verifiedTxnCache.go
@@ -87,10 +87,17 @@ type verifiedTransactionCache struct {
 type txnAuth struct {
 	Sig      crypto.Signature
 	Msig     crypto.MultisigSig
-	Lsig     transactions.LogicSig
-	PQsig    transactions.PQSig
+	Lsig     *transactions.LogicSig // 232B struct that is almost always nil
+	PQsig    *transactions.PQSig    // 56B struct
 	AuthAddr basics.Address
 }
+
+// emptyLogicSig is the emptiness test for the out-of-line LogicSig. It is deliberately
+// Equal against the zero value rather than Blank(): Blank() treats a non-nil empty slice
+// as empty, while Equal() -- the comparison matches() actually performs -- distinguishes
+// it from nil. Compressing on Blank() would let those two forms collide in the cache and
+// report a hit where a full comparison would not. Never written to.
+var emptyLogicSig transactions.LogicSig
 
 type verifiedTxnCtx struct {
 	specAddrs        transactions.SpecialAddresses
@@ -103,13 +110,31 @@ type verifiedTxnCtx struct {
 // specAddrs and consensus version, and txn must carry the same authorization material
 // that was verified back then.
 func (v *verifiedTxnCtx) matches(specAddrs transactions.SpecialAddresses, consensusVersion protocol.ConsensusVersion, txn *transactions.SignedTxn) bool {
-	return v.specAddrs == specAddrs &&
+	isEqual := v.specAddrs == specAddrs &&
 		v.consensusVersion == consensusVersion &&
 		v.sigs.Sig == txn.Sig &&
 		v.sigs.Msig.Equal(txn.Msig) &&
-		v.sigs.Lsig.Equal(&txn.Lsig) &&
-		v.sigs.PQsig.Equal(txn.PQsig) &&
 		v.sigs.AuthAddr == txn.AuthAddr
+
+	txnLsigEmpty := txn.Lsig.Equal(&emptyLogicSig)
+	txnPQsigBlank := txn.PQsig.Blank()
+	lsigNotNil := v.sigs.Lsig != nil
+	pqsigNotNil := v.sigs.PQsig != nil
+
+	if lsigNotNil && txnLsigEmpty || !lsigNotNil && !txnLsigEmpty {
+		return false
+	}
+	if lsigNotNil {
+		isEqual = isEqual && v.sigs.Lsig.Equal(&txn.Lsig)
+	}
+
+	if pqsigNotNil && txnPQsigBlank || !pqsigNotNil && !txnPQsigBlank {
+		return false
+	}
+	if pqsigNotNil {
+		isEqual = isEqual && v.sigs.PQsig.Equal(txn.PQsig)
+	}
+	return isEqual
 }
 
 // MakeVerifiedTransactionCache creates an instance of verifiedTransactionCache and returns it.
@@ -271,17 +296,24 @@ func (v *verifiedTransactionCache) add(groupCtx *GroupContext) {
 	}
 	currentBucket := v.buckets[v.base]
 	for _, txn := range groupCtx.signedGroupTxns {
-		currentBucket[txn.ID()] = &verifiedTxnCtx{
+		entry := &verifiedTxnCtx{
 			specAddrs:        groupCtx.specAddrs,
 			consensusVersion: groupCtx.consensusVersion,
 			sigs: txnAuth{
 				Sig:      txn.Sig,
 				Msig:     txn.Msig,
-				Lsig:     txn.Lsig,
-				PQsig:    txn.PQsig,
 				AuthAddr: txn.AuthAddr,
 			},
 		}
+		if !txn.Lsig.Equal(&emptyLogicSig) {
+			lsig := txn.Lsig // local copy to avoid the entire SignedTxn being referenced
+			entry.sigs.Lsig = &lsig
+		}
+		if !txn.PQsig.Blank() {
+			pqsig := txn.PQsig
+			entry.sigs.PQsig = &pqsig
+		}
+		currentBucket[txn.ID()] = entry
 	}
 }
 

--- a/data/transactions/verify/verifiedTxnCache.go
+++ b/data/transactions/verify/verifiedTxnCache.go
@@ -85,11 +85,11 @@ type verifiedTransactionCache struct {
 }
 
 type txnAuth struct {
-	Sig      crypto.Signature
-	Msig     crypto.MultisigSig
-	Lsig     *transactions.LogicSig // 232B struct that is almost always nil
-	PQsig    *transactions.PQSig    // 56B struct
-	AuthAddr basics.Address
+	sig      crypto.Signature
+	msig     crypto.MultisigSig
+	lsig     *transactions.LogicSig // 232B struct that is almost always nil
+	pqsig    *transactions.PQSig    // 56B struct
+	authAddr basics.Address
 }
 
 // emptyLogicSig is the emptiness test for the out-of-line LogicSig. It is deliberately
@@ -112,27 +112,27 @@ type verifiedTxnCtx struct {
 func (v *verifiedTxnCtx) matches(specAddrs transactions.SpecialAddresses, consensusVersion protocol.ConsensusVersion, txn *transactions.SignedTxn) bool {
 	isEqual := v.specAddrs == specAddrs &&
 		v.consensusVersion == consensusVersion &&
-		v.sigs.Sig == txn.Sig &&
-		v.sigs.Msig.Equal(txn.Msig) &&
-		v.sigs.AuthAddr == txn.AuthAddr
+		v.sigs.sig == txn.Sig &&
+		v.sigs.msig.Equal(txn.Msig) &&
+		v.sigs.authAddr == txn.AuthAddr
 
 	txnLsigEmpty := txn.Lsig.Equal(&emptyLogicSig)
 	txnPQsigBlank := txn.PQsig.Blank()
-	lsigNotNil := v.sigs.Lsig != nil
-	pqsigNotNil := v.sigs.PQsig != nil
+	lsigNotNil := v.sigs.lsig != nil
+	pqsigNotNil := v.sigs.pqsig != nil
 
 	if lsigNotNil && txnLsigEmpty || !lsigNotNil && !txnLsigEmpty {
 		return false
 	}
 	if lsigNotNil {
-		isEqual = isEqual && v.sigs.Lsig.Equal(&txn.Lsig)
+		isEqual = isEqual && v.sigs.lsig.Equal(&txn.Lsig)
 	}
 
 	if pqsigNotNil && txnPQsigBlank || !pqsigNotNil && !txnPQsigBlank {
 		return false
 	}
 	if pqsigNotNil {
-		isEqual = isEqual && v.sigs.PQsig.Equal(txn.PQsig)
+		isEqual = isEqual && v.sigs.pqsig.Equal(txn.PQsig)
 	}
 	return isEqual
 }
@@ -300,18 +300,18 @@ func (v *verifiedTransactionCache) add(groupCtx *GroupContext) {
 			specAddrs:        groupCtx.specAddrs,
 			consensusVersion: groupCtx.consensusVersion,
 			sigs: txnAuth{
-				Sig:      txn.Sig,
-				Msig:     txn.Msig,
-				AuthAddr: txn.AuthAddr,
+				sig:      txn.Sig,
+				msig:     txn.Msig,
+				authAddr: txn.AuthAddr,
 			},
 		}
 		if !txn.Lsig.Equal(&emptyLogicSig) {
 			lsig := txn.Lsig // local copy to avoid the entire SignedTxn being referenced
-			entry.sigs.Lsig = &lsig
+			entry.sigs.lsig = &lsig
 		}
 		if !txn.PQsig.Blank() {
 			pqsig := txn.PQsig
-			entry.sigs.PQsig = &pqsig
+			entry.sigs.pqsig = &pqsig
 		}
 		currentBucket[txn.ID()] = entry
 	}

--- a/data/transactions/verify/verifiedTxnCache.go
+++ b/data/transactions/verify/verifiedTxnCache.go
@@ -78,9 +78,9 @@ type verifiedTransactionCache struct {
 	// bucketsLock is the lock for synchronizing access to the cache
 	bucketsLock deadlock.Mutex
 	// buckets is the circular cache buckets buffer
-	buckets []map[transactions.Txid]*verifiedTxnCtx
+	buckets []map[transactions.Txid]verifiedTxnCtx
 	// pinned is the pinned transactions entries map.
-	pinned map[transactions.Txid]*verifiedTxnCtx
+	pinned map[transactions.Txid]verifiedTxnCtx
 	// base is the index into the buckets array where the next transaction entry would be written.
 	base int
 }
@@ -161,12 +161,12 @@ func (v *verifiedTxnCtx) matches(vctx unique.Handle[verificationContext], txn *t
 func MakeVerifiedTransactionCache(cacheSize int) VerifiedTransactionCache {
 	impl := &verifiedTransactionCache{
 		entriesPerBucket: (cacheSize + 1) / 2,
-		buckets:          make([]map[transactions.Txid]*verifiedTxnCtx, 3),
-		pinned:           make(map[transactions.Txid]*verifiedTxnCtx, cacheSize),
+		buckets:          make([]map[transactions.Txid]verifiedTxnCtx, 3),
+		pinned:           make(map[transactions.Txid]verifiedTxnCtx, cacheSize),
 		base:             0,
 	}
 	for i := 0; i < len(impl.buckets); i++ {
-		impl.buckets[i] = make(map[transactions.Txid]*verifiedTxnCtx, impl.entriesPerBucket)
+		impl.buckets[i] = make(map[transactions.Txid]verifiedTxnCtx, impl.entriesPerBucket)
 	}
 	return impl
 }
@@ -205,9 +205,9 @@ func (v *verifiedTransactionCache) GetUnverifiedTransactionGroups(txnGroups [][]
 			txn := &signedTxnGroup[txnIdx]
 			id := txn.Txn.ID()
 			// check pinned first
-			entryTxnCtx := v.pinned[id]
+			entryTxnCtx, found := v.pinned[id]
 			// if not found in the pinned map, try to find in the verified buckets:
-			if entryTxnCtx == nil {
+			if !found {
 				// try to look in the previously verified buckets.
 				// we use the (base + W) % W trick here so we can go backward and wrap around the zero.
 				for offsetBucketIdx := baseBucket + len(v.buckets); offsetBucketIdx > baseBucket; offsetBucketIdx-- {
@@ -215,12 +215,13 @@ func (v *verifiedTransactionCache) GetUnverifiedTransactionGroups(txnGroups [][]
 					if params, has := v.buckets[bucketIdx][id]; has {
 						entryTxnCtx = params
 						baseBucket = bucketIdx
+						found = true
 						break
 					}
 				}
 			}
 
-			if entryTxnCtx == nil {
+			if !found {
 				break
 			}
 			if !entryTxnCtx.matches(vctx, txn) {
@@ -240,7 +241,7 @@ func (v *verifiedTransactionCache) GetUnverifiedTransactionGroups(txnGroups [][]
 func (v *verifiedTransactionCache) UpdatePinned(pinnedTxns map[transactions.Txid]transactions.SignedTxn) (err error) {
 	v.bucketsLock.Lock()
 	defer v.bucketsLock.Unlock()
-	pinned := make(map[transactions.Txid]*verifiedTxnCtx, len(pinnedTxns))
+	pinned := make(map[transactions.Txid]verifiedTxnCtx, len(pinnedTxns))
 	for txID := range pinnedTxns {
 		if groupEntry, has := v.pinned[txID]; has {
 			pinned[txID] = groupEntry
@@ -314,7 +315,7 @@ func (v *verifiedTransactionCache) add(groupCtx *GroupContext) {
 	if len(v.buckets[v.base])+len(groupCtx.signedGroupTxns) > v.entriesPerBucket {
 		// move to the next bucket while deleting the content of the next bucket.
 		v.base = (v.base + 1) % len(v.buckets)
-		v.buckets[v.base] = make(map[transactions.Txid]*verifiedTxnCtx, v.entriesPerBucket)
+		v.buckets[v.base] = make(map[transactions.Txid]verifiedTxnCtx, v.entriesPerBucket)
 	}
 	currentBucket := v.buckets[v.base]
 	vctx := unique.Make(verificationContext{
@@ -322,7 +323,7 @@ func (v *verifiedTransactionCache) add(groupCtx *GroupContext) {
 		consensusVersion: groupCtx.consensusVersion,
 	})
 	for _, txn := range groupCtx.signedGroupTxns {
-		entry := &verifiedTxnCtx{
+		entry := verifiedTxnCtx{
 			vctx: vctx,
 			sigs: txnAuth{
 				sig:      txn.Sig,

--- a/data/transactions/verify/verifiedTxnCache.go
+++ b/data/transactions/verify/verifiedTxnCache.go
@@ -116,6 +116,10 @@ func (v *verifiedTxnCtx) matches(specAddrs transactions.SpecialAddresses, consen
 		v.sigs.msig.Equal(txn.Msig) &&
 		v.sigs.authAddr == txn.AuthAddr
 
+	if !isEqual {
+		return false
+	}
+
 	txnLsigEmpty := txn.Lsig.Equal(&emptyLogicSig)
 	txnPQsigBlank := txn.PQsig.Blank()
 	lsigNotNil := v.sigs.lsig != nil
@@ -125,12 +129,13 @@ func (v *verifiedTxnCtx) matches(specAddrs transactions.SpecialAddresses, consen
 		return false
 	}
 	if lsigNotNil {
-		isEqual = isEqual && v.sigs.lsig.Equal(&txn.Lsig)
+		isEqual = v.sigs.lsig.Equal(&txn.Lsig)
 	}
 
 	if pqsigNotNil && txnPQsigBlank || !pqsigNotNil && !txnPQsigBlank {
 		return false
 	}
+
 	if pqsigNotNil {
 		isEqual = isEqual && v.sigs.pqsig.Equal(txn.PQsig)
 	}

--- a/data/transactions/verify/verifiedTxnCache.go
+++ b/data/transactions/verify/verifiedTxnCache.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/algorand/go-deadlock"
 
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/protocol"
 )
@@ -75,23 +77,51 @@ type verifiedTransactionCache struct {
 	// bucketsLock is the lock for synchronizing access to the cache
 	bucketsLock deadlock.Mutex
 	// buckets is the circular cache buckets buffer
-	buckets []map[transactions.Txid]*GroupContext
+	buckets []map[transactions.Txid]*verifiedTxnCtx
 	// pinned is the pinned transactions entries map.
-	pinned map[transactions.Txid]*GroupContext
+	pinned map[transactions.Txid]*verifiedTxnCtx
 	// base is the index into the buckets array where the next transaction entry would be written.
 	base int
+}
+
+type txnAuth struct {
+	Sig      crypto.Signature
+	Msig     crypto.MultisigSig
+	Lsig     transactions.LogicSig
+	PQsig    transactions.PQSig
+	AuthAddr basics.Address
+}
+
+type verifiedTxnCtx struct {
+	specAddrs        transactions.SpecialAddresses
+	consensusVersion protocol.ConsensusVersion
+	sigs             txnAuth
+}
+
+// matches reports whether this cached entry records a verification that still applies to
+// txn. Both halves are required: the entry must have been verified under the same
+// specAddrs and consensus version, and txn must carry the same authorization material
+// that was verified back then.
+func (v *verifiedTxnCtx) matches(specAddrs transactions.SpecialAddresses, consensusVersion protocol.ConsensusVersion, txn *transactions.SignedTxn) bool {
+	return v.specAddrs == specAddrs &&
+		v.consensusVersion == consensusVersion &&
+		v.sigs.Sig == txn.Sig &&
+		v.sigs.Msig.Equal(txn.Msig) &&
+		v.sigs.Lsig.Equal(&txn.Lsig) &&
+		v.sigs.PQsig.Equal(txn.PQsig) &&
+		v.sigs.AuthAddr == txn.AuthAddr
 }
 
 // MakeVerifiedTransactionCache creates an instance of verifiedTransactionCache and returns it.
 func MakeVerifiedTransactionCache(cacheSize int) VerifiedTransactionCache {
 	impl := &verifiedTransactionCache{
 		entriesPerBucket: (cacheSize + 1) / 2,
-		buckets:          make([]map[transactions.Txid]*GroupContext, 3),
-		pinned:           make(map[transactions.Txid]*GroupContext, cacheSize),
+		buckets:          make([]map[transactions.Txid]*verifiedTxnCtx, 3),
+		pinned:           make(map[transactions.Txid]*verifiedTxnCtx, cacheSize),
 		base:             0,
 	}
 	for i := 0; i < len(impl.buckets); i++ {
-		impl.buckets[i] = make(map[transactions.Txid]*GroupContext, impl.entriesPerBucket)
+		impl.buckets[i] = make(map[transactions.Txid]*verifiedTxnCtx, impl.entriesPerBucket)
 	}
 	return impl
 }
@@ -117,10 +147,6 @@ func (v *verifiedTransactionCache) AddPayset(groupCtxs []*GroupContext) {
 func (v *verifiedTransactionCache) GetUnverifiedTransactionGroups(txnGroups [][]transactions.SignedTxn, currSpecAddrs transactions.SpecialAddresses, currProto protocol.ConsensusVersion) (unverifiedGroups [][]transactions.SignedTxn) {
 	v.bucketsLock.Lock()
 	defer v.bucketsLock.Unlock()
-	groupCtx := &GroupContext{
-		specAddrs:        currSpecAddrs,
-		consensusVersion: currProto,
-	}
 	unverifiedGroups = make([][]transactions.SignedTxn, 0, len(txnGroups))
 
 	for txnGroupIndex := 0; txnGroupIndex < len(txnGroups); txnGroupIndex++ {
@@ -132,35 +158,25 @@ func (v *verifiedTransactionCache) GetUnverifiedTransactionGroups(txnGroups [][]
 			txn := &signedTxnGroup[txnIdx]
 			id := txn.Txn.ID()
 			// check pinned first
-			entryGroup := v.pinned[id]
+			entryTxnCtx := v.pinned[id]
 			// if not found in the pinned map, try to find in the verified buckets:
-			if entryGroup == nil {
+			if entryTxnCtx == nil {
 				// try to look in the previously verified buckets.
 				// we use the (base + W) % W trick here so we can go backward and wrap around the zero.
 				for offsetBucketIdx := baseBucket + len(v.buckets); offsetBucketIdx > baseBucket; offsetBucketIdx-- {
 					bucketIdx := offsetBucketIdx % len(v.buckets)
 					if params, has := v.buckets[bucketIdx][id]; has {
-						entryGroup = params
+						entryTxnCtx = params
 						baseBucket = bucketIdx
 						break
 					}
 				}
 			}
 
-			if entryGroup == nil {
+			if entryTxnCtx == nil {
 				break
 			}
-
-			if !entryGroup.Equal(groupCtx) {
-				break
-			}
-
-			cachedTxn := &entryGroup.signedGroupTxns[txnIdx]
-			if cachedTxn.Sig != txn.Sig ||
-				!cachedTxn.Msig.Equal(txn.Msig) ||
-				!cachedTxn.Lsig.Equal(&txn.Lsig) ||
-				!cachedTxn.PQsig.Equal(txn.PQsig) ||
-				cachedTxn.AuthAddr != txn.AuthAddr {
+			if !entryTxnCtx.matches(currSpecAddrs, currProto, txn) {
 				break
 			}
 			verifiedTxn++
@@ -177,7 +193,7 @@ func (v *verifiedTransactionCache) GetUnverifiedTransactionGroups(txnGroups [][]
 func (v *verifiedTransactionCache) UpdatePinned(pinnedTxns map[transactions.Txid]transactions.SignedTxn) (err error) {
 	v.bucketsLock.Lock()
 	defer v.bucketsLock.Unlock()
-	pinned := make(map[transactions.Txid]*GroupContext, len(pinnedTxns))
+	pinned := make(map[transactions.Txid]*verifiedTxnCtx, len(pinnedTxns))
 	for txID := range pinnedTxns {
 		if groupEntry, has := v.pinned[txID]; has {
 			pinned[txID] = groupEntry
@@ -251,11 +267,21 @@ func (v *verifiedTransactionCache) add(groupCtx *GroupContext) {
 	if len(v.buckets[v.base])+len(groupCtx.signedGroupTxns) > v.entriesPerBucket {
 		// move to the next bucket while deleting the content of the next bucket.
 		v.base = (v.base + 1) % len(v.buckets)
-		v.buckets[v.base] = make(map[transactions.Txid]*GroupContext, v.entriesPerBucket)
+		v.buckets[v.base] = make(map[transactions.Txid]*verifiedTxnCtx, v.entriesPerBucket)
 	}
 	currentBucket := v.buckets[v.base]
 	for _, txn := range groupCtx.signedGroupTxns {
-		currentBucket[txn.ID()] = groupCtx
+		currentBucket[txn.ID()] = &verifiedTxnCtx{
+			specAddrs:        groupCtx.specAddrs,
+			consensusVersion: groupCtx.consensusVersion,
+			sigs: txnAuth{
+				Sig:      txn.Sig,
+				Msig:     txn.Msig,
+				Lsig:     txn.Lsig,
+				PQsig:    txn.PQsig,
+				AuthAddr: txn.AuthAddr,
+			},
+		}
 	}
 }
 

--- a/data/transactions/verify/verifiedTxnCache.go
+++ b/data/transactions/verify/verifiedTxnCache.go
@@ -87,10 +87,10 @@ type verifiedTransactionCache struct {
 
 type txnAuth struct {
 	sig      crypto.Signature
-	msig     crypto.MultisigSig
-	lsig     *transactions.LogicSig // 232B struct that is almost always nil
-	pqsig    *transactions.PQSig    // 56B struct
 	authAddr basics.Address
+	lsig     *transactions.LogicSig // 232B struct that is almost always nil
+	msig     *crypto.MultisigSig    // 32B struct
+	pqsig    *transactions.PQSig    // 56B struct
 }
 
 // emptyLogicSig is the emptiness test for the out-of-line LogicSig. It is deliberately
@@ -120,7 +120,6 @@ type verifiedTxnCtx struct {
 func (v *verifiedTxnCtx) matches(vctx unique.Handle[verificationContext], txn *transactions.SignedTxn) bool {
 	isEqual := v.vctx == vctx &&
 		v.sigs.sig == txn.Sig &&
-		v.sigs.msig.Equal(txn.Msig) &&
 		v.sigs.authAddr == txn.AuthAddr
 
 	if !isEqual {
@@ -129,14 +128,23 @@ func (v *verifiedTxnCtx) matches(vctx unique.Handle[verificationContext], txn *t
 
 	txnLsigEmpty := txn.Lsig.Equal(&emptyLogicSig)
 	txnPQsigBlank := txn.PQsig.Blank()
+	txnMsigBlank := txn.Msig.Blank()
 	lsigNotNil := v.sigs.lsig != nil
 	pqsigNotNil := v.sigs.pqsig != nil
+	msigNotNil := v.sigs.msig != nil
 
 	if lsigNotNil && txnLsigEmpty || !lsigNotNil && !txnLsigEmpty {
 		return false
 	}
 	if lsigNotNil {
 		isEqual = v.sigs.lsig.Equal(&txn.Lsig)
+	}
+
+	if msigNotNil && txnMsigBlank || !msigNotNil && !txnMsigBlank {
+		return false
+	}
+	if msigNotNil {
+		isEqual = isEqual && v.sigs.msig.Equal(txn.Msig)
 	}
 
 	if pqsigNotNil && txnPQsigBlank || !pqsigNotNil && !txnPQsigBlank {
@@ -318,13 +326,16 @@ func (v *verifiedTransactionCache) add(groupCtx *GroupContext) {
 			vctx: vctx,
 			sigs: txnAuth{
 				sig:      txn.Sig,
-				msig:     txn.Msig,
 				authAddr: txn.AuthAddr,
 			},
 		}
 		if !txn.Lsig.Equal(&emptyLogicSig) {
 			lsig := txn.Lsig // local copy to avoid the entire SignedTxn being referenced
 			entry.sigs.lsig = &lsig
+		}
+		if !txn.Msig.Blank() {
+			msig := txn.Msig
+			entry.sigs.msig = &msig
 		}
 		if !txn.PQsig.Blank() {
 			pqsig := txn.PQsig

--- a/data/transactions/verify/verifiedTxnCache_test.go
+++ b/data/transactions/verify/verifiedTxnCache_test.go
@@ -309,7 +309,7 @@ func TestGetUnverifiedTransactionGroupsAuthChanges(t *testing.T) {
 	}
 }
 
-// BenchmarkVerifiedCacheEntryRetention reports the marginal live heap each cached
+// BenchmarkVerifiedCacheRetention reports the marginal live heap each cached
 // transaction costs: pre-sized maps are filled without triggering growth or bucket
 // rotation, and the empty-container cost is measured separately and excluded, so the
 // reported figure is the retained value.

--- a/data/transactions/verify/verifiedTxnCache_test.go
+++ b/data/transactions/verify/verifiedTxnCache_test.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 	"testing"
 	"time"
+	"unique"
 
 	"github.com/stretchr/testify/require"
 
@@ -45,8 +46,10 @@ func TestAddingToCache(t *testing.T) {
 		ctx, has := impl.buckets[impl.base][txn.ID()]
 		require.True(t, has)
 		require.Equal(t, ctx, &verifiedTxnCtx{
-			specAddrs:        groupCtx.specAddrs,
-			consensusVersion: groupCtx.consensusVersion,
+			vctx: unique.Make(verificationContext{
+				specAddrs:        groupCtx.specAddrs,
+				consensusVersion: groupCtx.consensusVersion,
+			}),
 			sigs: txnAuth{
 				sig:      txn.Sig,
 				authAddr: txn.AuthAddr,
@@ -488,4 +491,76 @@ func TestAddingToCacheBlankLsigNilVsEmpty(t *testing.T) {
 	require.Len(t, cache.GetUnverifiedTransactionGroups(
 		[][]transactions.SignedTxn{{probe}}, groupCtx.specAddrs, groupCtx.consensusVersion), 1,
 		"a LogicSig that Equal() rejects was reported as already verified")
+}
+
+// TestGetUnverifiedTransactionGroupsContextChanges checks that a cached verification is
+// not reused when the external state it depended on has changed. The special addresses
+// and the consensus version are interned together into one handle, so this also guards
+// against that composite collapsing two distinct contexts onto the same handle.
+func TestGetUnverifiedTransactionGroupsContextChanges(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	_, signedTxns, secrets, addrs := generateTestObjects(4, 4, 0, 50)
+	group := generateTransactionGroups(1, signedTxns, secrets, addrs)[0]
+
+	cache := MakeVerifiedTransactionCache(50)
+	groupCtx, err := PrepareGroupContext(group, blockHeader, nil, nil)
+	require.NoError(t, err)
+	cache.Add(groupCtx)
+
+	cachedSpec := groupCtx.specAddrs
+	cachedProto := groupCtx.consensusVersion
+	payset := [][]transactions.SignedTxn{group}
+
+	// control: queried under the very context it was verified in, it is a hit
+	require.Empty(t, cache.GetUnverifiedTransactionGroups(payset, cachedSpec, cachedProto),
+		"the group must be recognised under its own verification context")
+
+	otherFeeSink := cachedSpec.FeeSink
+	otherFeeSink[0]++
+	otherRewardsPool := cachedSpec.RewardsPool
+	otherRewardsPool[0]++
+
+	tests := []struct {
+		name      string
+		specAddrs transactions.SpecialAddresses
+		proto     protocol.ConsensusVersion
+	}{
+		{
+			name:      "fee-sink",
+			specAddrs: transactions.SpecialAddresses{FeeSink: otherFeeSink, RewardsPool: cachedSpec.RewardsPool},
+			proto:     cachedProto,
+		},
+		{
+			name:      "rewards-pool",
+			specAddrs: transactions.SpecialAddresses{FeeSink: cachedSpec.FeeSink, RewardsPool: otherRewardsPool},
+			proto:     cachedProto,
+		},
+		{
+			name:      "consensus-version",
+			specAddrs: cachedSpec,
+			proto:     protocol.ConsensusFuture,
+		},
+		{
+			name:      "all-three",
+			specAddrs: transactions.SpecialAddresses{FeeSink: otherFeeSink, RewardsPool: otherRewardsPool},
+			proto:     protocol.ConsensusFuture,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.NotEqual(t, unique.Make(verificationContext{specAddrs: cachedSpec, consensusVersion: cachedProto}),
+				unique.Make(verificationContext{specAddrs: test.specAddrs, consensusVersion: test.proto}),
+				"the changed context must intern to a different handle")
+
+			unverified := cache.GetUnverifiedTransactionGroups(payset, test.specAddrs, test.proto)
+			require.Len(t, unverified, 1, "a cached verification was reused under a changed context")
+			require.Equal(t, group, unverified[0])
+		})
+	}
+
+	// and the original context still hits afterwards: querying under a different context
+	// must not disturb the entry
+	require.Empty(t, cache.GetUnverifiedTransactionGroups(payset, cachedSpec, cachedProto))
 }

--- a/data/transactions/verify/verifiedTxnCache_test.go
+++ b/data/transactions/verify/verifiedTxnCache_test.go
@@ -49,11 +49,75 @@ func TestAddingToCache(t *testing.T) {
 			consensusVersion: groupCtx.consensusVersion,
 			sigs: txnAuth{
 				Sig:      txn.Sig,
-				Msig:     txn.Msig,
-				Lsig:     txn.Lsig,
-				PQsig:    txn.PQsig,
 				AuthAddr: txn.AuthAddr,
+				Msig:     txn.Msig,
+				Lsig:     nil,
+				PQsig:    nil,
 			},
+		})
+	}
+}
+
+// TestAddingToCacheOutOfLineSigs covers the authorization material the cache keeps out of
+// line. Lsig and PQsig are stored behind pointers because almost no transaction carries
+// either, so both the present and the absent case need checking.
+func TestAddingToCacheOutOfLineSigs(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	_, signedTxns, _, _ := generateTestObjects(1, 2, 0, 50)
+
+	// a contract-account logicsig, which is the shape essentially all of them have:
+	// a program and arguments, with no delegation signature
+	contractLsig := transactions.SignedTxn{Txn: signedTxns[0].Txn}
+	contractLsig.Lsig.Logic = []byte{0x06, 0x81, 0x01}
+	contractLsig.Lsig.Args = [][]byte{[]byte("arg0"), []byte("arg1")}
+
+	tests := []struct {
+		name string
+		stxn transactions.SignedTxn
+	}{
+		{"lsig", contractLsig},
+		{"pqsig", makePQSignedTxn(t, 20)},
+		{"lsig-delegated-by-pqsig", makePQDelegatedLogicSigTxn(t, 21)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			icache := MakeVerifiedTransactionCache(500)
+			impl := icache.(*verifiedTransactionCache)
+
+			group := []transactions.SignedTxn{test.stxn}
+			groupCtx, err := PrepareGroupContext(group, blockHeader, nil, nil)
+			require.NoError(t, err)
+			impl.Add(groupCtx)
+
+			ctx, has := impl.buckets[impl.base][group[0].ID()]
+			require.True(t, has)
+
+			if test.stxn.Lsig.Blank() {
+				require.Nil(t, ctx.sigs.Lsig)
+			} else {
+				require.NotNil(t, ctx.sigs.Lsig, "a present Lsig must be stored")
+				require.Equal(t, test.stxn.Lsig, *ctx.sigs.Lsig)
+			}
+			if test.stxn.PQsig.Blank() {
+				require.Nil(t, ctx.sigs.PQsig)
+			} else {
+				require.NotNil(t, ctx.sigs.PQsig, "a present PQsig must be stored")
+				require.Equal(t, test.stxn.PQsig, *ctx.sigs.PQsig)
+			}
+
+			// the entry keeps its own copy: PrepareGroupContext retains the caller's
+			// slice, so storing a pointer into it would let later edits rewrite history
+			group[0].Lsig.Sig[0]++
+			group[0].Lsig.Logic = []byte{0xff}
+			group[0].PQsig.Salt++
+			if ctx.sigs.Lsig != nil {
+				require.Equal(t, test.stxn.Lsig, *ctx.sigs.Lsig, "cached Lsig aliases the caller")
+			}
+			if ctx.sigs.PQsig != nil {
+				require.Equal(t, test.stxn.PQsig, *ctx.sigs.PQsig, "cached PQsig aliases the caller")
+			}
 		})
 	}
 }
@@ -386,4 +450,42 @@ func measureRetention(tb testing.TB, groupSize int) (perTxn, totalMB float64) {
 
 	retained := full - empty
 	return float64(retained) / float64(total), float64(retained) / (1024 * 1024)
+}
+
+// TestAddingToCacheBlankLsigNilVsEmpty checks that the cache does not collapse a nil
+// LogicSig field with a non-nil empty one. LogicSig.Blank() treats both as empty, but
+// LogicSig.Equal() -- the comparison the cache actually performs -- distinguishes them
+// via safeSliceCheck, so compressing the entry on Blank() would report a hit for a
+// transaction that a full comparison rejects.
+func TestAddingToCacheBlankLsigNilVsEmpty(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	var nilLsig, emptyLsig transactions.LogicSig
+	emptyLsig.Logic = []byte{}
+	require.True(t, nilLsig.Blank())
+	require.True(t, emptyLsig.Blank(), "Blank() does not distinguish nil from empty")
+	require.False(t, nilLsig.Equal(&emptyLsig), "Equal() does distinguish them")
+
+	_, signedTxns, secrets, addrs := generateTestObjects(2, 2, 0, 50)
+	group := generateTransactionGroups(1, signedTxns, secrets, addrs)[0]
+
+	cached := group[0]
+	cached.Lsig.Logic = []byte{} // blank, but not nil
+	probe := cached
+	probe.Lsig.Logic = nil // blank, and nil
+	require.Equal(t, cached.ID(), probe.ID(), "the cache key must be identical")
+
+	cache := MakeVerifiedTransactionCache(50)
+	groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{cached}, blockHeader, nil, nil)
+	require.NoError(t, err)
+	cache.Add(groupCtx)
+
+	// the transaction as cached is still recognised
+	require.Empty(t, cache.GetUnverifiedTransactionGroups(
+		[][]transactions.SignedTxn{{cached}}, groupCtx.specAddrs, groupCtx.consensusVersion))
+
+	// the nil-valued form is a different LogicSig and must not inherit the verification
+	require.Len(t, cache.GetUnverifiedTransactionGroups(
+		[][]transactions.SignedTxn{{probe}}, groupCtx.specAddrs, groupCtx.consensusVersion), 1,
+		"a LogicSig that Equal() rejects was reported as already verified")
 }

--- a/data/transactions/verify/verifiedTxnCache_test.go
+++ b/data/transactions/verify/verifiedTxnCache_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
@@ -53,7 +54,7 @@ func TestAddingToCache(t *testing.T) {
 			sigs: txnAuth{
 				sig:      txn.Sig,
 				authAddr: txn.AuthAddr,
-				msig:     txn.Msig,
+				msig:     nil,
 				lsig:     nil,
 				pqsig:    nil,
 			},
@@ -491,6 +492,49 @@ func TestAddingToCacheBlankLsigNilVsEmpty(t *testing.T) {
 	require.Len(t, cache.GetUnverifiedTransactionGroups(
 		[][]transactions.SignedTxn{{probe}}, groupCtx.specAddrs, groupCtx.consensusVersion), 1,
 		"a LogicSig that Equal() rejects was reported as already verified")
+}
+
+// TestAddingToCacheBlankMsigNilVsEmpty pins down the multisig counterpart of
+// TestAddingToCacheBlankLsigNilVsEmpty test above, which points the opposite way.
+//
+// MultisigSig.Blank() tests Subsigs != nil, while MultisigSig.Equal() compares len(), so
+// a non-nil empty Subsigs is NOT blank yet IS equal to the zero value -- the mirror image
+// of LogicSig, where Blank() is the lenient one. The cache compresses on Blank(), so such
+// a transaction is stored out of line and a later nil-valued one is reported as a miss
+// even though Equal() would accept it.
+func TestAddingToCacheBlankMsigNilVsEmpty(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	// the asymmetry this test exists to document
+	var emptyMsig crypto.MultisigSig
+	emptyMsig.Subsigs = []crypto.MultisigSubsig{}
+	require.False(t, emptyMsig.Blank(), "Blank() tests Subsigs != nil, so an empty slice is not blank")
+	require.True(t, emptyMsig.Equal(crypto.MultisigSig{}), "Equal() compares len(), so it accepts the zero value")
+
+	_, signedTxns, secrets, addrs := generateTestObjects(2, 2, 0, 50)
+	group := generateTransactionGroups(1, signedTxns, secrets, addrs)[0]
+
+	cached := group[0]
+	cached.Msig.Subsigs = []crypto.MultisigSubsig{} // not blank, but equal to the zero value
+
+	mutated := cached
+	mutated.Msig.Subsigs = nil // blank, and still equal to the zero value
+	require.Equal(t, cached.ID(), mutated.ID(), "the cache key must be identical")
+	require.True(t, cached.Msig.Equal(mutated.Msig), "Equal() cannot tell these apart")
+
+	cache := MakeVerifiedTransactionCache(50)
+	groupCtx, err := PrepareGroupContext([]transactions.SignedTxn{cached}, blockHeader, nil, nil)
+	require.NoError(t, err)
+	cache.Add(groupCtx)
+
+	// the transaction as cached is still recognised
+	require.Empty(t, cache.GetUnverifiedTransactionGroups(
+		[][]transactions.SignedTxn{{cached}}, groupCtx.specAddrs, groupCtx.consensusVersion))
+
+	// the nil-valued form is reported as unverified: the conservative direction
+	require.Len(t, cache.GetUnverifiedTransactionGroups(
+		[][]transactions.SignedTxn{{mutated}}, groupCtx.specAddrs, groupCtx.consensusVersion), 1,
+		"compressing on Blank() must report a miss rather than inherit the verification")
 }
 
 // TestGetUnverifiedTransactionGroupsContextChanges checks that a cached verification is

--- a/data/transactions/verify/verifiedTxnCache_test.go
+++ b/data/transactions/verify/verifiedTxnCache_test.go
@@ -46,7 +46,7 @@ func TestAddingToCache(t *testing.T) {
 	for _, txn := range txnGroups[0] {
 		ctx, has := impl.buckets[impl.base][txn.ID()]
 		require.True(t, has)
-		require.Equal(t, ctx, &verifiedTxnCtx{
+		require.Equal(t, ctx, verifiedTxnCtx{
 			vctx: unique.Make(verificationContext{
 				specAddrs:        groupCtx.specAddrs,
 				consensusVersion: groupCtx.consensusVersion,
@@ -607,4 +607,70 @@ func TestGetUnverifiedTransactionGroupsContextChanges(t *testing.T) {
 	// and the original context still hits afterwards: querying under a different context
 	// must not disturb the entry
 	require.Empty(t, cache.GetUnverifiedTransactionGroups(payset, cachedSpec, cachedProto))
+}
+
+// BenchmarkVerifiedCacheGC measures what a saturated cache costs the garbage collector.
+//
+// This is the number the entry layout is really aimed at. Entries small enough to be
+// stored inline live inside the maps' bucket arrays; larger ones are allocated
+// individually, giving the collector one more object to find and trace per cached
+// transaction. At the default capacity that is the difference between a few thousand
+// objects and a few hundred thousand.
+//
+// ms/GC is GC work, not stop-the-world pause: marking is mostly concurrent in a running
+// node, so this shows CPU spent collecting rather than latency. total-MB is reported
+// alongside because storing entries inline trades memory for that work -- the maps are
+// pre-sized, so unused slots cost a whole entry each rather than a pointer.
+//
+// It touches the cache only through Add(), so it runs unchanged on any revision.
+func BenchmarkVerifiedCacheGC(b *testing.B) {
+	const cacheSize = 20000
+
+	runtime.GC()
+	before := liveHeap()
+
+	cache := MakeVerifiedTransactionCache(cacheSize)
+	impl := cache.(*verifiedTransactionCache)
+	// fill past capacity so the buckets have cycled and the cache is in the steady state
+	// a long-running node sees
+	for added := 0; added < cacheSize*3; {
+		groupCtxs, n := generateGroupContexts(b, 1, 2000)
+		for _, groupCtx := range groupCtxs {
+			cache.Add(groupCtx)
+		}
+		added += n
+	}
+	retained := liveHeap() - before
+
+	live := len(impl.pinned)
+	for _, bucket := range impl.buckets {
+		live += len(bucket)
+	}
+
+	// Everything reported below describes a full cache, so check that it actually is one.
+	// The fill relies on every generated transaction having a distinct Txid; were that to
+	// stop holding, later transactions would overwrite earlier ones and this would quietly
+	// measure a nearly empty cache instead of a saturated one. Groups here are always a
+	// single transaction, so the buckets fill exactly.
+	if capacity := impl.entriesPerBucket * len(impl.buckets); live != capacity {
+		b.Fatalf("cache did not saturate: %d live entries, capacity %d -- "+
+			"the generated transactions are probably not all distinct", live, capacity)
+	}
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	objects := ms.HeapObjects
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runtime.GC()
+	}
+	b.StopTimer()
+	runtime.KeepAlive(cache)
+
+	b.ReportMetric(float64(b.Elapsed().Microseconds())/float64(b.N)/1000, "ms/GC")
+	b.ReportMetric(float64(objects), "heap-objects")
+	b.ReportMetric(float64(live), "live-entries")
+	b.ReportMetric(float64(retained)/(1024*1024), "total-MB")
+	b.ReportMetric(float64(retained)/float64(live), "bytes/entry")
 }

--- a/data/transactions/verify/verifiedTxnCache_test.go
+++ b/data/transactions/verify/verifiedTxnCache_test.go
@@ -48,11 +48,11 @@ func TestAddingToCache(t *testing.T) {
 			specAddrs:        groupCtx.specAddrs,
 			consensusVersion: groupCtx.consensusVersion,
 			sigs: txnAuth{
-				Sig:      txn.Sig,
-				AuthAddr: txn.AuthAddr,
-				Msig:     txn.Msig,
-				Lsig:     nil,
-				PQsig:    nil,
+				sig:      txn.Sig,
+				authAddr: txn.AuthAddr,
+				msig:     txn.Msig,
+				lsig:     nil,
+				pqsig:    nil,
 			},
 		})
 	}
@@ -95,16 +95,16 @@ func TestAddingToCacheOutOfLineSigs(t *testing.T) {
 			require.True(t, has)
 
 			if test.stxn.Lsig.Blank() {
-				require.Nil(t, ctx.sigs.Lsig)
+				require.Nil(t, ctx.sigs.lsig)
 			} else {
-				require.NotNil(t, ctx.sigs.Lsig, "a present Lsig must be stored")
-				require.Equal(t, test.stxn.Lsig, *ctx.sigs.Lsig)
+				require.NotNil(t, ctx.sigs.lsig, "a present Lsig must be stored")
+				require.Equal(t, test.stxn.Lsig, *ctx.sigs.lsig)
 			}
 			if test.stxn.PQsig.Blank() {
-				require.Nil(t, ctx.sigs.PQsig)
+				require.Nil(t, ctx.sigs.pqsig)
 			} else {
-				require.NotNil(t, ctx.sigs.PQsig, "a present PQsig must be stored")
-				require.Equal(t, test.stxn.PQsig, *ctx.sigs.PQsig)
+				require.NotNil(t, ctx.sigs.pqsig, "a present PQsig must be stored")
+				require.Equal(t, test.stxn.PQsig, *ctx.sigs.pqsig)
 			}
 
 			// the entry keeps its own copy: PrepareGroupContext retains the caller's
@@ -112,11 +112,11 @@ func TestAddingToCacheOutOfLineSigs(t *testing.T) {
 			group[0].Lsig.Sig[0]++
 			group[0].Lsig.Logic = []byte{0xff}
 			group[0].PQsig.Salt++
-			if ctx.sigs.Lsig != nil {
-				require.Equal(t, test.stxn.Lsig, *ctx.sigs.Lsig, "cached Lsig aliases the caller")
+			if ctx.sigs.lsig != nil {
+				require.Equal(t, test.stxn.Lsig, *ctx.sigs.lsig, "cached Lsig aliases the caller")
 			}
-			if ctx.sigs.PQsig != nil {
-				require.Equal(t, test.stxn.PQsig, *ctx.sigs.PQsig, "cached PQsig aliases the caller")
+			if ctx.sigs.pqsig != nil {
+				require.Equal(t, test.stxn.PQsig, *ctx.sigs.pqsig, "cached PQsig aliases the caller")
 			}
 		})
 	}

--- a/data/transactions/verify/verifiedTxnCache_test.go
+++ b/data/transactions/verify/verifiedTxnCache_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 	"unique"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 
@@ -31,6 +32,18 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/test/partitiontest"
 )
+
+// maxInlineMapElemSize is the largest map element the Go 1.25 runtime stores inline in the
+// bucket array.
+const maxInlineMapElemSize = 128
+
+// TestVerifiedTxnCtxStaysInline checks that verifiedTxnCtx is small enough to be stored inline in the cache maps
+func TestVerifiedTxnCtxStaysInline(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	require.LessOrEqual(t, unsafe.Sizeof(verifiedTxnCtx{}), uintptr(maxInlineMapElemSize),
+		"verifiedTxnCtx no longer fits inline in the cache maps")
+}
 
 func TestAddingToCache(t *testing.T) {
 	partitiontest.PartitionTest(t)

--- a/data/transactions/verify/verifiedTxnCache_test.go
+++ b/data/transactions/verify/verifiedTxnCache_test.go
@@ -17,6 +17,8 @@
 package verify
 
 import (
+	"fmt"
+	"runtime"
 	"slices"
 	"testing"
 	"time"
@@ -42,7 +44,17 @@ func TestAddingToCache(t *testing.T) {
 	for _, txn := range txnGroups[0] {
 		ctx, has := impl.buckets[impl.base][txn.ID()]
 		require.True(t, has)
-		require.Equal(t, ctx, groupCtx)
+		require.Equal(t, ctx, &verifiedTxnCtx{
+			specAddrs:        groupCtx.specAddrs,
+			consensusVersion: groupCtx.consensusVersion,
+			sigs: txnAuth{
+				Sig:      txn.Sig,
+				Msig:     txn.Msig,
+				Lsig:     txn.Lsig,
+				PQsig:    txn.PQsig,
+				AuthAddr: txn.AuthAddr,
+			},
+		})
 	}
 }
 
@@ -252,4 +264,126 @@ func TestPinningTransactions(t *testing.T) {
 
 	// try to pin an entry that was not added.
 	require.Error(t, impl.Pin(txnGroups[len(txnGroups)-1]))
+}
+
+// TestGetUnverifiedTransactionGroupsAuthChanges checks that a cached transaction whose
+// authorization material has been altered is reported as unverified.
+func TestGetUnverifiedTransactionGroupsAuthChanges(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	blkHdr := createDummyBlockHeader()
+	cache := MakeVerifiedTransactionCache(50)
+
+	_, signedTxns, secrets, addrs := generateTestObjects(2, 2, 0, 50)
+	group := generateTransactionGroups(1, signedTxns, secrets, addrs)[0]
+	groupCtx, err := PrepareGroupContext(group, &blkHdr, nil, nil)
+	require.NoError(t, err)
+	cache.Add(groupCtx)
+
+	// the unmodified group is cached
+	require.Empty(t, cache.GetUnverifiedTransactionGroups([][]transactions.SignedTxn{group}, groupCtx.specAddrs, groupCtx.consensusVersion))
+
+	tests := []struct {
+		name   string
+		mutate func(*transactions.SignedTxn)
+	}{
+		{"sig", func(stxn *transactions.SignedTxn) { stxn.Sig[0] ^= 1 }},
+		{"auth-addr", func(stxn *transactions.SignedTxn) { stxn.AuthAddr[0] ^= 1 }},
+		{"msig-version", func(stxn *transactions.SignedTxn) { stxn.Msig.Version ^= 1 }},
+		{"lsig-logic", func(stxn *transactions.SignedTxn) { stxn.Lsig.Logic = []byte{0x06, 0x81, 0x01} }},
+		{"lsig-args", func(stxn *transactions.SignedTxn) { stxn.Lsig.Args = [][]byte{[]byte("arg")} }},
+		{"lsig-sig", func(stxn *transactions.SignedTxn) { stxn.Lsig.Sig[0] ^= 1 }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mutated := group[0]
+			test.mutate(&mutated)
+			require.Equal(t, group[0].ID(), mutated.ID())
+
+			unverifiedGroups := cache.GetUnverifiedTransactionGroups(
+				[][]transactions.SignedTxn{{mutated}}, groupCtx.specAddrs, groupCtx.consensusVersion)
+			require.Len(t, unverifiedGroups, 1, "altered authorization was accepted as already-verified")
+			require.Equal(t, []transactions.SignedTxn{mutated}, unverifiedGroups[0])
+		})
+	}
+}
+
+// BenchmarkVerifiedCacheEntryRetention reports the marginal live heap each cached
+// transaction costs: pre-sized maps are filled without triggering growth or bucket
+// rotation, and the empty-container cost is measured separately and excluded, so the
+// reported figure is the retained value.
+// To translate a bytes/txn figure into a node footprint, multiply by the cache capacity,
+// which is 1.5x the configured VerifiedTranscationsCacheSize: the implementation keeps
+// three buckets of (size+1)/2 entries. At the default 150000 that is 225000 entries.
+func BenchmarkVerifiedCacheRetention(b *testing.B) {
+	for _, groupSize := range []int{1, 4, 16} {
+		b.Run(fmt.Sprintf("gs=%d", groupSize), func(b *testing.B) {
+			var perTxn, totalMB float64
+			for i := 0; i < b.N; i++ {
+				perTxn, totalMB = measureRetention(b, groupSize)
+			}
+			b.ReportMetric(perTxn, "bytes/txn")
+			b.ReportMetric(totalMB, "MB")
+			b.ReportMetric(perTxn*225000/(1024*1024), "MB-def-cap")
+		})
+	}
+}
+
+// liveHeap reports the live heap once the collector has settled. Two cycles are needed
+// because the first can leave finalizable objects uncollected.
+func liveHeap() uint64 {
+	runtime.GC()
+	runtime.GC()
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	return ms.HeapAlloc
+}
+
+// generateGroupContexts builds signed transaction groups totalling at least numTxns
+// transactions and prepares a GroupContext for each, exactly as the verification path
+// does before handing them to the cache.
+func generateGroupContexts(tb testing.TB, maxGroupSize, numTxns int) ([]*GroupContext, int) {
+	groupCtxs := make([]*GroupContext, 0, numTxns)
+	total := 0
+	for total < numTxns {
+		// generate in chunks so no single signing pass dominates
+		_, signedTxns, secrets, addrs := generateTestObjects(1024, 64, total, 50)
+		for _, group := range generateTransactionGroups(maxGroupSize, signedTxns, secrets, addrs) {
+			groupCtx, err := PrepareGroupContext(group, blockHeader, nil, nil)
+			require.NoError(tb, err)
+			groupCtxs = append(groupCtxs, groupCtx)
+			total += len(group)
+			if total >= numTxns {
+				break
+			}
+		}
+	}
+	return groupCtxs, total
+}
+
+// measureRetention fills one container and returns bytes retained per transaction and in
+// total. The GroupContexts and their transactions go out of scope before the final
+// measurement, so only what the container itself holds is counted.
+func measureRetention(tb testing.TB, groupSize int) (perTxn, totalMB float64) {
+	// sized so that every entry fits without map growth or bucket rotation
+	const membenchTxns = 20000
+	cache := MakeVerifiedTransactionCache(membenchTxns * 3)
+
+	// the empty containers are already allocated, so their fixed cost is excluded
+	empty := liveHeap()
+
+	total := func() int {
+		groupCtxs, total := generateGroupContexts(tb, groupSize, membenchTxns)
+		for _, groupCtx := range groupCtxs {
+			cache.Add(groupCtx)
+		}
+		return total
+	}()
+
+	full := liveHeap()
+	runtime.KeepAlive(cache)
+
+	retained := full - empty
+	return float64(retained) / float64(total), float64(retained) / (1024 * 1024)
 }

--- a/data/txHandler.go
+++ b/data/txHandler.go
@@ -658,20 +658,29 @@ func (handler *TxHandler) incomingMsgErlCheck(sender util.ErlClient) (*util.ErlC
 	return capguard, false
 }
 
+// unverifiedTxGroupPool holds decodeMsg buffers
+var unverifiedTxGroupPool = sync.Pool{
+	New: func() any {
+		buf := make([]transactions.SignedTxn, bounds.MaxTxGroupSize+1) // +1 to allow probing one past the end of the group
+		return &buf                                                    // return a pointer to avoid copying the slice header on each Get() call
+	},
+}
+
 // decodeMsg decodes TX message buffer into transactions.SignedTxn,
 // and returns number of bytes consumed from the buffer and a boolean indicating if the message was invalid.
 func decodeMsg(data []byte) (unverifiedTxGroup []transactions.SignedTxn, consumed int, invalid bool) {
-	unverifiedTxGroup = make([]transactions.SignedTxn, 1)
-	dec := protocol.NewMsgpDecoderBytes(data)
+	unverifiedTxGroupBufPtr := unverifiedTxGroupPool.Get().(*[]transactions.SignedTxn)
+	unverifiedTxGroupBuf := *unverifiedTxGroupBufPtr
 	ntx := 0
+	defer func() {
+		clear(unverifiedTxGroupBuf[:ntx+1]) // clear only touched entries
+		unverifiedTxGroupPool.Put(unverifiedTxGroupBufPtr)
+	}()
+
+	dec := protocol.NewMsgpDecoderBytes(data)
 
 	for {
-		if len(unverifiedTxGroup) == ntx {
-			n := make([]transactions.SignedTxn, len(unverifiedTxGroup)*2)
-			copy(n, unverifiedTxGroup)
-			unverifiedTxGroup = n
-		}
-		err := dec.Decode(&unverifiedTxGroup[ntx])
+		err := dec.Decode(&unverifiedTxGroupBuf[ntx])
 		if err != nil {
 			if err == io.EOF {
 				break
@@ -695,11 +704,12 @@ func decodeMsg(data []byte) (unverifiedTxGroup []transactions.SignedTxn, consume
 		return nil, 0, true
 	}
 
-	unverifiedTxGroup = unverifiedTxGroup[:ntx]
-
 	if ntx == bounds.MaxTxGroupSize {
 		transactionMessageTxGroupFull.Inc(nil)
 	}
+
+	unverifiedTxGroup = make([]transactions.SignedTxn, ntx)
+	copy(unverifiedTxGroup, unverifiedTxGroupBuf[:ntx])
 
 	return unverifiedTxGroup, consumed, false
 }

--- a/data/txHandler_test.go
+++ b/data/txHandler_test.go
@@ -31,6 +31,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 
@@ -3259,4 +3260,55 @@ func TestTxHandlerNilTxPool(t *testing.T) {
 		TxPool: &mockTxPool{},
 	})
 	require.NotErrorIs(t, err, ErrInvalidTxPool)
+}
+
+// TestTxHandlerDecodeMsgNoStaleFields checks that decoding does not leak fields from a previously decoded message.
+func TestTxHandlerDecodeMsgNoStaleFields(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	// a full-size "dirty" message: makeRandomTransactions populates the optional Note and
+	// AuthAddr fields, so every slot of the scratch buffer ends up holding them
+	_, dirty := makeRandomTransactions(bounds.MaxTxGroupSize)
+
+	// ...and a single-transaction "clean" message that omits both
+	cleanTxns, _ := makeRandomTransactions(1)
+	cleanTxns[0].Txn.Note = nil
+	cleanTxns[0].AuthAddr = basics.Address{}
+	clean := protocol.Encode(&cleanTxns[0])
+
+	// the scratch buffer comes from a sync.Pool, so repeat enough times to be confident
+	// the same buffer is handed to both decodes
+	for i := 0; i < 100; i++ {
+		_, _, invalid := decodeMsg(dirty)
+		require.False(t, invalid)
+
+		group, _, invalid := decodeMsg(clean)
+		require.False(t, invalid)
+		require.Equal(t, cleanTxns, group, "iteration %d decoded stale fields", i)
+	}
+}
+
+const sizeofSignedTxn = int(unsafe.Sizeof(transactions.SignedTxn{}))
+
+// BenchmarkTxHandlerDecodeMsg measures decodeMsg across the legal group sizes.
+func BenchmarkTxHandlerDecodeMsg(b *testing.B) {
+	for _, n := range []int{1, 2, 4, 8, bounds.MaxTxGroupSize} {
+		b.Run(fmt.Sprintf("group-%d", n), func(b *testing.B) {
+			_, blob := makeRandomTransactions(n)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(blob)))
+			b.ResetTimer()
+
+			var retained int64
+			for i := 0; i < b.N; i++ {
+				group, _, invalid := decodeMsg(blob)
+				if invalid {
+					b.Fatal("decodeMsg reported invalid")
+				}
+				retained += int64(cap(group) * sizeofSignedTxn)
+			}
+			b.ReportMetric(float64(retained)/float64(b.N), "retained-B/op")
+		})
+	}
 }


### PR DESCRIPTION
## Summary

This PR reduced amount of RAM a live node use by factor of 10. (more exactly, 8-12x depending on dominating group size). Under a low load (current mainnet) the usage is expected to go down from 4GB to under 500MB with default TxPoolSize and VerifiedTranscationsCacheSize values.

There are two allocation sites (transaction decoder in `txHandler` and `PrepareGroupContext`) allocate some exceed amount of data that ends up in long-living `verifiedTransactionCache`.

Two issues addressed:
1. txHandler's `decodeMsg` now uses oversized buffer from `sync.Pool` and then allocates exact-size `[]SignedTxn` slice instead of 2x oversized one (see the slice reallocation code removed).
2. `verifiedTransactionCache` now uses a subset of `GroupContext` data allocated by `PrepareGroupContext` - namely `ConsensusParams` and `logic.EvalParams` are not hold by the cache.

### Benchmarks

1. decodeMsg
Before
```
BenchmarkTxHandlerDecodeMsg/group-1-10         	 1902784	       600.4 ns/op	 494.64 MB/s	      3520 retained-B/op	    5955 B/op	       4 allocs/op
BenchmarkTxHandlerDecodeMsg/group-2-10         	  810830	      1399 ns/op	 424.56 MB/s	      7040 retained-B/op	   14214 B/op	       7 allocs/op
BenchmarkTxHandlerDecodeMsg/group-4-10         	  508108	      2411 ns/op	 492.64 MB/s	     14080 retained-B/op	   28684 B/op	      12 allocs/op
BenchmarkTxHandlerDecodeMsg/group-8-10         	  270121	      4392 ns/op	 541.01 MB/s	     28160 retained-B/op	   57625 B/op	      21 allocs/op
BenchmarkTxHandlerDecodeMsg/group-16-10        	  142815	      8369 ns/op	 567.78 MB/s	     56320 retained-B/op	  115507 B/op	      38 allocs/op
```

After
```
BenchmarkTxHandlerDecodeMsg/group-1-10         	 4047714	       294.4 ns/op	1008.68 MB/s	      1760 retained-B/op	    1860 B/op	       3 allocs/op
BenchmarkTxHandlerDecodeMsg/group-2-10         	 1855179	       641.0 ns/op	 926.64 MB/s	      3520 retained-B/op	    4232 B/op	       5 allocs/op
BenchmarkTxHandlerDecodeMsg/group-4-10         	  933769	      1248 ns/op	 951.76 MB/s	      7040 retained-B/op	    8466 B/op	       9 allocs/op
BenchmarkTxHandlerDecodeMsg/group-8-10         	  602005	      1910 ns/op	1243.74 MB/s	     14080 retained-B/op	   14882 B/op	      17 allocs/op
BenchmarkTxHandlerDecodeMsg/group-16-10        	  323571	      3653 ns/op	1300.90 MB/s	     28160 retained-B/op	   29760 B/op	      33 allocs/op
```

It is a pure 2x win.

2. verifiedTransactionCache

Before
```
BenchmarkVerifiedCacheRetention/gs=1-10         	       3	 448136403 ns/op	       123.2 MB	      1386 MB-def-cap	      6459 bytes/txn	393519165 B/op	  593771 allocs/op
BenchmarkVerifiedCacheRetention/gs=4-10         	       3	 411563430 ns/op	        87.51 MB	       984.4 MB-def-cap	      4587 bytes/txn	419656776 B/op	  457478 allocs/op
BenchmarkVerifiedCacheRetention/gs=16-10        	       3	 402065111 ns/op	        79.01 MB	       888.5 MB-def-cap	      4141 bytes/txn	407863330 B/op	  403970 allocs/op
```

After
```
BenchmarkVerifiedCacheRetention/gs=1-10         	       3	 441279153 ns/op	         9.769 MB	       109.9 MB-def-cap	       512.2 bytes/txn	403759176 B/op	  613771 allocs/op
BenchmarkVerifiedCacheRetention/gs=4-10         	       3	 410822903 ns/op	         9.767 MB	       109.9 MB-def-cap	       512.0 bytes/txn	429840720 B/op	  477695 allocs/op
BenchmarkVerifiedCacheRetention/gs=16-10        	       3	 401842958 ns/op	         9.770 MB	       109.9 MB-def-cap	       512.0 bytes/txn	418152416 B/op	  424029 allocs/op
```

It is a win in total memory consumption but by cost of some extra allocations. There is a way to reduce allocs by switching the new cache entry `verifiedTxnCtx` to be `verifiedTxnGroupCtx` by having a slice of `sigs` - in this case `GetUnverifiedTransactionGroups` will be a bit more complex with txn indexing logic, not sure if it worth.

What's else left is `statusCache`, it gets its size from `TxPoolSize` and can also grow quite large. There are couple options to address this:
1. Create it is own config parameter as a upper bound
2. And/or make it to flush every X blocks
3. Store encoded `SignedTxn` over there

## Test Plan

1. Existing tests pass
4. New refactoring-related tests added
5. 36h hours node results: 1.2GB vs 4.5GB original. Next targets are `statusCache`. The `VerifiedTransactionCache` is 107MB in heap (vs 109.9 MB pre-calculated in `BenchmarkVerifiedCacheRetention`)