### PR TITLE
txsync: fix double logging

### DIFF
--- a/catchup/service.go
+++ b/catchup/service.go
@@ -826,6 +826,12 @@ func (s *Service) fetchRound(cert agreement.Certificate, verifier *agreement.Asy
 				return
 			default:
 			}
+			if errors.Is(err, errLedgerAlreadyHasBlock) {
+				// ledger already has the block, no need to request this block.
+				// only the agreement could have added this block into the ledger, catchup is complete
+				s.log.Infof("fetchRound(%d): the block is already in the ledger. The catchup is complete", cert.Round)
+				return
+			}
 			failureRank := peerRankDownloadFailed
 			var nbfe noBlockForRoundError
 			if errors.As(err, &nbfe) {

--- a/rpcs/blockService_test.go
+++ b/rpcs/blockService_test.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -240,6 +239,14 @@ func TestBlockServiceShutdown(t *testing.T) {
 	<-requestDone
 }
 
+// setMemoryUsed overrides the block service memory accounting, so that tests can
+// drive the service in and out of its over-capacity state deterministically.
+func (bs *BlockService) setMemoryUsed(used uint64) {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	bs.memoryUsed = used
+}
+
 // TestRedirectOnFullCapacity tests the case when the block service
 // fallback to another because its memory use is at capacity
 func TestRedirectOnFullCapacity(t *testing.T) {
@@ -296,74 +303,52 @@ func TestRedirectOnFullCapacity(t *testing.T) {
 	parsedURL, err := addr.ParseHostOrURL(nodeA.rootURL())
 	require.NoError(t, err)
 
-	client := http.Client{}
-
 	parsedURL.Path = FormatBlockQuery(uint64(2), parsedURL.Path, net1)
 	parsedURL.Path = strings.Replace(parsedURL.Path, "{genesisID}", "test-genesis-ID", 1)
 	blockURL := parsedURL.String()
-	request, err := http.NewRequest("GET", blockURL, nil)
-	require.NoError(t, err)
-	network.SetUserAgentHeader(request.Header)
 
-	var responses1, responses2, responses3, responses4 *http.Response
-	var blk bookkeeping.Block
-	var l2Failed bool
-	xDone := 1000
-	// Keep on sending 4 simultaneous requests to the first node, to force it to redirect to node 2
-	// then check the timestamp from the block header to confirm the redirection took place
-	var x int
-forloop:
-	for ; x < xDone; x++ {
-		wg := sync.WaitGroup{}
-		wg.Add(4)
-		go func() {
-			defer wg.Done()
-			responses1, _ = client.Do(request)
-		}()
-		go func() {
-			defer wg.Done()
-			responses2, _ = client.Do(request)
-		}()
-		go func() {
-			defer wg.Done()
-			responses3, _ = client.Do(request)
-		}()
-		go func() {
-			defer wg.Done()
-			responses4, _ = client.Do(request)
-		}()
-
-		wg.Wait()
-		responses := [4]*http.Response{responses1, responses2, responses3, responses4}
-		for p := 0; p < 4; p++ {
-			if responses[p] == nil {
-				continue
-			}
-			if responses[p].StatusCode == http.StatusServiceUnavailable {
-				l2Failed = true
-				require.Equal(t, "3", responses[p].Header["Retry-After"][0])
-				continue
-			}
-			// parse the block to get the header timestamp which is needed to know which node served the block
-			require.Equal(t, http.StatusOK, responses[p].StatusCode)
-			bodyData, err := io.ReadAll(responses[p].Body)
-			require.NoError(t, err)
-			require.NotEqual(t, 0, len(bodyData))
-			var blkCert PreEncodedBlockCert
-			err = protocol.DecodeReflect(bodyData, &blkCert)
-			require.NoError(t, err)
-			err = protocol.Decode(blkCert.Block, &blk)
-			require.NoError(t, err)
-			if blk.TimeStamp == l2Block2Ts && l2Failed {
-				break forloop
-			}
-		}
+	client := http.Client{}
+	getBlock := func() *http.Response {
+		t.Helper()
+		request, err := http.NewRequest("GET", blockURL, nil)
+		require.NoError(t, err)
+		network.SetUserAgentHeader(request.Header)
+		response, err := client.Do(request)
+		require.NoError(t, err)
+		t.Cleanup(func() { response.Body.Close() })
+		return response
 	}
-	require.Less(t, x, xDone)
+
+	// Both the redirect and the retry-after paths trigger off memoryUsed exceeding
+	// memoryCap, which rawBlockBytes checks before serving a block. Set that state
+	// directly instead of racing concurrent requests for it.
+
+	// Both nodes are over capacity: nodeA redirects to nodeB, and nodeB, having no
+	// fallback endpoint of its own, has to answer with retry-after. Neither node
+	// serves a block here, so neither one touches its own memory accounting.
+	bs1.setMemoryUsed(bs1.memoryCap + 1)
+	bs2.setMemoryUsed(bs2.memoryCap + 1)
+
+	response := getBlock()
+	require.Equal(t, http.StatusServiceUnavailable, response.StatusCode)
+	require.Equal(t, blockResponseRetryAfter, response.Header.Get("Retry-After"))
+
+	// nodeA is still over capacity but nodeB now has room, so the redirected
+	// request gets served out of ledger2.
+	bs2.setMemoryUsed(0)
+
+	response = getBlock()
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	bodyData, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NotEqual(t, 0, len(bodyData))
+	// parse the block to get the header timestamp, which tells us which node served it
+	var blkCert PreEncodedBlockCert
+	require.NoError(t, protocol.DecodeReflect(bodyData, &blkCert))
+	var blk bookkeeping.Block
+	require.NoError(t, protocol.Decode(blkCert.Block, &blk))
 	// check if redirection happened
-	require.Equal(t, blk.TimeStamp, l2Block2Ts)
-	// check if node 2 was also overwhelmed and responded with retry-after, since it cannod redirect
-	require.True(t, l2Failed)
+	require.Equal(t, l2Block2Ts, blk.TimeStamp)
 
 	// First node redirects, does not return retry
 	require.True(t, strings.Contains(logBuffer1.String(), "redirectRequest: redirected block request to"))

--- a/rpcs/httpTxSync.go
+++ b/rpcs/httpTxSync.go
@@ -119,7 +119,6 @@ func (hts *HTTPTxSync) Sync(ctx context.Context, bloom *bloom.Filter) (txgroups 
 	params.Set("bf", bloomParam)
 	request, err := http.NewRequest("POST", syncURL, strings.NewReader(params.Encode()))
 	if err != nil {
-		hts.log.Errorf("txSync POST setup %v: %s", syncURL, err)
 		return nil, err
 	}
 	request.Header.Set("Content-Type", requestContentType)
@@ -137,7 +136,6 @@ func (hts *HTTPTxSync) Sync(ctx context.Context, bloom *bloom.Filter) (txgroups 
 		response.Body.Close()
 		return [][]transactions.SignedTxn{}, nil
 	default:
-		hts.log.Warn("txSync response status code : ", response.StatusCode)
 		response.Body.Close()
 		return nil, fmt.Errorf("txSync POST error response status code %d for '%s'. Request bloom filter length was %d bytes", response.StatusCode, syncURL, len(bloomParam))
 	}
@@ -147,7 +145,6 @@ func (hts *HTTPTxSync) Sync(ctx context.Context, bloom *bloom.Filter) (txgroups 
 	contentTypes := response.Header["Content-Type"]
 	if len(contentTypes) != 1 {
 		err = fmt.Errorf("txSync POST invalid content type count %d", len(contentTypes))
-		hts.log.Warn(err)
 		response.Body.Close()
 		return nil, err
 	}
@@ -155,7 +152,6 @@ func (hts *HTTPTxSync) Sync(ctx context.Context, bloom *bloom.Filter) (txgroups 
 	// Remove this 'old' string after next release.
 	const responseContentTypeOld = "application/x-algorand-ptx-v1"
 	if contentTypes[0] != responseContentType && contentTypes[0] != responseContentTypeOld {
-		hts.log.Warnf("http response has an invalid content type : %s", contentTypes[0])
 		response.Body.Close()
 		return nil, fmt.Errorf("txSync POST invalid content type '%s'", contentTypes[0])
 	}


### PR DESCRIPTION
## Summary

Fixes inspired by node.log from a running node:
1. remove duplicate log + err in `HTTPTxSync.Sync` - let the only caller `TxSyncer.Start` to log it.
2. catchup: handle `errLedgerAlreadyHasBlock` in `fetchRound` the same way as `fetchAndWrite` does - info log + exit
3. `TestRedirectOnFullCapacity` does not use node hammering with 4 threads to trigger the redirect condition - use an explicit helper instead.

## Test Plan

Existing tests should pass