### PR TITLE
ledger: unblock the catchpoint hash reader if the trie writer stops

### DIFF
--- a/ledger/catchpointtracker.go
+++ b/ledger/catchpointtracker.go
@@ -55,6 +55,8 @@ const (
 	trieRebuildAccountChunkSize = 16384
 	// trieRebuildCommitFrequency defines the number of accounts that would get added before we call evict to commit the changes and adjust the memory cache.
 	trieRebuildCommitFrequency = 65536
+	// trieRebuildQueueDepth defines how many chunks the hash reader may run ahead of the trie writer during trie construction.
+	trieRebuildQueueDepth = 16
 
 	// CatchpointFileVersionV5 is the catchpoint file version that was used when the database schema was V0-V5.
 	CatchpointFileVersionV5 = uint64(0200)

--- a/ledger/catchupaccessor.go
+++ b/ledger/catchupaccessor.go
@@ -814,7 +814,13 @@ func (c *catchpointCatchupAccessorImpl) BuildMerkleTrie(ctx context.Context, pro
 	wg.Add(2)
 	errChan := make(chan error, 2)
 
-	writerQueue := make(chan [][]byte, 16)
+	// workCtx lets the writer tell the reader it has stopped consuming. Without it, a writer
+	// that exits early leaves the reader blocked forever on a send into writerQueue, so
+	// wg.Wait never returns.
+	workCtx, workCancel := context.WithCancel(ctx)
+	defer workCancel()
+
+	writerQueue := make(chan [][]byte, trieRebuildQueueDepth)
 	c.ledger.setSynchronousMode(ctx, c.ledger.accountsRebuildSynchronousMode)
 	defer c.ledger.setSynchronousMode(ctx, c.ledger.synchronousMode)
 
@@ -827,18 +833,26 @@ func (c *catchpointCatchupAccessorImpl) BuildMerkleTrie(ctx context.Context, pro
 		dbErr := dbs.Snapshot(func(transactionCtx context.Context, tx trackerdb.SnapshotScope) (err error) {
 			it := tx.MakeCatchpointPendingHashesIterator(trieRebuildAccountChunkSize)
 			var hashes [][]byte
+		scan:
 			for {
 				hashes, err = it.Next(transactionCtx)
 				if err != nil {
 					break
 				}
 				if len(hashes) > 0 {
-					writerQueue <- hashes
+					select {
+					case writerQueue <- hashes:
+					case <-workCtx.Done():
+						// Nobody is draining the queue. Report no error of our own, so
+						// the writer's reason for stopping reaches the caller.
+						it.Close()
+						break scan
+					}
 				}
 				if len(hashes) != trieRebuildAccountChunkSize {
 					break
 				}
-				if ctx.Err() != nil {
+				if workCtx.Err() != nil {
 					it.Close()
 					break
 				}
@@ -856,6 +870,9 @@ func (c *catchpointCatchupAccessorImpl) BuildMerkleTrie(ctx context.Context, pro
 	// starts the merkle trie writer
 	go func() {
 		defer wg.Done()
+		// Deferred so every exit path releases a parked reader, including the trie-creation
+		// failure below that returns before the receive loop starts.
+		defer workCancel()
 		var trie *merkletrie.Trie
 		uncommitedHashesCount := 0
 		keepWriting := true

--- a/ledger/catchupaccessor_test.go
+++ b/ledger/catchupaccessor_test.go
@@ -373,6 +373,66 @@ func TestBuildMerkleTrie(t *testing.T) {
 	require.Equal(t, basics.Round(0), blockRound)
 }
 
+// TestBuildMerkleTrieDuplicateHash stages a catchpoint with a repeated account hash. The
+// trie writer rejects it, but stops draining writerQueue as it does, so the hash reader
+// must notice rather than park on a send. A parked reader means BuildMerkleTrie never
+// returns and the node stays wedged in catchup holding a database snapshot.
+func TestBuildMerkleTrieDuplicateHash(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	log := logging.TestingLog(t)
+	genesisInitState, _ := ledgertesting.GenerateInitState(t, protocol.ConsensusCurrentVersion, 100)
+	cfg := config.GetDefaultLocal()
+	l, err := OpenLedger(log, t.Name(), true, genesisInitState, cfg)
+	require.NoError(t, err, "could not open ledger")
+	defer l.Close()
+
+	catchpointAccessor := MakeCatchpointCatchupAccessor(l, log)
+	ctx := context.Background()
+	err = catchpointAccessor.ResetStagingBalances(ctx, true)
+	require.NoError(t, err, "ResetStagingBalances")
+
+	// The writer fails on the first chunk, so the reader needs enough left to fill the queue
+	// and still hold one. With fewer it finishes scanning before the queue backs up, and the
+	// deadlock stays hidden.
+	const chunks = trieRebuildQueueDepth + 2
+	hashes := make([][]byte, chunks*trieRebuildAccountChunkSize)
+	for i := range hashes {
+		hash := make([]byte, 4+crypto.DigestSize)
+		hash[trackerdb.HashKindEncodingIndex] = byte(trackerdb.AccountHK)
+		// The pending-hash iterator reads ORDER BY data, so a leading counter fixes the
+		// order and keeps the duplicate pair first.
+		binary.BigEndian.PutUint32(hash[trackerdb.HashKindEncodingIndex+1:], uint32(i))
+		hashes[i] = hash
+	}
+	// The duplicate, sorted first so the writer fails on chunk 1 with most of the scan
+	// still ahead of the reader.
+	hashes[1] = hashes[0]
+
+	err = l.trackerDB().Transaction(func(ctx context.Context, tx trackerdb.TransactionScope) error {
+		crw, err := tx.MakeCatchpointWriter()
+		if err != nil {
+			return err
+		}
+		return crw.WriteCatchpointStagingHashes(ctx, []trackerdb.NormalizedAccountBalance{{AccountHashes: hashes}})
+	})
+	require.NoError(t, err, "WriteCatchpointStagingHashes")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- catchpointAccessor.BuildMerkleTrie(ctx, nil)
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorContains(t, err, "contained the same account more than once")
+	case <-time.After(30 * time.Second):
+		// Unrecoverable: the parked reader and the database snapshot it holds leak for the
+		// rest of the test binary's run.
+		t.Fatal("BuildMerkleTrie did not return: the hash reader deadlocked on writerQueue")
+	}
+}
+
 func TestCatchupAccessorStateProofVerificationContext(t *testing.T) {
 	partitiontest.PartitionTest(t)
 


### PR DESCRIPTION
## Summary

`BuildMerkleTrie` runs two goroutines: a reader that pages `catchpointpendinghashes` into a buffered channel, and a writer that drains it into the merkle trie. The reader's send was unconditional, and its `ctx.Err()` check came after the send, so it only ran if the send completed. The hang:
- The writer hits an error in a per-chunk transaction and leaves its receive loop.
- `writerQueue` stops draining and fills.
- The reader blocks in the send with nothing left to receive from it.
- `wg.Wait()` never returns, so `BuildMerkleTrie` never returns the error the writer already had.

Both goroutines and the reader's SQLite snapshot leak, and the node stays in catchup until an operator restarts it. Any writer-side error does this: the duplicate-hash rejection for a catchpoint carrying the same account twice, or the ordinary failures from a truncated or corrupt catchpoint.

The fix derives a `workCtx` from `ctx`, cancels it from a `defer` in the writer goroutine, and makes the reader's send a `select` on `workCtx.Done()`. The deferred cancel covers all three writer exits, including the trie-creation failure that returns before the receive loop starts. The reader reports no error of its own on that path, so the writer's error is what reaches the caller. 

## Test Plan

New test TestBuildMerkleTrieDuplicateHash added, which adds `trieRebuildQueueDepth + 2` chunks with the duplicate pair first, so the writer fails on chunk 1 while the reader still has enough left to fill the queue. 