### PR TITLE
tests: fix recent CI flaky tests

### DIFF
--- a/catchup/fetcher_test.go
+++ b/catchup/fetcher_test.go
@@ -71,6 +71,12 @@ func buildTestLedger(t *testing.T, blk bookkeeping.Block) (ledger *data.Ledger, 
 		t.Fatal("couldn't build ledger", err)
 		return
 	}
+	// The ledger's tracker goroutines log through log, which is bound to t: if the
+	// ledger outlives the test, they keep calling t.Log() after the test has
+	// completed. Closing the ledger makes the tracker syncher goroutine to exit.
+	// It is safe to call ledger.Close() in tests as well.
+	t.Cleanup(ledger.Close)
+
 	next = ledger.NextRound()
 	tx := transactions.Transaction{
 		Type: protocol.PaymentTx,

--- a/catchup/fetcher_test.go
+++ b/catchup/fetcher_test.go
@@ -73,7 +73,7 @@ func buildTestLedger(t *testing.T, blk bookkeeping.Block) (ledger *data.Ledger, 
 	}
 	// The ledger's tracker goroutines log through log, which is bound to t: if the
 	// ledger outlives the test, they keep calling t.Log() after the test has
-	// completed. Closing the ledger makes the tracker syncher goroutine to exit.
+	// completed. Closing the ledger makes the tracker syncher goroutine exit.
 	// It is safe to call ledger.Close() in tests as well.
 	t.Cleanup(ledger.Close)
 

--- a/catchup/service_test.go
+++ b/catchup/service_test.go
@@ -592,7 +592,6 @@ func TestOnSwitchToUnSupportedProtocol1(t *testing.T) {
 	// i.e. rounds 1 and 2 may be simultaneously fetched.
 	require.Less(t, int(local.LastRound()), 3)
 	require.Equal(t, lastRoundRemote, int(remote.LastRound()))
-	remote.Ledger.Close()
 }
 
 // Test the interruption in "the rest" loop
@@ -610,7 +609,6 @@ func TestOnSwitchToUnSupportedProtocol2(t *testing.T) {
 	}
 	require.Equal(t, lastRoundLocal, int(local.LastRound()))
 	require.Equal(t, lastRoundRemote, int(remote.LastRound()))
-	remote.Ledger.Close()
 }
 
 // Test the interruption with short notice (less than
@@ -635,7 +633,6 @@ func TestOnSwitchToUnSupportedProtocol3(t *testing.T) {
 	// fetched.
 	require.Less(t, int(local.LastRound()), lastRoundLocal+2)
 	require.Equal(t, lastRoundRemote, int(remote.LastRound()))
-	remote.Ledger.Close()
 }
 
 // Test the interruption with short notice (less than
@@ -668,7 +665,6 @@ func TestOnSwitchToUnSupportedProtocol4(t *testing.T) {
 	// ledger, round 8 will not be fetched.
 	require.Equal(t, int(local.LastRound()), lastRoundLocal)
 	require.Equal(t, lastRoundRemote, int(remote.LastRound()))
-	remote.Ledger.Close()
 }
 
 func helperTestOnSwitchToUnSupportedProtocol(
@@ -923,7 +919,6 @@ func TestCatchupUnmatchedCertificate(t *testing.T) {
 		t.Fatal(err)
 		return
 	}
-	defer remote.Close()
 	addBlocks(t, remote, blk, numBlocks-1)
 
 	// Create a network and block service

--- a/catchup/universalFetcher_test.go
+++ b/catchup/universalFetcher_test.go
@@ -58,6 +58,7 @@ func TestUGetBlockWs(t *testing.T) {
 	up := makeTestUnicastPeer(net, t)
 	ls := rpcs.MakeBlockService(logging.Base(), blockServiceConfig, ledger, net, "test genesisID")
 	ls.Start()
+	defer ls.Stop()
 
 	fetcher := makeUniversalBlockFetcher(logging.TestingLog(t), net, cfg)
 

--- a/catchup/universalFetcher_test.go
+++ b/catchup/universalFetcher_test.go
@@ -188,7 +188,6 @@ func TestRequestBlockBytesErrors(t *testing.T) {
 		t.Fatal(err)
 		return
 	}
-	defer ledger.Ledger.Close()
 
 	blockServiceConfig := config.GetDefaultLocal()
 	blockServiceConfig.EnableBlockService = true

--- a/ledger/applications_test.go
+++ b/ledger/applications_test.go
@@ -46,21 +46,20 @@ func commitRound(offset uint64, dbRound basics.Round, l *Ledger) {
 	commitRoundLookback(l.Latest().SubSaturate(dbRound+basics.Round(offset)), l)
 }
 
+// commitRoundLookback schedules a commit and waits until the tracker db round has
+// actually reached Latest()-lookback.
 func commitRoundLookback(lookback basics.Round, l *Ledger) {
-	l.trackers.mu.Lock()
-	l.trackers.lastFlushTime = time.Time{}
-	l.trackers.mu.Unlock()
-
-	l.trackers.scheduleCommit(l.Latest(), lookback)
-	// wait for the operation to complete. Once it does complete, the tr.lastFlushTime is going to be updated, so we can
-	// use that as an indicator.
+	target := l.Latest().SubSaturate(lookback)
 	for {
 		l.trackers.mu.Lock()
-		isDone := (!l.trackers.lastFlushTime.IsZero()) && (len(l.trackers.deferredCommits) == 0)
+		dbRound := l.trackers.dbRound
+		l.trackers.lastFlushTime = time.Time{} // force a flush
 		l.trackers.mu.Unlock()
-		if isDone {
-			break
+
+		if dbRound >= target {
+			return
 		}
+		l.trackers.scheduleCommit(l.Latest(), lookback)
 		time.Sleep(time.Millisecond)
 	}
 }

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -2481,9 +2481,14 @@ int %d // 10001000
 	}
 
 	commitRoundLookback(basics.Round(cfg.MaxAcctLookback), l)
+	// read dbRound out before asserting: a failing require calls t.FailNow, and running
+	// the deferred l.Close() while still holding trackers.mu deadlocks against the
+	// commitSyncer goroutine that Close waits on.
 	l.trackers.mu.RLock()
-	require.Equal(t, programRound, l.trackers.dbRound+1) // programRound is next to be replayed
+	dbRound := l.trackers.dbRound
 	l.trackers.mu.RUnlock()
+	require.Equal(t, programRound, dbRound+1) // programRound is next to be replayed
+
 	err = l.reloadLedger()
 	require.NoError(t, err)
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -337,7 +337,7 @@ func TestSyncingFullNode(t *testing.T) {
 					}
 				}
 			case <-timer.C:
-				require.Fail(t, fmt.Sprintf("no block notification for account: %d - %v. Iteration: %v", i, wallets[i], tests))
+				require.Fail(t, fmt.Sprintf("no block notification for account: %d - %v. Iteration: %v. Rounds reached: %v", i, wallets[i], tests, nodesLastRounds(nodes)))
 				return
 			}
 		}
@@ -467,8 +467,9 @@ func TestSimpleUpgrade(t *testing.T) {
 					panic(err)
 				}
 				blocks[i] = blk
-			case <-time.After(60 * time.Second):
-				require.Fail(t, fmt.Sprintf("no block notification for account: %v. Iteration: %v", wallets[i], tests))
+			case <-time.After(30*time.Second + 2*expectedAgreementTime):
+				require.Fail(t, fmt.Sprintf("no block notification for account: %v. Iteration: %v. Rounds reached: %v",
+					wallets[i], tests, nodesLastRounds(nodes)))
 				return
 			}
 		}
@@ -499,6 +500,16 @@ func TestSimpleUpgrade(t *testing.T) {
 	}
 
 	require.Equal(t, 2, roundsCheckedForUpgrade)
+}
+
+// nodesLastRounds reports the round each node last committed, so a missing block
+// notification can be told apart from a network that is merely slow.
+func nodesLastRounds(nodes []*AlgorandFullNode) []basics.Round {
+	rounds := make([]basics.Round, len(nodes))
+	for i := range nodes {
+		rounds[i] = nodes[i].ledger.LastRound()
+	}
+	return rounds
 }
 
 const defaultFirstNodeStartDelay = 20 * time.Second

--- a/test/e2e-go/upgrades/application_support_test.go
+++ b/test/e2e-go/upgrades/application_support_test.go
@@ -62,6 +62,10 @@ func makeApplicationUpgradeConsensus(t *testing.T) (appConsensus config.Consensu
 	currentProtocolParams.ApprovedUpgrades = make(map[protocol.ConsensusVersion]uint64)
 	currentProtocolParams.ApprovedUpgrades[consensusTestFastUpgrade(firstProtocolWithApplicationSupport)] = 0
 
+	// terminate the upgrade path at the target version to prevent upgrading further
+	// in order to ensure the upgrade waiting loop not to miss the target version.
+	futureProtocolParams.ApprovedUpgrades = make(map[protocol.ConsensusVersion]uint64)
+
 	appConsensus[consensusTestUnupgradedProtocol] = currentProtocolParams
 	appConsensus[consensusTestFastUpgrade(firstProtocolWithApplicationSupport)] = futureProtocolParams
 

--- a/test/e2e-go/upgrades/rekey_support_test.go
+++ b/test/e2e-go/upgrades/rekey_support_test.go
@@ -146,14 +146,20 @@ func TestRekeyUpgrade(t *testing.T) {
 
 	startLoopTime := time.Now()
 	// wait until the network upgrade : this can take a while.
-	for protocol.ConsensusVersion(curStatus.LastVersion) != consensusTestFastUpgrade(firstProtocolWithApplicationSupport) {
+	// wait for "left the unupgraded protocol" rather than for the target version
+	// itself: the network only stays on any given version for a handful of rounds,
+	// so a test that samples for an exact version can miss it entirely.
+	for protocol.ConsensusVersion(curStatus.LastVersion) == consensusTestUnupgradedProtocol {
 		curStatus, err = client.Status()
 		a.NoError(err)
 
 		a.Less(int64(time.Since(startLoopTime)), int64(3*time.Minute))
 		time.Sleep(time.Duration(smallLambdaMs) * time.Millisecond)
-		round = curStatus.LastRound
 	}
+	// makeApplicationUpgradeConsensus terminates the upgrade path at this version,
+	// which is the first one supporting rekeying.
+	a.Equal(consensusTestFastUpgrade(firstProtocolWithApplicationSupport), protocol.ConsensusVersion(curStatus.LastVersion))
+	round = curStatus.LastRound
 
 	// now that the network already upgraded:
 	tx, err = client.ConstructPayment(accountC, accountD, fee, amount, nil, "", lease, basics.Round(round), basics.Round(round+1000))

--- a/test/e2e-go/upgrades/send_receive_upgrade_test.go
+++ b/test/e2e-go/upgrades/send_receive_upgrade_test.go
@@ -130,7 +130,8 @@ func testAccountsCanSendMoneyAcrossUpgrade(t *testing.T, templatePath string, ta
 		// stop upgrading at targetVersion if the caller specified one.
 		// this allows a test to run assertions against a specific protocol version
 		// without upgrading rest of the newer consensus versions.
-		targetParams := consensus[targetVersion]
+		targetParams, ok := consensus[targetVersion]
+		a.True(ok, "targetVersion %s not in generated consensus", targetVersion)
 		targetParams.ApprovedUpgrades = make(map[protocol.ConsensusVersion]uint64)
 		consensus[targetVersion] = targetParams
 	}

--- a/test/e2e-go/upgrades/send_receive_upgrade_test.go
+++ b/test/e2e-go/upgrades/send_receive_upgrade_test.go
@@ -126,6 +126,14 @@ func testAccountsCanSendMoneyAcrossUpgrade(t *testing.T, templatePath string, ta
 	a := require.New(fixtures.SynchronizedTest(t))
 
 	consensus := generateFastUpgradeConsensus()
+	if targetVersion != "" {
+		// stop upgrading at targetVersion if the caller specified one.
+		// this allows a test to run assertions against a specific protocol version
+		// without upgrading rest of the newer consensus versions.
+		targetParams := consensus[targetVersion]
+		targetParams.ApprovedUpgrades = make(map[protocol.ConsensusVersion]uint64)
+		consensus[targetVersion] = targetParams
+	}
 
 	var fixture fixtures.RestClientFixture
 	fixture.SetConsensus(consensus)


### PR DESCRIPTION
## Summary

1. Fix a ledger closing race in catchup tests - some tests were not closing ledger created by `buildTestLedger` helper. Use `t.Cleanup(ledger.Close)` in `buildTestLedger`
2. Old upgrade integration tests were waiting for specific consensus version but the upgrade chain now extends far after the target version so the waiting loops were missed the condition when the network upgraded past the target. Fixed by terminating upgrade chain on tests' target versions.
3. Give TestSimpleUpgrade the same waiting budget as TestSyncingFullNode
4. Fix TestLedgerReloadTxTailHistoryAccess as seen [here](https://github.com/algorand/go-algorand/actions/runs/33544103124/job/99977255217#step:5:7612): the asserting flakiness (quitting earlier) and the asserting under a lock that caused the deadlock (test suite termination and tracker goroutine hold)

## Test Plan

Existing tests fixes