### PR TITLE
agreement: delete old router.Children entries in-place

### DIFF
--- a/agreement/router.go
+++ b/agreement/router.go
@@ -151,7 +151,9 @@ func (router *rootRouter) update(state player, r round, gc bool) {
 	if router.Children == nil {
 		router.Children = make(map[round]*roundRouter)
 	}
-	if router.Children[r] == nil {
+	// Don't create a child the gc pass below would immediately delete;
+	// submitTop hits this with r=0 on every event.
+	if router.Children[r] == nil && (!gc || r+credentialRoundLag >= state.Round) {
 		router.Children[r] = new(roundRouter)
 	}
 
@@ -208,7 +210,8 @@ func (router *roundRouter) update(state player, p period, gc bool) {
 	if router.Children == nil {
 		router.Children = make(map[period]*periodRouter)
 	}
-	if router.Children[p] == nil {
+	// As above, don't create a child the gc pass would immediately delete.
+	if router.Children[p] == nil && (!gc || p+1 >= state.Period || p <= 1) {
 		router.Children[p] = new(periodRouter)
 	}
 

--- a/agreement/router.go
+++ b/agreement/router.go
@@ -84,6 +84,13 @@ func (h *routerHandle) dispatch(state player, e event, dest stateMachineTag, r r
 // router routes events and queries to the correct receiving state machine.
 //
 // router also encapsulates the garbage collection of old state machines.
+//
+// A router tree is owned by the goroutine running Service.mainLoop and is not
+// synchronized. Note that this applies to queries as well as events: dispatch
+// calls update, which mutates the tree by lazily building children and
+// collecting old ones, so even a read-only helper like stagedValue writes. No
+// other goroutine may touch a tree that mainLoop is still driving; see the
+// persistRouter assignment in mainLoop for the one snapshot that escapes.
 type router interface {
 	dispatch(t *tracer, state player, e event, src stateMachineTag, dest stateMachineTag, r round, p period, s step) event
 }

--- a/agreement/router.go
+++ b/agreement/router.go
@@ -85,12 +85,11 @@ func (h *routerHandle) dispatch(state player, e event, dest stateMachineTag, r r
 //
 // router also encapsulates the garbage collection of old state machines.
 //
-// A router tree is owned by the goroutine running Service.mainLoop and is not
-// synchronized. Note that this applies to queries as well as events: dispatch
-// calls update, which mutates the tree by lazily building children and
-// collecting old ones, so even a read-only helper like stagedValue writes. No
-// other goroutine may touch a tree that mainLoop is still driving; see the
-// persistRouter assignment in mainLoop for the one snapshot that escapes.
+// A router tree is not safe for concurrent use: every dispatch, queries
+// included, calls update, which may create and garbage-collect children.
+// Only mainLoop drives the tree. demuxLoop reads a shallow copy of it
+// (persistRouter) in encode, safe only because mainLoop is blocked on
+// input until do() returns.
 type router interface {
 	dispatch(t *tracer, state player, e event, src stateMachineTag, dest stateMachineTag, r round, p period, s step) event
 }

--- a/agreement/router.go
+++ b/agreement/router.go
@@ -160,7 +160,7 @@ func (router *rootRouter) update(state player, r round, gc bool) {
 	}
 	// Don't create a child the gc pass below would immediately delete;
 	// submitTop hits this with r=0 on every event.
-	if router.Children[r] == nil && (!gc || r+credentialRoundLag >= state.Round) {
+	if (!gc || r+credentialRoundLag >= state.Round) && router.Children[r] == nil {
 		router.Children[r] = new(roundRouter)
 	}
 
@@ -218,7 +218,7 @@ func (router *roundRouter) update(state player, p period, gc bool) {
 		router.Children = make(map[period]*periodRouter)
 	}
 	// As above, don't create a child the gc pass would immediately delete.
-	if router.Children[p] == nil && (!gc || p+1 >= state.Period || p <= 1) {
+	if (!gc || p+1 >= state.Period || p <= 1) && router.Children[p] == nil {
 		router.Children[p] = new(periodRouter)
 	}
 

--- a/agreement/router.go
+++ b/agreement/router.go
@@ -156,17 +156,14 @@ func (router *rootRouter) update(state player, r round, gc bool) {
 	}
 
 	if gc {
-		children := make(map[round]*roundRouter)
-		for r, c := range router.Children {
+		for r := range router.Children {
 			// We may still receive credential messages from old rounds. Keep
 			// old round routers around, for as long as those credentials may
 			// arrive to keep track of them.
-			rr := r + credentialRoundLag
-			if rr >= state.Round {
-				children[r] = c
+			if r+credentialRoundLag < state.Round {
+				delete(router.Children, r)
 			}
 		}
-		router.Children = children
 	}
 }
 
@@ -216,19 +213,15 @@ func (router *roundRouter) update(state player, p period, gc bool) {
 	}
 
 	if gc {
-		children := make(map[period]*periodRouter)
-		for p, c := range router.Children {
-			if p+1 >= state.Period {
-				children[p] = c
-			} else if p <= 1 {
-				// avoid garbage-collecting (next round, period 0/1) state
-				// this is conservative:
-				// we can collect more eagerly if router's round is passed in
-				// TODO may want regression test for correct pipelining behavior
-				children[p] = c
+		for p := range router.Children {
+			// Keep p+1 >= state.Period, and keep periods 0 and 1 to avoid
+			// garbage-collecting (next round, period 0/1) state. This is conservative:
+			// we can collect more eagerly if router's round is passed in.
+			// TODO may want regression test for correct pipelining behavior
+			if p+1 < state.Period && p > 1 {
+				delete(router.Children, p)
 			}
 		}
-		router.Children = children
 	}
 }
 

--- a/agreement/router_gc_test.go
+++ b/agreement/router_gc_test.go
@@ -1,0 +1,197 @@
+// Copyright (C) 2019-2026 Algorand Foundation Ltd.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package agreement
+
+import (
+	"maps"
+	"math/rand"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/test/partitiontest"
+)
+
+// rebuildRootChildren is the garbage collection rootRouter.update used to perform: select
+// the survivors into a freshly allocated map. Kept here as the reference the in-place
+// deletion is checked against.
+func rebuildRootChildren(in map[round]*roundRouter, stateRound round) map[round]*roundRouter {
+	children := make(map[round]*roundRouter)
+	for r, c := range in {
+		if r+credentialRoundLag >= stateRound {
+			children[r] = c
+		}
+	}
+	return children
+}
+
+// rebuildRoundChildren is the same for roundRouter.update.
+func rebuildRoundChildren(in map[period]*periodRouter, statePeriod period) map[period]*periodRouter {
+	children := make(map[period]*periodRouter)
+	for p, c := range in {
+		if p+1 >= statePeriod {
+			children[p] = c
+		} else if p <= 1 {
+			children[p] = c
+		}
+	}
+	return children
+}
+
+// TestRouterUpdateGarbageCollection checks that deleting stale children in place keeps
+// exactly the children the previous (moving to a new map) approach kept.
+//
+// The retention rule turns on a single boundary - how far a child's round or period lags
+// the player's - so the sweep below covers every combination on and around it exhaustively
+// rather than hoping random draws land there. A smaller randomized pass follows, for the
+// one thing a single-child sweep cannot exercise: deleting several entries while ranging
+// over the map.
+func TestRouterUpdateGarbageCollection(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	// rootRouter: a child at round r survives while r+credentialRoundLag >= state.Round.
+	// Sweeping to 3x the lag puts the boundary well inside the range in both directions.
+	maxRound := 3 * credentialRoundLag
+	for stateRound := round(0); stateRound <= maxRound; stateRound++ {
+		for childRound := round(0); childRound <= maxRound; childRound++ {
+			// arg is the round update() is asked to route to, which it creates a child
+			// for before collecting; vary it across the interesting positions
+			for _, arg := range []round{0, childRound, stateRound, maxRound} {
+				root := new(rootRouter)
+				root.Children = map[round]*roundRouter{childRound: new(roundRouter)}
+
+				seeded := maps.Clone(root.Children)
+				if seeded[arg] == nil {
+					seeded[arg] = new(roundRouter)
+				}
+				want := rebuildRootChildren(seeded, stateRound)
+
+				root.update(player{Round: stateRound}, arg, true)
+				require.Equal(t, slices.Sorted(maps.Keys(want)), slices.Sorted(maps.Keys(root.Children)),
+					"rootRouter children differ: state.Round=%d child=%d arg=%d", stateRound, childRound, arg)
+			}
+		}
+	}
+
+	// roundRouter: a child at period p survives while p+1 >= state.Period, and periods 0
+	// and 1 are kept unconditionally, so the range only needs to reach past both rules.
+	const maxPeriod = period(6)
+	for statePeriod := period(0); statePeriod <= maxPeriod; statePeriod++ {
+		for childPeriod := period(0); childPeriod <= maxPeriod; childPeriod++ {
+			for _, arg := range []period{0, childPeriod, statePeriod, maxPeriod} {
+				rr := new(roundRouter)
+				rr.Children = map[period]*periodRouter{childPeriod: new(periodRouter)}
+
+				seeded := maps.Clone(rr.Children)
+				if seeded[arg] == nil {
+					seeded[arg] = new(periodRouter)
+				}
+				want := rebuildRoundChildren(seeded, statePeriod)
+
+				rr.update(player{Period: statePeriod}, arg, true)
+				require.Equal(t, slices.Sorted(maps.Keys(want)), slices.Sorted(maps.Keys(rr.Children)),
+					"roundRouter children differ: state.Period=%d child=%d arg=%d", statePeriod, childPeriod, arg)
+			}
+		}
+	}
+
+	// Several children at once, so that a collection pass deletes more than one entry
+	// while ranging over the map.
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 200; i++ {
+		stateRound := round(rng.Intn(int(maxRound)))
+		arg := round(rng.Intn(int(maxRound)))
+		root := new(rootRouter)
+		root.Children = make(map[round]*roundRouter)
+		for j := 0; j < 1+rng.Intn(15); j++ {
+			root.Children[round(rng.Intn(int(maxRound)))] = new(roundRouter)
+		}
+		seeded := maps.Clone(root.Children)
+		if seeded[arg] == nil {
+			seeded[arg] = new(roundRouter)
+		}
+		want := rebuildRootChildren(seeded, stateRound)
+
+		root.update(player{Round: stateRound}, arg, true)
+		require.Equal(t, slices.Sorted(maps.Keys(want)), slices.Sorted(maps.Keys(root.Children)),
+			"rootRouter children differ with %d children: state.Round=%d arg=%d", len(seeded), stateRound, arg)
+	}
+}
+
+// TestRouterUpdateKeepsChildIdentity checks that garbage collection preserves the router
+// instances themselves, not merely their keys: a surviving child must be the same object,
+// since it carries the state machine's accumulated state.
+func TestRouterUpdateKeepsChildIdentity(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	root := new(rootRouter)
+	root.Children = make(map[round]*roundRouter)
+	survivor := new(roundRouter)
+	root.Children[100] = survivor
+	root.Children[1] = new(roundRouter) // far enough back to be collected
+
+	root.update(player{Round: 100}, 100, true)
+
+	require.Same(t, survivor, root.Children[100], "surviving child must be the same instance")
+	require.NotContains(t, root.Children, round(1), "stale child must be collected")
+}
+
+// BenchmarkRouterUpdate measures the per-event cost of routing state garbage collection.
+//
+// rootRouter.update and roundRouter.update run on every event routed through the state
+// machine tree -- submitTop and dispatch both call them with gc set -- so their allocation
+// count is multiplied by the agreement message rate. Reported allocs/op is the figure of
+// interest: collecting in place rather than rebuilding the children map should keep it at
+// the one allocation update genuinely makes (the child for the requested round), and none
+// at all once that child already exists.
+func BenchmarkRouterUpdate(b *testing.B) {
+	b.Run("root", func(b *testing.B) {
+		router := new(rootRouter)
+		router.Children = make(map[round]*roundRouter)
+		// the rounds a steady-state node keeps: everything within credentialRoundLag
+		const current = round(1000)
+		for r := current; r+credentialRoundLag >= current; r-- {
+			router.Children[r] = new(roundRouter)
+		}
+		state := player{Round: current}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			// what submitTop does for every event
+			router.update(state, 0, true)
+		}
+	})
+
+	b.Run("round", func(b *testing.B) {
+		router := new(roundRouter)
+		router.Children = make(map[period]*periodRouter)
+		const current = period(3)
+		for p := period(0); p <= current; p++ {
+			router.Children[p] = new(periodRouter)
+		}
+		state := player{Period: current}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			// what roundRouter.dispatch does for every event it routes
+			router.update(state, current, true)
+		}
+	})
+}

--- a/agreement/router_gc_test.go
+++ b/agreement/router_gc_test.go
@@ -156,9 +156,9 @@ func TestRouterUpdateKeepsChildIdentity(t *testing.T) {
 // rootRouter.update and roundRouter.update run on every event routed through the state
 // machine tree -- submitTop and dispatch both call them with gc set -- so their allocation
 // count is multiplied by the agreement message rate. Reported allocs/op is the figure of
-// interest: collecting in place rather than rebuilding the children map should keep it at
-// the one allocation update genuinely makes (the child for the requested round), and none
-// at all once that child already exists.
+// interest: collecting in place rather than rebuilding the children map, and not creating
+// a child that collection would immediately delete, should make steady-state updates
+// allocation-free.
 func BenchmarkRouterUpdate(b *testing.B) {
 	b.Run("root", func(b *testing.B) {
 		router := new(rootRouter)

--- a/agreement/service.go
+++ b/agreement/service.go
@@ -162,6 +162,14 @@ func (s *Service) Start() {
 	})
 
 	s.persistenceLoop.Start()
+	// These three channels are deliberately unbuffered: their rendezvous is what
+	// serializes mainLoop against demuxLoop, and ready is the one that does the work.
+	// Each iteration mainLoop hands its actions over output, parks on ready, and resumes
+	// only when demuxLoop sends the next event over input. demuxLoop meanwhile runs do()
+	// - where encode reads the router tree mainLoop shares through persistRouter - and
+	// only receives from ready once do() has returned. So mainLoop is still parked while
+	// that read is in flight and cannot re-enter submitTop to mutate the tree. Buffering
+	// any of the three would let mainLoop run ahead and break that ordering.
 	input := make(chan externalEvent)
 	output := make(chan []action)
 	ready := make(chan externalDemuxSignals)
@@ -264,6 +272,12 @@ func (s *Service) mainLoop(input <-chan externalEvent, output chan<- []action, r
 		status, a = router.submitTop(s.tracer, status, e)
 
 		if persistent(a) {
+			// This is a shallow copy: the Children map and every router below
+			// it remain shared with the tree mainLoop keeps mutating. It is
+			// sound only because encode runs synchronously inside demuxLoop's
+			// do(), by which point mainLoop is parked on the unbuffered
+			// output/ready/input handshake and cannot reach submitTop. Running
+			// encode anywhere else requires a deep copy.
 			s.persistRouter = router
 			s.persistStatus = status
 			s.persistActions = a

--- a/agreement/service.go
+++ b/agreement/service.go
@@ -266,10 +266,9 @@ func (s *Service) mainLoop(input <-chan externalEvent, output chan<- []action, r
 		if persistent(a) {
 			// This is a shallow copy: the Children map and every router below
 			// it remain shared with the tree mainLoop keeps mutating. It is
-			// sound only because encode runs synchronously inside demuxLoop's
-			// do(), by which point mainLoop is parked on the unbuffered
-			// output/ready/input handshake and cannot reach submitTop. Running
-			// encode anywhere else requires a deep copy.
+			// safe only because encode runs synchronously inside demuxLoop's
+			// do(), while mainLoop is blocked on input and cannot reach submitTop.
+			// Running encode anywhere else requires a deep copy.
 			s.persistRouter = router
 			s.persistStatus = status
 			s.persistActions = a

--- a/agreement/service.go
+++ b/agreement/service.go
@@ -162,14 +162,6 @@ func (s *Service) Start() {
 	})
 
 	s.persistenceLoop.Start()
-	// These three channels are deliberately unbuffered: their rendezvous is what
-	// serializes mainLoop against demuxLoop, and ready is the one that does the work.
-	// Each iteration mainLoop hands its actions over output, parks on ready, and resumes
-	// only when demuxLoop sends the next event over input. demuxLoop meanwhile runs do()
-	// - where encode reads the router tree mainLoop shares through persistRouter - and
-	// only receives from ready once do() has returned. So mainLoop is still parked while
-	// that read is in flight and cannot re-enter submitTop to mutate the tree. Buffering
-	// any of the three would let mainLoop run ahead and break that ordering.
 	input := make(chan externalEvent)
 	output := make(chan []action)
 	ready := make(chan externalDemuxSignals)


### PR DESCRIPTION
## Summary

Shave approx 20% of total allocations according to the heap profile after few days of run time.

<img width="943" height="186" alt="image" src="https://github.com/user-attachments/assets/b028aa33-6f71-4df4-a0e1-1ab9781dc876" />

```
github.com/algorand/go-algorand/agreement.(*rootRouter).update

github.com/algorand/go-algorand/agreement/router.go

  Total:  5033248479 5033248479 (flat, cum) 26.06%
    150            .          .           	} 
    151            .          .           	if router.Children == nil { 
    152            .          .           		router.Children = make(map[round]*roundRouter) 
    153            .          .           	} 
    154            .          .           	if router.Children[r] == nil { 
    155    594699247  594699247           		router.Children[r] = new(roundRouter) 
    156            .          .           	} 
    157            .          .            
    158            .          .           	if gc { 
    159    886393116  886393116           		children := make(map[round]*roundRouter) 
    160            .          .           		for r, c := range router.Children { 
    161            .          .           			// We may still receive credential messages from old rounds. Keep 
    162            .          .           			// old round routers around, for as long as those credentials may 
    163            .          .           			// arrive to keep track of them. 
    164            .          .           			rr := r + credentialRoundLag 
    165            .          .           			if rr >= state.Round { 
    166   3552156116 3552156116           				children[r] = c 
    167            .          .           			} 
    168            .          .           		} 
    169            .          .           		router.Children = children 
    170            .          .           	} 
    171            .          .           } 
```

#### Benchmark

Before
```
BenchmarkRouterUpdate/root-10         	 3852776	       310.5 ns/op	    1032 B/op	       6 allocs/op
BenchmarkRouterUpdate/round-10        	13706760	        85.59 ns/op	     192 B/op	       2 allocs/op
```

After
```
BenchmarkRouterUpdate/root-10         	 9614924	       122.1 ns/op	     512 B/op	       1 allocs/op
BenchmarkRouterUpdate/round-10        	35838322	        32.01 ns/op	       0 B/op	       0 allocs/op
```

## Test Plan

Added a new test making sure no regressions in what to retain.