### PR TITLE
partkeys: do not resurrect deleted keys in the registry cache

### DIFF
--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -408,7 +408,7 @@ func dbSchemaUpgrade0(ctx context.Context, tx *sql.Tx, newDatabase bool) error {
 type participationDB struct {
 	cache map[ParticipationID]ParticipationRecord
 
-	// dirty marked on Record(), DeleteExpired(), cleared on Register(), Delete(), Flush()
+	// dirty marked on Record(), DeleteExpired(), cleared on Delete(), Flush()
 	dirty map[ParticipationID]struct{}
 
 	log   logging.Logger
@@ -963,10 +963,13 @@ func (db *participationDB) Register(id ParticipationID, on basics.Round) error {
 }
 
 // applyRegistration installs the effective rounds that Register computed from its
-// snapshot, and clears the dirty flag because registerOp persists those fields.
-// Register also builds its update without holding the registry lock, so the same
-// rule as applyVotingTruncation applies: skip records deleted in the meantime, and
-// merge only the fields Register changed.
+// snapshot. Register builds its update without holding the registry lock, so the
+// same rule as applyVotingTruncation applies: skip records deleted in the meantime,
+// and merge only the fields Register changed.
+//
+// The dirty flag is left alone. registerOp writes every rolling field from
+// Register's snapshot, so a Record or DeleteExpired that landed inside the window is
+// already stale on disk; clearing the flag would drop the flush that repairs it.
 func (db *participationDB) applyRegistration(updated map[ParticipationID]updatingParticipationRecord) {
 	db.mutex.Lock()
 	defer db.mutex.Unlock()
@@ -978,7 +981,6 @@ func (db *participationDB) applyRegistration(updated map[ParticipationID]updatin
 		cached.EffectiveFirst = record.ParticipationRecord.EffectiveFirst
 		cached.EffectiveLast = record.ParticipationRecord.EffectiveLast
 		db.cache[id] = cached
-		delete(db.dirty, id)
 	}
 }
 

--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -953,8 +953,11 @@ func (db *participationDB) Register(id ParticipationID, on basics.Round) error {
 	}
 
 	if len(updated) != 0 {
-		db.writeQueue <- makeOpRequest(&registerOp{updated: updated})
+		// Update the cache before queuing the write. The queue has one consumer, so a
+		// flushOp queued after registerOp applies after it, and would otherwise write
+		// pre-registration effective rounds read from a cache not yet updated.
 		db.applyRegistration(updated)
+		db.writeQueue <- makeOpRequest(&registerOp{updated: updated})
 	}
 
 	db.log.Infof("Registered key (%s) for account (%s) first valid (%d) last valid (%d)\n",

--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -368,9 +368,13 @@ const (
 		FROM StateProofKeys s
 		WHERE round=?
 		   AND pk IN (SELECT pk FROM Keysets WHERE participationID=?)`
-	deleteKeysets          = `DELETE FROM Keysets WHERE pk=?`
-	deleteRolling          = `DELETE FROM Rolling WHERE pk=?`
-	deleteStateProofByPK   = `DELETE FROM StateProofKeys WHERE pk=?`
+	deleteKeysets            = `DELETE FROM Keysets WHERE pk=?`
+	deleteRolling            = `DELETE FROM Rolling WHERE pk=?`
+	deleteStateProofByPK     = `DELETE FROM StateProofKeys WHERE pk=?`
+	updateEffectiveRoundsSQL = `UPDATE Rolling
+		 SET effectiveFirstRound=?,
+		     effectiveLastRound=?
+		 WHERE pk IN (SELECT pk FROM Keysets WHERE participationID=?)`
 	updateRollingFieldsSQL = `UPDATE Rolling
 		 SET lastVoteRound=?,
 		     lastBlockProposalRound=?,
@@ -408,7 +412,8 @@ func dbSchemaUpgrade0(ctx context.Context, tx *sql.Tx, newDatabase bool) error {
 type participationDB struct {
 	cache map[ParticipationID]ParticipationRecord
 
-	// dirty marked on Record(), DeleteExpired(), cleared on Delete(), Flush()
+	// dirty marked on Record(), DeleteExpired(); cleared on Delete(), Flush(),
+	// and when registerOp evicts a record whose Rolling row has vanished
 	dirty map[ParticipationID]struct{}
 
 	log   logging.Logger
@@ -882,6 +887,29 @@ func updateRollingFields(ctx context.Context, tx *sql.Tx, record ParticipationRe
 		return err
 	}
 
+	return rollingRowsAffected(result)
+}
+
+// updateEffectiveRounds sets only the effective rounds, which is all Register owns.
+// The other rolling fields belong to Record and DeleteExpired, and reach the database
+// through flushOp from the live cache. Writing them from Register's snapshot would
+// revert whatever landed after that snapshot was taken.
+func updateEffectiveRounds(ctx context.Context, tx *sql.Tx, record ParticipationRecord) error {
+	result, err := tx.ExecContext(ctx, updateEffectiveRoundsSQL,
+		record.EffectiveFirst,
+		record.EffectiveLast,
+		record.ParticipationID[:])
+
+	if err != nil {
+		return err
+	}
+
+	return rollingRowsAffected(result)
+}
+
+// rollingRowsAffected turns the row count of a Rolling update into the sentinel
+// errors its callers switch on.
+func rollingRowsAffected(result sql.Result) error {
 	numRows, err := result.RowsAffected()
 	if err != nil {
 		return err
@@ -970,9 +998,8 @@ func (db *participationDB) Register(id ParticipationID, on basics.Round) error {
 // same rule as applyVotingTruncation applies: skip records deleted in the meantime,
 // and merge only the fields Register changed.
 //
-// The dirty flag is left alone. registerOp writes every rolling field from
-// Register's snapshot, so a Record or DeleteExpired that landed inside the window is
-// already stale on disk; clearing the flag would drop the flush that repairs it.
+// The dirty flag is left alone: registerOp persists the effective rounds only, so it
+// says nothing about the fields the flag tracks.
 func (db *participationDB) applyRegistration(updated map[ParticipationID]updatingParticipationRecord) {
 	db.mutex.Lock()
 	defer db.mutex.Unlock()

--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -610,14 +610,29 @@ func (db *participationDB) DeleteExpired(latestRound basics.Round, agreementProt
 		}
 	}
 
-	// mark updated records as dirty, so they will be flushed by a call to FlushRegistry after each round
-	db.mutex.Lock()
-	for _, r := range updated {
-		db.dirty[r.ParticipationID] = struct{}{}
-		db.cache[r.ParticipationID] = r
-	}
-	db.mutex.Unlock()
+	db.applyVotingTruncation(updated)
 	return nil
+}
+
+// applyVotingTruncation installs the truncated voting secrets that DeleteExpired
+// computed from its GetAll snapshot, and marks the records dirty so the next
+// FlushRegistry persists them. The snapshot is truncated without holding the
+// registry lock, so a record may since have been deleted or updated: writing an
+// absent record back would hand its secrets to AccountManager.Keys until the node
+// restarts, and overwriting a present one would revert a concurrent Record or
+// Register, so only Voting is merged into what the cache holds now.
+func (db *participationDB) applyVotingTruncation(updated []ParticipationRecord) {
+	db.mutex.Lock()
+	defer db.mutex.Unlock()
+	for _, r := range updated {
+		cached, ok := db.cache[r.ParticipationID]
+		if !ok {
+			continue
+		}
+		cached.Voting = r.Voting
+		db.cache[r.ParticipationID] = cached
+		db.dirty[r.ParticipationID] = struct{}{}
+	}
 }
 
 // scanRecords is a helper to manage scanning participation records.
@@ -939,18 +954,32 @@ func (db *participationDB) Register(id ParticipationID, on basics.Round) error {
 
 	if len(updated) != 0 {
 		db.writeQueue <- makeOpRequest(&registerOp{updated: updated})
-
-		db.mutex.Lock()
-		for id, record := range updated {
-			delete(db.dirty, id)
-			db.cache[id] = record.ParticipationRecord
-		}
-		db.mutex.Unlock()
+		db.applyRegistration(updated)
 	}
 
 	db.log.Infof("Registered key (%s) for account (%s) first valid (%d) last valid (%d)\n",
 		id, recordToRegister.Account, recordToRegister.FirstValid, recordToRegister.LastValid)
 	return nil
+}
+
+// applyRegistration installs the effective rounds that Register computed from its
+// snapshot, and clears the dirty flag because registerOp persists those fields.
+// Register also builds its update without holding the registry lock, so the same
+// rule as applyVotingTruncation applies: skip records deleted in the meantime, and
+// merge only the fields Register changed.
+func (db *participationDB) applyRegistration(updated map[ParticipationID]updatingParticipationRecord) {
+	db.mutex.Lock()
+	defer db.mutex.Unlock()
+	for id, record := range updated {
+		cached, ok := db.cache[id]
+		if !ok {
+			continue
+		}
+		cached.EffectiveFirst = record.ParticipationRecord.EffectiveFirst
+		cached.EffectiveLast = record.ParticipationRecord.EffectiveLast
+		db.cache[id] = cached
+		delete(db.dirty, id)
+	}
 }
 
 func (db *participationDB) Record(account basics.Address, round basics.Round, participationAction ParticipationAction) error {

--- a/data/account/participationRegistry_test.go
+++ b/data/account/participationRegistry_test.go
@@ -273,6 +273,94 @@ func (m testMessage) ToBeHashed() (protocol.HashID, []byte) {
 	return protocol.Message, []byte(m)
 }
 
+// TestParticipation_WriteBackAfterDelete covers the window DeleteExpired and
+// Register leave open: both read a snapshot, compute their update without holding
+// the registry lock, then write it back. A Delete landing in that window must win,
+// since the API removes the key file and the database row and only the cache would
+// keep the secrets, and AccountManager.Keys serves votes straight from the cache.
+// Calling the write-backs directly puts the Delete inside the window without
+// depending on goroutine timing.
+func TestParticipation_WriteBackAfterDelete(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	registry, dbfile := getRegistry(t)
+	defer registryCloseTest(t, registry, dbfile)
+
+	isDirty := func(id ParticipationID) bool {
+		registry.mutex.RLock()
+		defer registry.mutex.RUnlock()
+		_, dirty := registry.dirty[id]
+		return dirty
+	}
+
+	t.Run("DeleteExpired", func(t *testing.T) {
+		a := require.New(t)
+		p := makeTestParticipation(a, 1, 1, 10, 1)
+		id, err := registry.Insert(p)
+		a.NoError(err)
+
+		snapshot := registry.GetAll()
+		a.Len(snapshot, 1)
+
+		a.NoError(registry.Delete(id))
+		a.True(registry.Get(id).IsZero())
+
+		registry.applyVotingTruncation(snapshot)
+		a.True(registry.Get(id).IsZero(), "deleted key was restored to the cache")
+		a.Empty(registry.GetAll())
+		a.False(isDirty(id), "deleted key was marked dirty")
+	})
+
+	t.Run("Register", func(t *testing.T) {
+		a := require.New(t)
+		p := makeTestParticipation(a, 2, 1, 10, 1)
+		id, err := registry.Insert(p)
+		a.NoError(err)
+
+		record := registry.Get(id)
+		a.False(record.IsZero())
+		record.EffectiveFirst = 1
+		record.EffectiveLast = 10
+		update := map[ParticipationID]updatingParticipationRecord{
+			id: {record, true},
+		}
+
+		a.NoError(registry.Delete(id))
+		a.True(registry.Get(id).IsZero())
+
+		registry.applyRegistration(update)
+		a.True(registry.Get(id).IsZero(), "deleted key was restored to the cache")
+		a.Empty(registry.GetAll())
+	})
+
+	// A record still present takes the truncation, and keeps the fields the
+	// write-back does not own: a vote recorded inside the window survives.
+	t.Run("concurrent update", func(t *testing.T) {
+		a := require.New(t)
+		p := makeTestParticipation(a, 3, 1, 10, 1)
+		id, err := registry.Insert(p)
+		a.NoError(err)
+		a.NoError(registry.Register(id, 1))
+
+		snapshot := registry.GetAll()
+		a.Len(snapshot, 1)
+		truncated := snapshot[0]
+		keysBefore := len(truncated.Voting.Offsets) + len(truncated.Voting.Batches)
+		truncated.Voting.DeleteBeforeFineGrained(basics.OneTimeIDForRound(5, truncated.KeyDilution), truncated.KeyDilution)
+		a.Less(len(truncated.Voting.Offsets)+len(truncated.Voting.Batches), keysBefore)
+
+		a.NoError(registry.Record(p.Parent, 4, Vote))
+
+		registry.applyVotingTruncation([]ParticipationRecord{truncated})
+		record := registry.Get(id)
+		a.Equal(basics.Round(4), record.LastVote, "vote recorded in the window was reverted")
+		a.Equal(len(truncated.Voting.Offsets)+len(truncated.Voting.Batches),
+			len(record.Voting.Offsets)+len(record.Voting.Batches), "truncation was not applied")
+		a.True(isDirty(id))
+
+		a.NoError(registry.Delete(id))
+	})
+}
+
 func TestParticipation_DeleteExpired(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	a := require.New(t)
@@ -666,6 +754,8 @@ func TestParticipation_RecordMultipleUpdates_DB(t *testing.T) {
 	a.EqualError(err, ErrMultipleKeysForID.Error())
 
 	// Registering the ID - No error because it is already registered so we don't try to re-register.
+	// Voting must be set: the flush below snapshots it, and the registration write-back
+	// no longer replaces this record wholesale, so nothing else supplies it.
 	registry.cache[id] = ParticipationRecord{
 		ParticipationID: id,
 		Account:         p.Parent,
@@ -674,6 +764,7 @@ func TestParticipation_RecordMultipleUpdates_DB(t *testing.T) {
 		KeyDilution:     p.KeyDilution,
 		EffectiveFirst:  p.FirstValid,
 		EffectiveLast:   p.LastValid,
+		Voting:          &crypto.OneTimeSignatureSecrets{},
 	}
 	err = registry.Register(id, 1)
 	a.NoError(err)

--- a/data/account/participationRegistry_test.go
+++ b/data/account/participationRegistry_test.go
@@ -359,6 +359,39 @@ func TestParticipation_WriteBackAfterDelete(t *testing.T) {
 
 		a.NoError(registry.Delete(id))
 	})
+
+	// A vote recorded inside Register's window has to survive the write-back and
+	// still reach the database: registerOp writes the rolling fields from Register's
+	// snapshot, which predates the vote.
+	t.Run("concurrent update during registration", func(t *testing.T) {
+		a := require.New(t)
+		p := makeTestParticipation(a, 4, 1, 10, 1)
+		id, err := registry.Insert(p)
+		a.NoError(err)
+		a.NoError(registry.Register(id, 1))
+
+		snapshot := registry.Get(id)
+		a.False(snapshot.IsZero())
+		update := map[ParticipationID]updatingParticipationRecord{id: {snapshot, true}}
+
+		a.NoError(registry.Record(p.Parent, 4, Vote))
+
+		registry.applyRegistration(update)
+		a.Equal(basics.Round(4), registry.Get(id).LastVote, "vote recorded in the window was reverted")
+		a.True(isDirty(id), "vote recorded in the window lost its pending flush")
+
+		a.NoError(registry.Flush(defaultTimeout))
+		var lastVote basics.Round
+		err = registry.store.Rdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+			return tx.QueryRow(
+				`SELECT lastVoteRound FROM Rolling WHERE pk IN (SELECT pk FROM Keysets WHERE participationID=?)`,
+				id[:]).Scan(&lastVote)
+		})
+		a.NoError(err)
+		a.Equal(basics.Round(4), lastVote, "vote recorded in the window never reached the database")
+
+		a.NoError(registry.Delete(id))
+	})
 }
 
 func TestParticipation_DeleteExpired(t *testing.T) {

--- a/data/account/participationRegistry_test.go
+++ b/data/account/participationRegistry_test.go
@@ -292,6 +292,25 @@ func TestParticipation_WriteBackAfterDelete(t *testing.T) {
 		return dirty
 	}
 
+	votingKeys := func(v *crypto.OneTimeSignatureSecrets) int {
+		return len(v.Offsets) + len(v.Batches)
+	}
+
+	// votingKeysInDB reads the persisted voting secrets, which is where a resurrected
+	// key would survive a restart.
+	votingKeysInDB := func(a *require.Assertions, id ParticipationID) int {
+		var raw []byte
+		err := registry.store.Rdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+			return tx.QueryRow(
+				`SELECT voting FROM Rolling WHERE pk IN (SELECT pk FROM Keysets WHERE participationID=?)`,
+				id[:]).Scan(&raw)
+		})
+		a.NoError(err)
+		var voting crypto.OneTimeSignatureSecrets
+		a.NoError(protocol.Decode(raw, &voting))
+		return votingKeys(&voting)
+	}
+
 	t.Run("DeleteExpired", func(t *testing.T) {
 		a := require.New(t)
 		p := makeTestParticipation(a, 1, 1, 10, 1)
@@ -389,6 +408,42 @@ func TestParticipation_WriteBackAfterDelete(t *testing.T) {
 		})
 		a.NoError(err)
 		a.Equal(basics.Round(4), lastVote, "vote recorded in the window never reached the database")
+
+		a.NoError(registry.Delete(id))
+	})
+
+	// registerOp carries Register's snapshot, so it must write only the effective
+	// rounds. A truncation and its flush landing between the snapshot and registerOp
+	// reaching the database would otherwise be undone on disk: the cache stays
+	// truncated while the database holds keys a restart would load back.
+	t.Run("stale registration write", func(t *testing.T) {
+		a := require.New(t)
+		p := makeTestParticipation(a, 5, 1, 10, 1)
+		id, err := registry.Insert(p)
+		a.NoError(err)
+		a.NoError(registry.Register(id, 1))
+
+		// the snapshot Register would have taken, before the truncation below
+		stale := registry.Get(id)
+		a.False(stale.IsZero())
+
+		truncated := registry.Get(id)
+		keysBefore := votingKeys(truncated.Voting)
+		truncated.Voting.DeleteBeforeFineGrained(basics.OneTimeIDForRound(5, truncated.KeyDilution), truncated.KeyDilution)
+		keysAfter := votingKeys(truncated.Voting)
+		a.Less(keysAfter, keysBefore)
+
+		registry.applyVotingTruncation([]ParticipationRecord{truncated})
+		a.NoError(registry.Flush(defaultTimeout))
+		a.Equal(keysAfter, votingKeysInDB(a, id))
+
+		// registerOp reaches the database only after that flush
+		registry.writeQueue <- makeOpRequest(&registerOp{
+			updated: map[ParticipationID]updatingParticipationRecord{id: {stale, true}},
+		})
+		a.NoError(registry.Flush(defaultTimeout))
+		a.Equal(keysAfter, votingKeysInDB(a, id), "registration restored truncated voting keys")
+		a.Equal(keysAfter, votingKeys(registry.Get(id).Voting), "cache lost the truncation")
 
 		a.NoError(registry.Delete(id))
 	})

--- a/data/account/registeryDbOps.go
+++ b/data/account/registeryDbOps.go
@@ -104,7 +104,7 @@ func (r *registerOp) apply(db *participationDB) error {
 	err := db.store.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 		// Disable active key if there is one
 		for id, record := range r.updated {
-			err := updateRollingFields(ctx, tx, record.ParticipationRecord)
+			err := updateEffectiveRounds(ctx, tx, record.ParticipationRecord)
 			// Repair the case when no keys were updated
 			if err == ErrNoKeyForID {
 				db.log.Warn("participationDB unable to update key in cache. Removing from cache.")


### PR DESCRIPTION
## Summary
Fixes a race in the participation registry where two snapshot-mutate-write-back sites could resurrect a participation record that a concurrent `Delete` had already removed from the cache. Both write-backs now take the mutex, skip any ID no longer present in `db.cache`, and merge back only the fields their caller actually computed:

- `applyVotingTruncation` (extracted from `DeleteExpired`) writes back only `Voting`, then marks the record dirty.
- `applyRegistration` (extracted from `Register`) writes back only `EffectiveFirst` / `EffectiveLast`, replacing a wholesale overwrite of the cached record.

## Test Plan
Adds `TestParticipation_WriteBackAfterDelete`, and updates `TestParticipation_RecordMultipleUpdates_DB` to pass.