### PR TITLE
logic: require explicit LogicSig allowances

### DIFF
--- a/PR.md
+++ b/PR.md
@@ -1,0 +1,28 @@
+## Summary
+
+Make sensitive LogicSig operations opt-in starting with AVM v14.
+
+This adds the LogicSig-only `allow F` opcode. An authorization is recorded only when the opcode executes, and applies only to the transaction whose LogicSig is being evaluated. A successful v14+ LogicSig must execute the corresponding authorization for:
+
+- a nonzero `RekeyTo` on any transaction type;
+- a payment with a nonzero `CloseRemainderTo`;
+- an asset transfer with a nonzero `AssetCloseTo`;
+- an asset transfer with a nonzero `AssetSender`, enabling a clawback; and
+- any `KeyRegistration` transaction, including online, offline, and nonparticipating registrations.
+
+For example, a LogicSig that has validated a rekey operation can authorize it with `allow RekeyTo`. If the program returns successfully without executing that opcode, evaluation fails. A program that returns false remains a normal LogicSig rejection, even when the transaction would otherwise require an allowance.
+
+Programs below v14 retain their existing behavior. Allowances are isolated between transactions in a group, and the per-field version metadata allows future authorization kinds to be introduced without making them available to earlier program versions.
+
+## Open questions
+
+Does this protect the right set of operations?
+Requiring an allowance reduces the risk of accidental authorization, at the cost of introducing the risk of accidental rejection when the corresponding `allow` is omitted.
+
+## Test Plan
+
+New tests:
+
+- `data/transactions/logic/eval_test.go` adds `TestLogicSigAllow`, covering every protected operation, v13 compatibility, v14 enforcement, executed-path and transaction-group isolation, independent allowances when a transaction requires more than one, and false program results.
+- `data/transactions/logic/eval_test.go` adds `TestLogicSigAllowOpcode`, covering opcode version gating and invalid immediates.
+- `data/transactions/verify/txn_test.go` adds `TestTxnValidationLogicSigAllow`, which exercises end-to-end transaction verification for both contract-account and delegated LogicSigs, covering rekeying and key registration with and without the required v14 allowances.

--- a/cmd/opdoc/opdoc.go
+++ b/cmd/opdoc/opdoc.go
@@ -36,6 +36,9 @@ import (
 // checked in CI before they are promoted to a released consensus version.
 // Documenting logic.LogicVersion instead would publish vFuture opcodes
 // unconditionally.
+// TODO: When docVersion is bumped to 14, copy authorization.md to the specs
+// opcode includes in data/transactions/logic/Makefile and add the corresponding
+// specs-side include.
 const docVersion = 13
 
 // slug returns the auto generated named anchor "slug" for a given heading

--- a/cmd/opdoc/tmLanguage.go
+++ b/cmd/opdoc/tmLanguage.go
@@ -187,6 +187,11 @@ func buildSyntaxHighlight(version uint64) *tmLanguage {
 		names := logic.OpGroups[grp]
 		sort.Strings(names)
 		switch grp {
+		case "Authorization":
+			keywords.Patterns = append(keywords.Patterns, pattern{
+				Name:  "keyword.other.teal",
+				Match: fmt.Sprintf("^(%s)\\b", strings.Join(names, "|")),
+			})
 		case "Flow Control":
 			keywords.Patterns = append(keywords.Patterns, pattern{
 				Name:  "keyword.control.teal",

--- a/data/transactions/logic/Makefile
+++ b/data/transactions/logic/Makefile
@@ -32,6 +32,6 @@ fields_string.go:	fields.go
 clean:
 	rm -f TEAL_opcodes*.md langspec_v*.json teal.tmLanguage.json fields_string.go \
 	      avm-appendix-a.md avm-stack-types.md constants-*.md \
-	      account-access.md application-access.md arithmetic.md asset-access.md \
+	      account-access.md application-access.md arithmetic.md asset-access.md authorization.md \
 	      block-access.md box-access.md byte-array-*.md cryptography.md \
 	      flow-control.md inner-transactions.md loading-values.md

--- a/data/transactions/logic/assembler_test.go
+++ b/data/transactions/logic/assembler_test.go
@@ -443,6 +443,10 @@ pushbytes 0x0123
 sumhash512
 `
 
+const allowNonsense = `
+allow RekeyTo
+`
+
 const sha512Nonsense = `
 pushbytes 0x0123
 sha512
@@ -475,8 +479,9 @@ const v12Nonsense = v11Nonsense + fvNonsense
 
 const v13Nonsense = v12Nonsense + sha512Nonsense + poseidon2Nonsense + foreignBoxNonsense
 
-// sumhash512 is experimental, held back to v14 while v13 is released.
-const v14Nonsense = v13Nonsense + sumhashNonsense
+// LogicSig allowances are part of v14. sumhash512 is experimental at v14
+// and should move with sumhashVersion if it is not promoted.
+const v14Nonsense = v13Nonsense + sumhashNonsense + allowNonsense
 
 const foreignBoxNonsense = `
 pushint 1
@@ -519,6 +524,7 @@ const fvCompiled = "8002abcd494985"
 const v12Compiled = v11Compiled + fvCompiled
 
 const sumhashCompiled = "8002012386"
+const allowCompiled = "c700"
 const sha512Compiled = "8002012387"
 const poseidon2Compiled = "802011223344556677889900aabbccddeeff11223344556677889900aabbccddeeffe700"
 const foreignBoxCompiled = "8101760bd401d402d403d404d405d406d407d408d409"
@@ -533,8 +539,8 @@ const v13BaseCompiled = "2004010002b7a60c26050242420c68656c6c6f20776f726c6421070
 const v13Compiled = v13BaseCompiled + sha512Compiled + poseidon2Compiled + foreignBoxCompiled
 
 // v14 adds no encoding changes over v13, so its base is v13's program with the
-// experimental sumhash512 opcode (held back from the v13 release) appended.
-const v14Compiled = v13Compiled + sumhashCompiled
+// experimental v14 opcodes appended.
+const v14Compiled = v13Compiled + sumhashCompiled + allowCompiled
 
 var nonsense = map[uint64]string{
 	1:  v1Nonsense,

--- a/data/transactions/logic/doc.go
+++ b/data/transactions/logic/doc.go
@@ -162,6 +162,12 @@ var opDescByName = map[string]OpDesc{
 	"arg_2": {"LogicSig argument 2", "", nil, ""},
 	"arg_3": {"LogicSig argument 3", "", nil, ""},
 	"args":  {"Ath LogicSig argument", "", nil, ""},
+	"allow": {
+		"authorize the current LogicSig to perform sensitive transaction operation F",
+		"Authorization takes effect only when `allow` executes and applies only to the current transaction. " +
+			"In v14+, the protected fields and any `KeyRegistration` transaction require corresponding authorization.",
+		[]string{"LogicSig allowance index"}, "",
+	},
 
 	"txn": {"field F of current transaction", "", []string{"transaction field index"}, ""},
 	"gtxn": {
@@ -382,6 +388,7 @@ var OpGroups = map[string][]string{
 	"Byte Array Logic":        {"b|", "b&", "b^", "b~"},
 	"Cryptography":            {"sha256", "keccak256", "sha512_256", "sha3_256", "sha512", "sumhash512", "falcon_verify", "ed25519verify", "ed25519verify_bare", "ecdsa_verify", "ecdsa_pk_recover", "ecdsa_pk_decompress", "vrf_verify", "ec_add", "ec_scalar_mul", "ec_pairing_check", "ec_multi_scalar_mul", "ec_subgroup_check", "ec_map_to", "mimc", "poseidon2"},
 	"Loading Values":          {"intcblock", "intc", "intc_0", "intc_1", "intc_2", "intc_3", "pushint", "pushints", "bytecblock", "bytec", "bytec_0", "bytec_1", "bytec_2", "bytec_3", "pushbytes", "pushbytess", "bzero", "arg", "arg_0", "arg_1", "arg_2", "arg_3", "args", "txn", "gtxn", "txna", "txnas", "gtxna", "gtxnas", "gtxns", "gtxnsa", "gtxnsas", "global", "load", "loads", "store", "stores", "gload", "gloads", "gloadss", "gaid", "gaids"},
+	"Authorization":           {"allow"},
 	"Flow Control":            {"err", "bnz", "bz", "b", "return", "pop", "popn", "dup", "dup2", "dupn", "dig", "bury", "cover", "uncover", "frame_dig", "frame_bury", "swap", "select", "assert", "callsub", "proto", "retsub", "switch", "match"},
 	"Block Access":            {"online_stake", "log", "block"},
 	"Account Access":          {"balance", "min_balance", "acct_params_get", "voter_params_get"},

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -737,8 +737,9 @@ type EvalContext struct {
 	version uint64
 	Scratch scratchSpace
 
-	// logicSigAllowances records sensitive transaction operations authorized by
-	// allow opcodes that were executed on the successful LogicSig path.
+	// logicSigAllowances is a bitset of sensitive transaction operations authorized
+	// by executed allow opcodes. Bit n corresponds to the LogicSig allowance whose
+	// immediate field index is n.
 	logicSigAllowances uint64
 
 	// creatorAddr caches the creator of appID, looked up lazily by

--- a/data/transactions/logic/eval.go
+++ b/data/transactions/logic/eval.go
@@ -737,6 +737,10 @@ type EvalContext struct {
 	version uint64
 	Scratch scratchSpace
 
+	// logicSigAllowances records sensitive transaction operations authorized by
+	// allow opcodes that were executed on the successful LogicSig path.
+	logicSigAllowances uint64
+
 	// creatorAddr caches the creator of appID, looked up lazily by
 	// getCreatorAddress (a zero value means "not yet looked up"). Besides
 	// backing the `global CreatorAddress` op, it is used to decide family
@@ -1527,7 +1531,53 @@ func eval(program []byte, cx *EvalContext) (pass bool, err error) {
 		return false, errors.New("stack finished with bytes not int")
 	}
 
-	return cx.Stack[0].Uint != 0, nil
+	if cx.Stack[0].Uint == 0 {
+		return false, nil
+	}
+	if cx.runMode == ModeSig && cx.version >= logicSigAllowVersion {
+		if err := cx.checkLogicSigAllowances(); err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func (cx *EvalContext) checkLogicSigAllowances() error {
+	txn := &cx.txn.Txn
+	var required uint64
+
+	if !txn.RekeyTo.IsZero() {
+		required |= uint64(1) << uint(allowRekeyTo)
+	}
+
+	switch txn.Type {
+	case protocol.PaymentTx:
+		if !txn.CloseRemainderTo.IsZero() {
+			required |= uint64(1) << uint(allowCloseRemainderTo)
+		}
+	case protocol.AssetTransferTx:
+		if !txn.AssetCloseTo.IsZero() {
+			required |= uint64(1) << uint(allowAssetCloseTo)
+		}
+		if !txn.AssetSender.IsZero() {
+			required |= uint64(1) << uint(allowAssetSender)
+		}
+	case protocol.KeyRegistrationTx:
+		required |= uint64(1) << uint(allowKeyRegistration)
+	}
+
+	missing := required &^ cx.logicSigAllowances
+	for field := logicSigAllowance(0); field < invalidLogicSigAllowance; field++ {
+		if missing&(uint64(1)<<uint(field)) != 0 {
+			fs, _ := logicSigAllowanceSpecByField(field)
+			if fs.version > cx.version {
+				continue
+			}
+			return fmt.Errorf("transaction %s %s requires `allow %s`", fs.kind, fs.name, fs.name)
+		}
+	}
+	return nil
 }
 
 // CheckContract should be faster than EvalContract.  It can perform
@@ -1899,6 +1949,16 @@ func (cx *EvalContext) ensureStackCap(targetCap int) error {
 
 func opErr(cx *EvalContext) error {
 	return errors.New("err opcode executed")
+}
+
+func opAllow(cx *EvalContext) error {
+	field := logicSigAllowance(cx.program[cx.pc+1])
+	fs, ok := logicSigAllowanceSpecByField(field)
+	if !ok || fs.version > cx.version {
+		return fmt.Errorf("invalid allow field %s", field)
+	}
+	cx.logicSigAllowances |= uint64(1) << uint(field)
+	return nil
 }
 
 func opReturn(cx *EvalContext) error {

--- a/data/transactions/logic/evalStateful_test.go
+++ b/data/transactions/logic/evalStateful_test.go
@@ -268,7 +268,8 @@ txna Accounts 0
 gtxna 0 ApplicationArgs 0
 ==
 `
-	opcodesRunModeSignature := `arg_0
+	opcodesRunModeSignature := `allow RekeyTo
+arg_0
 arg_1
 !=
 arg_2
@@ -403,13 +404,14 @@ log
 			"not allowed in current mode", "not allowed in current mode")
 	}
 
-	// check that arg is not allowed in stateful mode beyond v5
+	// check that signature-only opcodes are not allowed in stateful mode
 	disallowed := []string{
 		"arg 0",
 		"arg_0",
 		"arg_1",
 		"arg_2",
 		"arg_3",
+		"allow RekeyTo",
 	}
 	for _, source := range disallowed {
 		ops := testProg(t, source, AssemblerMaxVersion)
@@ -3479,6 +3481,7 @@ func TestReturnTypes(t *testing.T) {
 
 				tx0 := makeSampleTxn()
 				tx0.Txn.Type = protocol.ApplicationCallTx
+				tx0.Txn.RekeyTo = basics.Address{}
 				tx0.Txn.ApplicationID = 300
 				tx0.Txn.ForeignApps = []basics.AppIndex{300}
 				tx0.Txn.ForeignAssets = []basics.AssetIndex{400}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -434,6 +434,190 @@ func TestWrongProtoVersion(t *testing.T) {
 	}
 }
 
+func TestLogicSigAllow(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	protected := []struct {
+		name    string
+		txnType protocol.TxType
+		set     func(*transactions.Transaction)
+	}{
+		{"RekeyTo", protocol.ApplicationCallTx, func(txn *transactions.Transaction) { txn.RekeyTo = basics.Address{1} }},
+		{"CloseRemainderTo", protocol.PaymentTx, func(txn *transactions.Transaction) { txn.CloseRemainderTo = basics.Address{1} }},
+		{"AssetCloseTo", protocol.AssetTransferTx, func(txn *transactions.Transaction) { txn.AssetCloseTo = basics.Address{1} }},
+		{"AssetSender", protocol.AssetTransferTx, func(txn *transactions.Transaction) { txn.AssetSender = basics.Address{1} }},
+	}
+
+	for _, tc := range protected {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var txn transactions.SignedTxn
+			txn.Txn.Type = tc.txnType
+			tc.set(&txn.Txn)
+
+			// Existing LogicSigs retain their historical behavior.
+			testLogic(t, "int 1", logicSigAllowVersion-1, defaultSigParams(txn))
+
+			errText := fmt.Sprintf("transaction field %s requires `allow %s`", tc.name, tc.name)
+			// A v14+ LogicSig fails without the corresponding `allow`.
+			testLogic(t, "int 1", logicSigAllowVersion, defaultSigParams(txn), errText)
+			// A v14+ LogicSig succeeds with the corresponding `allow`.
+			testLogic(t, "allow "+tc.name+"; int 1", logicSigAllowVersion, defaultSigParams(txn))
+			// Repeated `allow` is ok.
+			testLogic(t, "allow "+tc.name+"; allow "+tc.name+"; int 1", logicSigAllowVersion, defaultSigParams(txn))
+		})
+	}
+
+	// Every key registration form changes persistent participation state.
+	t.Run("KeyRegistration", func(t *testing.T) {
+		t.Parallel()
+		forms := []struct {
+			name string
+			set  func(*transactions.Transaction)
+		}{
+			{"Offline", func(*transactions.Transaction) {}},
+			{"Online", func(txn *transactions.Transaction) {
+				txn.VotePK[0] = 1
+				txn.SelectionPK[0] = 1
+				txn.StateProofPK[0] = 1
+				txn.VoteFirst = 1
+				txn.VoteLast = 2
+				txn.VoteKeyDilution = 1
+			}},
+			{"Nonparticipating", func(txn *transactions.Transaction) { txn.Nonparticipation = true }},
+		}
+
+		for _, form := range forms {
+			t.Run(form.name, func(t *testing.T) {
+				t.Parallel()
+				var txn transactions.SignedTxn
+				txn.Txn.Type = protocol.KeyRegistrationTx
+				form.set(&txn.Txn)
+
+				testLogic(t, "int 1", logicSigAllowVersion-1, defaultSigParams(txn))
+				testLogic(t, "int 1", logicSigAllowVersion, defaultSigParams(txn),
+					"transaction type KeyRegistration requires `allow KeyRegistration`")
+				testLogic(t, "allow KeyRegistration; int 1", logicSigAllowVersion, defaultSigParams(txn))
+			})
+		}
+
+		t.Run("WithRekey", func(t *testing.T) {
+			t.Parallel()
+			var txn transactions.SignedTxn
+			txn.Txn.Type = protocol.KeyRegistrationTx
+			txn.Txn.RekeyTo = basics.Address{1}
+
+			testLogic(t, "allow KeyRegistration; int 1", logicSigAllowVersion, defaultSigParams(txn),
+				"transaction field RekeyTo requires `allow RekeyTo`")
+			testLogic(t, "allow RekeyTo; int 1", logicSigAllowVersion, defaultSigParams(txn),
+				"transaction type KeyRegistration requires `allow KeyRegistration`")
+			testLogic(t, "allow RekeyTo; allow KeyRegistration; int 1", logicSigAllowVersion, defaultSigParams(txn))
+		})
+	})
+
+	// Multiple allowances work together.
+	t.Run("Multiple", func(t *testing.T) {
+		t.Parallel()
+		var txn transactions.SignedTxn
+		txn.Txn.Type = protocol.PaymentTx
+		txn.Txn.RekeyTo = basics.Address{1}
+		txn.Txn.CloseRemainderTo = basics.Address{2}
+
+		testLogic(t, "allow RekeyTo; int 1", logicSigAllowVersion, defaultSigParams(txn),
+			"transaction field CloseRemainderTo requires `allow CloseRemainderTo`")
+		testLogic(t, "allow RekeyTo; allow CloseRemainderTo; int 1", logicSigAllowVersion, defaultSigParams(txn))
+	})
+
+	// AssetCloseTo and AssetSender require independent allowances.
+	t.Run("MultipleAssetTransfer", func(t *testing.T) {
+		t.Parallel()
+		var txn transactions.SignedTxn
+		txn.Txn.Type = protocol.AssetTransferTx
+		txn.Txn.AssetCloseTo = basics.Address{1}
+		txn.Txn.AssetSender = basics.Address{2}
+
+		testLogic(t, "allow AssetCloseTo; int 1", logicSigAllowVersion, defaultSigParams(txn),
+			"transaction field AssetSender requires `allow AssetSender`")
+		testLogic(t, "allow AssetCloseTo; allow AssetSender; int 1", logicSigAllowVersion, defaultSigParams(txn))
+	})
+
+	// `allow` must be executed to be effective.
+	t.Run("ExecutedPath", func(t *testing.T) {
+		t.Parallel()
+		var txn transactions.SignedTxn
+		txn.Txn.Type = protocol.PaymentTx
+		txn.Txn.RekeyTo = basics.Address{1}
+
+		testLogic(t, "int 0; bnz skip; allow RekeyTo; skip: int 1", logicSigAllowVersion, defaultSigParams(txn))
+		testLogic(t, "int 1; bnz skip; allow RekeyTo; skip: int 1", logicSigAllowVersion, defaultSigParams(txn),
+			"transaction field RekeyTo requires `allow RekeyTo`")
+	})
+
+	// A program rejection takes precedence over a missing allowance.
+	t.Run("RejectBeforeAllowanceCheck", func(t *testing.T) {
+		t.Parallel()
+		var txn transactions.SignedTxn
+		txn.Txn.Type = protocol.PaymentTx
+		txn.Txn.RekeyTo = basics.Address{1}
+
+		program := testProg(t, "int 0", logicSigAllowVersion).Program
+		err := testLogicFull(t, program, 0, defaultSigParams(txn), "REJECT")
+		require.NoError(t, err)
+	})
+
+	// `allow` only affects its own transaction.
+	t.Run("GroupIsolation", func(t *testing.T) {
+		t.Parallel()
+		txns := make([]transactions.SignedTxn, 2)
+		for i := range txns {
+			txns[i].Txn.Type = protocol.PaymentTx
+			txns[i].Txn.RekeyTo = basics.Address{byte(i + 1)}
+		}
+		testLogics(t, []string{"allow RekeyTo; int 1", "int 1"}, txns, nil,
+			exp(1, "transaction field RekeyTo requires `allow RekeyTo`"))
+	})
+
+	// Zero-valued protected fields do not require `allow`.
+	t.Run("ZeroFields", func(t *testing.T) {
+		t.Parallel()
+		var txn transactions.SignedTxn
+		txn.Txn.Type = protocol.PaymentTx
+		testLogic(t, "int 1", logicSigAllowVersion, defaultSigParams(txn))
+	})
+}
+
+func TestLogicSigAllowOpcode(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	for _, fs := range logicSigAllowanceSpecs {
+		source := "allow " + fs.name + "; int 1"
+		ops := testProg(t, source, fs.version)
+		previousVersion := fs.version - 1
+		if fs.version == logicSigAllowVersion {
+			testProg(t, source, previousVersion, exp(1, "allow opcode was introduced in v14"))
+		} else {
+			testProg(t, source, previousVersion, exp(1,
+				fmt.Sprintf("...allow %s field was introduced in v%d...", fs.name, fs.version)))
+			ops.Program[0] = byte(previousVersion)
+			testLogicBytes(t, ops.Program, defaultSigParamsWithVersion(previousVersion), "invalid allow field")
+		}
+	}
+	testProg(t, "allow Unknown; int 1", logicSigAllowVersion, exp(1, "allow unknown field..."))
+
+	op := OpsByName[logicSigAllowVersion]["allow"]
+	truncatedProgram := []byte{byte(logicSigAllowVersion), op.Opcode}
+	testLogicBytes(t, truncatedProgram, defaultSigParams(),
+		"program ends without immediate value", "program ends without immediate value")
+
+	program := testProg(t, "allow RekeyTo; int 1", logicSigAllowVersion).Program
+	require.Equal(t, op.Opcode, program[1])
+	require.Equal(t, byte(allowRekeyTo), program[2])
+	program[2] = byte(invalidLogicSigAllowance)
+	testLogicBytes(t, program, defaultSigParams(), "invalid allow field")
+}
+
 // TestBlankStackSufficient will fail if an opcode is added with more than the
 // current max number of stack arguments. Update `blankStack` to be longer.
 func TestBlankStackSufficient(t *testing.T) {
@@ -597,7 +781,11 @@ func TestTLHC(t *testing.T) {
 			a1, _ := basics.UnmarshalChecksumAddress("DFPKC2SJP3OTFVJFMCD356YB7BOT4SJZTGWLIPPFEWL3ZABUFLTOY6ILYE")
 			a2, _ := basics.UnmarshalChecksumAddress("YYKRMERAFXMXCDWMBNR6BUUWQXDCUR53FPUGXLUYS7VNASRTJW2ENQ7BMQ")
 			secret, _ := base64.StdEncoding.DecodeString("xPUB+DJir1wsH7g2iEY1QwYqHqYH1vUJtzZKW4RxXsY=")
-			ops := testProg(t, tlhcProgramText, v)
+			source := tlhcProgramText
+			if v >= logicSigAllowVersion {
+				source = "allow CloseRemainderTo\n" + source
+			}
+			ops := testProg(t, source, v)
 			var txn transactions.SignedTxn
 			txn.Lsig.Logic = ops.Program
 			// right answer
@@ -1382,6 +1570,10 @@ txn TypeEnum
 int %s
 ==
 &&`, symbol, string(tt))
+					// A successful v14+ keyreg LogicSig must authorize the transaction type.
+					if v >= logicSigAllowVersion && tt == protocol.KeyRegistrationTx {
+						text += "\nallow KeyRegistration"
+					}
 					ops := testProg(t, text, v)
 					txn := transactions.SignedTxn{}
 					txn.Txn.Type = tt
@@ -1835,8 +2027,8 @@ const testTxnProgramTextV13 = testTxnProgramTextV12 + `
 assert
 int 1`
 
-// v14 adds no new txn fields.
-const testTxnProgramTextV14 = testTxnProgramTextV13
+// v14 LogicSigs must explicitly authorize a nonzero RekeyTo.
+const testTxnProgramTextV14 = "allow RekeyTo\n" + testTxnProgramTextV13
 
 func makeSampleTxn() transactions.SignedTxn {
 	var txn transactions.SignedTxn
@@ -2309,7 +2501,14 @@ func testLogicsWithAssembler(t *testing.T, programs []string, txgroup []transact
 
 	if txgroup == nil {
 		for range programs {
-			txgroup = append(txgroup, makeSampleTxn())
+			txn := makeSampleTxn()
+			// Generic LogicSig tests use the richly populated sample transaction
+			// for field access, but are not exercising sensitive operations. Clear
+			// protected fields rather than changing the supplied programs, whose
+			// exact bytecode and cost may be part of the test.
+			txn.Txn.RekeyTo = basics.Address{}
+			txn.Txn.CloseRemainderTo = basics.Address{}
+			txgroup = append(txgroup, txn)
 		}
 	}
 	// Place the logicsig code first, so NewSigEvalParams calcs budget
@@ -4510,6 +4709,7 @@ func TestAnyRekeyToOrApplicationRaisesMinAvmVersion(t *testing.T) {
 	txn0 := makeSampleTxn()
 	txn0.Txn.Type = protocol.PaymentTx
 	txn0.Txn.RekeyTo = basics.Address{}
+	txn0.Txn.CloseRemainderTo = basics.Address{}
 	txn1 := txn0
 	txngroup0 := []transactions.SignedTxn{txn0, txn1}
 
@@ -4517,6 +4717,7 @@ func TestAnyRekeyToOrApplicationRaisesMinAvmVersion(t *testing.T) {
 	txn2 := makeSampleTxn()
 	txn2.Txn.Type = protocol.PaymentTx
 	txn2.Txn.RekeyTo = basics.Address{}
+	txn2.Txn.CloseRemainderTo = basics.Address{}
 	txn3 := txn2
 	txn3.Txn.Type = protocol.ApplicationCallTx
 	txngroup1 := []transactions.SignedTxn{txn2, txn3}
@@ -4524,6 +4725,7 @@ func TestAnyRekeyToOrApplicationRaisesMinAvmVersion(t *testing.T) {
 	// Construct a group of one payment, one rekeying payment
 	txn4 := makeSampleTxn()
 	txn4.Txn.Type = protocol.PaymentTx
+	txn4.Txn.CloseRemainderTo = basics.Address{}
 	txn5 := txn4
 	txn4.Txn.RekeyTo = basics.Address{}
 	txn5.Txn.RekeyTo = basics.Address{1}

--- a/data/transactions/logic/fields.go
+++ b/data/transactions/logic/fields.go
@@ -1127,6 +1127,86 @@ var JSONRefTypes = FieldGroup{
 	jsonRefSpecByName,
 }
 
+// logicSigAllowance identifies a sensitive transaction operation that a
+// LogicSig may explicitly authorize with the allow opcode.
+type logicSigAllowance int
+
+const (
+	allowRekeyTo logicSigAllowance = iota
+	allowCloseRemainderTo
+	allowAssetCloseTo
+	allowAssetSender
+	allowKeyRegistration
+	invalidLogicSigAllowance
+)
+
+var logicSigAllowanceNames [invalidLogicSigAllowance]string
+
+type logicSigAllowanceSpec struct {
+	field   logicSigAllowance
+	version uint64
+	name    string
+	kind    string
+	doc     string
+}
+
+func (fs logicSigAllowanceSpec) Field() byte {
+	return byte(fs.field)
+}
+func (fs logicSigAllowanceSpec) Type() StackType {
+	return StackNone
+}
+func (fs logicSigAllowanceSpec) OpVersion() uint64 {
+	return logicSigAllowVersion
+}
+func (fs logicSigAllowanceSpec) Version() uint64 {
+	return fs.version
+}
+func (fs logicSigAllowanceSpec) Note() string {
+	return fs.doc
+}
+func (fs logicSigAllowanceSpec) Modes() RunMode {
+	return ModeSig
+}
+
+var logicSigAllowanceSpecs = [...]logicSigAllowanceSpec{
+	{allowRekeyTo, logicSigAllowVersion, "RekeyTo", "field", "Permit a nonzero RekeyTo field to change the transaction sender's authorizer"},
+	{allowCloseRemainderTo, logicSigAllowVersion, "CloseRemainderTo", "field", "Permit a payment to close the sender's remaining Algo balance"},
+	{allowAssetCloseTo, logicSigAllowVersion, "AssetCloseTo", "field", "Permit an asset transfer to close the sender's asset holding"},
+	{allowAssetSender, logicSigAllowVersion, "AssetSender", "field", "Permit a nonzero AssetSender field, enabling an asset clawback"},
+	{allowKeyRegistration, logicSigAllowVersion, "KeyRegistration", "type", "Permit a key registration transaction to change the sender's participation status or consensus keys"},
+}
+
+func logicSigAllowanceSpecByField(field logicSigAllowance) (logicSigAllowanceSpec, bool) {
+	if field < 0 || int(field) >= len(logicSigAllowanceSpecs) {
+		return logicSigAllowanceSpec{}, false
+	}
+	return logicSigAllowanceSpecs[field], true
+}
+
+func (field logicSigAllowance) String() string {
+	if fs, ok := logicSigAllowanceSpecByField(field); ok {
+		return fs.name
+	}
+	return fmt.Sprintf("logicSigAllowance(%d)", field)
+}
+
+var logicSigAllowanceSpecByName = make(logicSigAllowanceNameSpecMap, len(logicSigAllowanceNames))
+
+type logicSigAllowanceNameSpecMap map[string]logicSigAllowanceSpec
+
+func (s logicSigAllowanceNameSpecMap) get(name string) (FieldSpec, bool) {
+	fs, ok := s[name]
+	return fs, ok
+}
+
+// LogicSigAllowanceFields describes the immediate constants accepted by allow.
+var LogicSigAllowanceFields = FieldGroup{
+	"LogicSig", "Allowances",
+	logicSigAllowanceNames[:],
+	logicSigAllowanceSpecByName,
+}
+
 // VrfStandard is an enum for the `vrf_verify` opcode
 type VrfStandard int
 
@@ -1894,6 +1974,16 @@ func init() {
 		equal(int(s.field), i)
 		jsonRefTypeNames[i] = s.field.String()
 		jsonRefSpecByName[s.field.String()] = s
+	}
+
+	equal(len(logicSigAllowanceSpecs), len(logicSigAllowanceNames))
+	if invalidLogicSigAllowance > 64 {
+		panic("too many LogicSig allowances for allowance bitset")
+	}
+	for i, s := range logicSigAllowanceSpecs {
+		equal(int(s.field), i)
+		logicSigAllowanceNames[s.field] = s.name
+		logicSigAllowanceSpecByName[s.name] = s
 	}
 
 	equal(len(vrfStandardSpecs), len(vrfStandardNames))

--- a/data/transactions/logic/opcodes.go
+++ b/data/transactions/logic/opcodes.go
@@ -82,6 +82,10 @@ const varintBranchVersion = 13 // branch offsets encoded as binary.Varint instea
 const poseidon2Version = 13
 const foreignBoxVersion = 13 // app_params_set, foreign app box access
 
+// logicSigAllowVersion is the first version in which LogicSigs must explicitly
+// authorize sensitive transaction operations with the allow opcode.
+const logicSigAllowVersion = 14
+
 // EXPERIMENTAL. These should be revisited whenever a new LogicSigVersion is
 // moved from vFuture to a new consensus version. If they remain unready, bump
 // their version, and fixup TestAssemble() in assembler_test.go.
@@ -781,6 +785,7 @@ var OpSpecs = []OpSpec{
 	{0xc4, "gloadss", opGloadss, proto("ii:a"), 6, only(ModeApp)},
 	{0xc5, "itxnas", opItxnas, proto("i:a"), 6, field("f", &TxnArrayFields).only(ModeApp)},
 	{0xc6, "gitxnas", opGitxnas, proto("i:a"), 6, immediates("t", "f").field("f", &TxnArrayFields).only(ModeApp)},
+	{0xc7, "allow", opAllow, proto(":"), logicSigAllowVersion, field("f", &LogicSigAllowanceFields).only(ModeSig)},
 
 	// randomness support
 	{0xd0, "vrf_verify", opVrfVerify, proto("bb{80}b{32}:b{64}T"), randomnessVersion, field("s", &VrfStandards).costs(5700)},

--- a/data/transactions/logic/teal.tmLanguage.json
+++ b/data/transactions/logic/teal.tmLanguage.json
@@ -63,6 +63,10 @@
           }
         },
         {
+          "name": "keyword.other.teal",
+          "match": "^(allow)\\b"
+        },
+        {
           "name": "keyword.control.teal",
           "match": "^(assert|b|bnz|bury|bz|callsub|cover|dig|dup|dup2|dupn|err|frame_bury|frame_dig|match|pop|popn|proto|retsub|return|select|swap|switch|uncover)\\b"
         },

--- a/data/transactions/verify/txn_test.go
+++ b/data/transactions/verify/txn_test.go
@@ -623,6 +623,85 @@ func TestTxnValidationPQDelegatedLogicSigSignsRawProgram(t *testing.T) {
 	require.ErrorContains(t, err, "invalid falcon-1024 signature")
 }
 
+func TestTxnValidationLogicSigAllow(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	proto := config.Consensus[protocol.ConsensusFuture]
+	blkHdr := createDummyBlockHeader(protocol.ConsensusFuture)
+	dummyLedger := DummyLedgerForSignature{}
+
+	makeLogicSigTxn := func(t *testing.T, source string, version uint64, delegated bool) transactions.SignedTxn {
+		t.Helper()
+
+		ops, err := logic.AssembleStringWithVersion(source, version)
+		require.NoError(t, err)
+
+		var sender basics.Address
+		var sig crypto.Signature
+		if delegated {
+			secrets := keypair()
+			sender = basics.Address(secrets.SignatureVerifier)
+			sig = secrets.Sign(logic.Program(ops.Program))
+		} else {
+			sender = basics.Address(logic.HashProgram(ops.Program))
+		}
+
+		txn := createPayTransaction(proto.MinTxnFee, 40, 60, 1, sender, basics.Address{1})
+		txn.RekeyTo = basics.Address{2}
+		return transactions.SignedTxn{
+			Txn: txn,
+			Lsig: transactions.LogicSig{
+				Logic: ops.Program,
+				Sig:   sig,
+			},
+		}
+	}
+	makeKeyregLogicSigTxn := func(t *testing.T, source string, version uint64, delegated bool) transactions.SignedTxn {
+		t.Helper()
+		stxn := makeLogicSigTxn(t, source, version, delegated)
+		stxn.Txn.Type = protocol.KeyRegistrationTx
+		stxn.Txn.RekeyTo = basics.Address{}
+		stxn.Txn.PaymentTxnFields = transactions.PaymentTxnFields{}
+		return stxn
+	}
+
+	for _, delegated := range []bool{false, true} {
+		name := "contract"
+		if delegated {
+			name = "delegated"
+		}
+		t.Run(name, func(t *testing.T) {
+			// Programs from before v14 retain their historical behavior.
+			stxn := makeLogicSigTxn(t, "int 1", 13, delegated)
+			_, err := TxnGroup([]transactions.SignedTxn{stxn}, &blkHdr, nil, &dummyLedger)
+			require.NoError(t, err)
+
+			stxn = makeLogicSigTxn(t, "int 1", proto.LogicSigVersion, delegated)
+			_, err = TxnGroup([]transactions.SignedTxn{stxn}, &blkHdr, nil, &dummyLedger)
+			requireTxGroupErrorReason(t, err, TxGroupErrorReasonLogicSigFailed)
+			require.ErrorContains(t, err, "transaction field RekeyTo requires `allow RekeyTo`")
+
+			stxn = makeLogicSigTxn(t, "allow RekeyTo; int 1", proto.LogicSigVersion, delegated)
+			_, err = TxnGroup([]transactions.SignedTxn{stxn}, &blkHdr, nil, &dummyLedger)
+			require.NoError(t, err)
+
+			// Key registration requires a transaction-level allowance.
+			stxn = makeKeyregLogicSigTxn(t, "int 1", 13, delegated)
+			_, err = TxnGroup([]transactions.SignedTxn{stxn}, &blkHdr, nil, &dummyLedger)
+			require.NoError(t, err)
+
+			stxn = makeKeyregLogicSigTxn(t, "int 1", proto.LogicSigVersion, delegated)
+			_, err = TxnGroup([]transactions.SignedTxn{stxn}, &blkHdr, nil, &dummyLedger)
+			requireTxGroupErrorReason(t, err, TxGroupErrorReasonLogicSigFailed)
+			require.ErrorContains(t, err, "transaction type KeyRegistration requires `allow KeyRegistration`")
+
+			stxn = makeKeyregLogicSigTxn(t, "allow KeyRegistration; int 1", proto.LogicSigVersion, delegated)
+			_, err = TxnGroup([]transactions.SignedTxn{stxn}, &blkHdr, nil, &dummyLedger)
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestTxnValidationEmptySig(t *testing.T) {
 	partitiontest.PartitionTest(t)
 


### PR DESCRIPTION
## Summary

Make sensitive LogicSig operations opt-in starting with AVM v14.

This adds the LogicSig-only `allow F` opcode. An authorization is recorded only when the opcode executes, and applies only to the transaction whose LogicSig is being evaluated. A successful v14+ LogicSig must execute the corresponding authorization for:

- a nonzero `RekeyTo` on any transaction type;
- a payment with a nonzero `CloseRemainderTo`;
- an asset transfer with a nonzero `AssetCloseTo`;
- an asset transfer with a nonzero `AssetSender`, enabling a clawback; and
- any `KeyRegistration` transaction, including online, offline, and nonparticipating registrations.

For example, a LogicSig that has validated a rekey operation can authorize it with `allow RekeyTo`. If the program returns successfully without executing that opcode, evaluation fails. A program that returns false remains a normal LogicSig rejection, even when the transaction would otherwise require an allowance.

Programs below v14 retain their existing behavior. Allowances are isolated between transactions in a group, and the per-field version metadata allows future authorization kinds to be introduced without making them available to earlier program versions.

## Open questions

Does this protect the right set of operations?
Requiring an allowance reduces the risk of accidental authorization, at the cost of introducing the risk of accidental rejection when the corresponding `allow` is omitted.

## Test Plan

New tests:

- `data/transactions/logic/eval_test.go` adds `TestLogicSigAllow`, covering every protected operation, v13 compatibility, v14 enforcement, executed-path and transaction-group isolation, independent allowances when a transaction requires more than one, and false program results.
- `data/transactions/logic/eval_test.go` adds `TestLogicSigAllowOpcode`, covering opcode version gating and invalid immediates.
- `data/transactions/verify/txn_test.go` adds `TestTxnValidationLogicSigAllow`, which exercises end-to-end transaction verification for both contract-account and delegated LogicSigs, covering rekeying and key registration with and without the required v14 allowances.