### PR TITLE
DevOps: remove SECURITY.md to fall back to org policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,5 +59,5 @@ All changes are subject to a minimum of two reviews from subject matter experts 
 
 [gh-pr-process]: https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
 [go-algorand-issues]: https://github.com/algorand/go-algorand/issues/new/choose
-[security-disclosure]: https://github.com/algorand/go-algorand/security/policy
+[security-disclosure]: https://github.com/algorand/go-algorand?tab=security-ov-file#security-ov-file
 [algorand-docs]: https://github.com/algorand/docs/blob/staging/CONTRIBUTING.md

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,0 @@
-# Vulnerability Disclosures
-
-Algorand takes the security of the platform and of its users very seriously. We recognize the important role of external security researchers and developers in helping keep our community safe. Vulnerabilities must be disclosed to us privately with reasonable time to respond, and avoid compromise of other users and accounts, or loss of funds that are not your own. We do not reward denial of service, spam, or social engineering vulnerabilities.
-
-If you believe that you have found a security vulnerability you may disclose it here:
-
-https://algorandtechnologies.com/contact/security/


### PR DESCRIPTION
## Summary

We want to consolidate security policies on the `algorand` org to a single policy, so need to remove this file.

There was a link to the policy on the CONTRIBUTING.md file as well, which was updated. This won't point to the new policy until this is merged.

## Test Plan

N/A

