### PR TITLE
tests: fix more recent CI flaky tests

### DIFF
--- a/data/txDupCache_test.go
+++ b/data/txDupCache_test.go
@@ -203,8 +203,13 @@ func TestTxHandlerSaltedCacheScheduled(t *testing.T) {
 
 	const size = 20
 	updateInterval := 1000 * time.Microsecond
+	ctx, cancel := context.WithCancel(context.Background())
 	cache := makeSaltedCache(size)
-	cache.Start(context.Background(), updateInterval)
+	cache.Start(ctx, updateInterval)
+	defer func() {
+		cancel()
+		cache.WaitForStop()
+	}()
 	require.Zero(t, cache.Len())
 
 	// add some unique random
@@ -220,7 +225,10 @@ func TestTxHandlerSaltedCacheScheduled(t *testing.T) {
 		}
 	}
 
-	require.Less(t, cache.Len(), size)
+	// Two scheduled rotations evict everything inserted above. Do not require them to land
+	// inside the loop: on a busy machine the salter goroutine can be starved for longer than
+	// the whole loop and ticker ticks coalesce, leaving Len() == size at this point.
+	require.Eventually(t, func() bool { return cache.Len() < size }, 10*time.Second, updateInterval)
 }
 
 func TestTxHandlerSaltedCacheManual(t *testing.T) {

--- a/test/e2e-go/cli/goal/expect/goalLogicSigTest.exp
+++ b/test/e2e-go/cli/goal/expect/goalLogicSigTest.exp
@@ -26,6 +26,9 @@ if { [catch {
     set PRIMARY_NODE_ADDRESS [ ::AlgorandGoal::GetAlgodNetworkAddress $TEST_PRIMARY_NODE_DIR ]
     puts "Primary Node Address: $PRIMARY_NODE_ADDRESS"
 
+    # Wait for the first block before submitting the confirming clerk send below.
+    ::AlgorandGoal::WaitForRound 1 $TEST_PRIMARY_NODE_DIR
+
     set PRIMARY_WALLET_NAME unencrypted-default-wallet
 
     # Determine primary account

--- a/test/scripts/e2e_subs/app-accounts.sh
+++ b/test/scripts/e2e_subs/app-accounts.sh
@@ -52,7 +52,8 @@ function balance {
     goal account balance -a "$acct" | awk '{print $1}'
 }
 
-[ "$(balance "$ACCOUNT")" = $((1000000000000 - SMALL_FUNDING - MIN_FEE)) ]
+# ACCOUNT holds 1M Algos and earns 1 Algo every time the rewards level ticks, so exclude rewards.
+[ "$(balance_without_rewards "$ACCOUNT")" = $((1000000000000 - SMALL_FUNDING - MIN_FEE)) ]
 [ "$(balance "$SMALL")" = $SMALL_FUNDING ]
 
 APPID=$(${gcmd} app create --creator "${SMALL}" --approval-prog=${TEAL}/app-escrow.teal --global-byteslices 4 --global-ints 0 --local-byteslices 0 --local-ints 1  --clear-prog=${TEAL}/approve-all.teal | grep Created | awk '{ print $6 }')

--- a/test/scripts/e2e_subs/app-assets-access.sh
+++ b/test/scripts/e2e_subs/app-assets-access.sh
@@ -41,33 +41,24 @@ MAX_MIN_BALANCE=628500
 TOTAL_NEEDED=$((NEEDED_FOR_FEES + MAX_MIN_BALANCE + MIN_FEE * 3))
 
 # Fund with at least 2 Algos to ensure enough for high MIN_FEE scenarios
-# Note: Account will earn rewards (RewardUnit = 1,000,000), so balance checks must be tolerant
+# Note: Account will earn rewards (RewardUnit = 1,000,000), so balance checks exclude rewards
 SMALL_FUNDING=$((TOTAL_NEEDED > 2000000 ? TOTAL_NEEDED : 2000000))
 
-# Tolerance for balance checks (to account for rewards earned)
-# Allow up to 5000 microAlgos tolerance per balance check
-BALANCE_TOLERANCE=5000
 SMALL=$(${gcmd} account new | awk '{ print $6 }')
 ${gcmd} clerk send -a $SMALL_FUNDING -f "$ACCOUNT" -t "$SMALL"
 
-function balance {
-    acct=$1; shift
-    goal account balance -a "$acct" | awk '{print $1}'
-}
-
-# Check if balance is within tolerance of expected value
+# Check that an account's balance, excluding rewards, exactly matches the expected value.
 # Usage: check_balance <account> <expected_balance>
-# Allows BALANCE_TOLERANCE above expected (for rewards) but exact match below
 function check_balance {
     local acct=$1
     local expected=$2
     local actual
-    actual=$(balance "$acct")
+    actual=$(balance_without_rewards "$acct")
     local diff=$((actual - expected))
 
-    if [ $diff -lt 0 ] || [ $diff -gt $BALANCE_TOLERANCE ]; then
+    if [ "$diff" -ne 0 ]; then
         echo "ERROR: Balance check failed for $acct"
-        echo "  Expected: $expected (tolerance: +0 to +$BALANCE_TOLERANCE)"
+        echo "  Expected: $expected"
         echo "  Actual:   $actual (diff: $diff)"
         return 1
     fi

--- a/test/scripts/e2e_subs/app-assets.sh
+++ b/test/scripts/e2e_subs/app-assets.sh
@@ -40,33 +40,24 @@ MAX_MIN_BALANCE=628500
 TOTAL_NEEDED=$((NEEDED_FOR_FEES + MAX_MIN_BALANCE + MIN_FEE * 3))
 
 # Fund with at least 2 Algos to ensure enough for high MIN_FEE scenarios
-# Note: Account will earn rewards (RewardUnit = 1,000,000), so balance checks must be tolerant
+# Note: Account will earn rewards (RewardUnit = 1,000,000), so balance checks exclude rewards
 SMALL_FUNDING=$((TOTAL_NEEDED > 2000000 ? TOTAL_NEEDED : 2000000))
 
-# Tolerance for balance checks (to account for rewards earned)
-# Allow up to 5000 microAlgos tolerance per balance check
-BALANCE_TOLERANCE=5000
 SMALL=$(${gcmd} account new | awk '{ print $6 }')
 ${gcmd} clerk send -a $SMALL_FUNDING -f "$ACCOUNT" -t "$SMALL"
 
-function balance {
-    acct=$1; shift
-    goal account balance -a "$acct" | awk '{print $1}'
-}
-
-# Check if balance is within tolerance of expected value
+# Check that an account's balance, excluding rewards, exactly matches the expected value.
 # Usage: check_balance <account> <expected_balance>
-# Allows BALANCE_TOLERANCE above expected (for rewards) but exact match below
 function check_balance {
     local acct=$1
     local expected=$2
     local actual
-    actual=$(balance "$acct")
+    actual=$(balance_without_rewards "$acct")
     local diff=$((actual - expected))
 
-    if [ $diff -lt 0 ] || [ $diff -gt $BALANCE_TOLERANCE ]; then
+    if [ "$diff" -ne 0 ]; then
         echo "ERROR: Balance check failed for $acct"
-        echo "  Expected: $expected (tolerance: +0 to +$BALANCE_TOLERANCE)"
+        echo "  Expected: $expected"
         echo "  Actual:   $actual (diff: $diff)"
         return 1
     fi

--- a/test/scripts/e2e_subs/limit-swap-test.sh
+++ b/test/scripts/e2e_subs/limit-swap-test.sh
@@ -44,7 +44,9 @@ echo "closeout part b, asset trader"
 # quick expiration, test closeout
 
 ROUND=$(goal node status | grep 'Last committed block:'|awk '{ print $4 }')
-SETUP_ROUND=$((${ROUND} + 10))
+# The funding payment and the asset opt-in below must both commit before SETUP_ROUND.
+# Leave enough rounds for slow kmd signing under CI load.
+SETUP_ROUND=$((${ROUND} + 20))
 TIMEOUT_ROUND=$((${SETUP_ROUND} + 1))
 
 sed s/TMPL_ASSET/${ASSET_ID}/g < tools/teal/templates/limit-order-b.teal.tmpl | sed s/TMPL_SWAPN/137/g | sed s/TMPL_SWAPD/31337/g | sed s/TMPL_TIMEOUT/${TIMEOUT_ROUND}/g | sed s/TMPL_OWN/${ACCOUNT}/g | sed s/TMPL_FEE/100000/g | sed s/TMPL_MINTRD/10000/g > ${TEMPDIR}/limit-order-b.teal
@@ -58,8 +60,8 @@ ${gcmd} clerk send --amount 1000000 --from ${ACCOUNT} --to ${ACCOUNT_ASSET_TRADE
 # ${gcmd} account balance -a $ACCOUNT_ASSET_TRADER
 
 echo "make asset trader able to accept asset"
-ROUND=$(goal node status | grep 'Last committed block:'|awk '{ print $4 }')
-${gcmd} asset optin -o ${TEMPDIR}/b-asset-init.tx --assetid ${ASSET_ID} -a $ACCOUNT_ASSET_TRADER --validrounds $((${SETUP_ROUND} - ${ROUND} - 1))
+# The program only approves the opt-in if txn.LastValid < TMPL_TIMEOUT.
+${gcmd} asset optin -o ${TEMPDIR}/b-asset-init.tx --assetid ${ASSET_ID} -a $ACCOUNT_ASSET_TRADER --lastvalid ${SETUP_ROUND}
 
 ${gcmd} clerk sign -i ${TEMPDIR}/b-asset-init.tx -p ${TEMPDIR}/limit-order-b.teal -o ${TEMPDIR}/b-asset-init.stx
 

--- a/test/scripts/e2e_subs/limit-swap-test.sh
+++ b/test/scripts/e2e_subs/limit-swap-test.sh
@@ -106,8 +106,8 @@ echo "setup trader with Algos"
 ${gcmd} clerk send --amount 1000000 --from ${ACCOUNT} --to ${ACCOUNT_ASSET_TRADER}
 
 echo "make asset trader able to accept asset"
-ROUND=$(goal node status | grep 'Last committed block:'|awk '{ print $4 }')
-${gcmd} asset optin -o ${TEMPDIR}/b-asset-init.tx --assetid ${ASSET_ID} -a $ACCOUNT_ASSET_TRADER --validrounds $((${SETUP_ROUND} - ${ROUND} - 1))
+# The program only approves the opt-in if txn.LastValid < TMPL_TIMEOUT.
+${gcmd} asset optin -o ${TEMPDIR}/b-asset-init.tx --assetid ${ASSET_ID} -a $ACCOUNT_ASSET_TRADER --lastvalid ${SETUP_ROUND}
 
 ${gcmd} clerk sign -i ${TEMPDIR}/b-asset-init.tx -p ${TEMPDIR}/limit-order-b.teal -o ${TEMPDIR}/b-asset-init.stx
 

--- a/test/scripts/e2e_subs/rest.sh
+++ b/test/scripts/e2e_subs/rest.sh
@@ -85,6 +85,10 @@ function get_min_fee {
   fi
 }
 
+function balance_without_rewards {
+  rest "/v2/accounts/$1" | jq -r '.amount - .rewards'
+}
+
 
 function fail_and_exit {
   printf "\n\nFailed test - $1 ($2): $3\n\n"


### PR DESCRIPTION
## Summary

1. Fix test assertions for `TestTxHandlerSaltedCache` tests as seen in https://github.com/algorand/go-algorand/actions/runs/34071599443/job/101590698746
2. app-accounts.sh, app-assets.sh, app-assets-access.sh - use balance without rewards in balance checks. Also removed `BALANCE_TOLERANCE=5000` allowed balance drift due to rewards accumulation (see failures at https://github.com/algorand/go-algorand-private/actions/runs/34122220781/job/101744586140)
3. Extend validity period in limit-swap-test.sh
4. Fix goalLogicSigTest.exp as in https://github.com/algorand/go-algorand-private/actions/runs/34275327242/job/102226816481

## Test Plan

These are existing test fixes