### PR TITLE
transactions: reject group duplicates, remove obsolete checks

### DIFF
--- a/data/transactions/checks.go
+++ b/data/transactions/checks.go
@@ -19,6 +19,7 @@ package transactions
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/merklearray"
@@ -28,10 +29,6 @@ import (
 )
 
 var (
-	errMissingHeartbeatFields       = errors.New("heartbeat transaction is missing its heartbeat fields")
-	errHeartbeatInResourceGroup     = errors.New("heartbeat transaction may not be grouped with an application call or asset creation")
-	errMalformedTxType              = errors.New("transaction has an unknown type")
-	errMalformedApplicationBoxIndex = errors.New("application transaction box index exceeds foreign apps")
 	errMalformedStateProofSignature = errors.New("state proof reveal has an empty or too-short signature")
 	errMalformedStateProofProof     = errors.New("state proof reveal has an invalid Merkle proof depth")
 	errMalformedStateProofPath      = errors.New("state proof has a Merkle path element with an unexpected size")
@@ -58,6 +55,8 @@ const (
 	TxGroupMalformedErrorReasonIncompleteGroup
 	// TxGroupErrorReasonInvalidFee indicates a group with improper fees.
 	TxGroupErrorReasonInvalidFee
+	// TxGroupMalformedErrorReasonDuplicateTxn indicates a group that contains the same transaction twice.
+	TxGroupMalformedErrorReasonDuplicateTxn
 )
 
 // TxGroupMalformedError indicates a transaction group that violates a group-wide rule.
@@ -72,11 +71,6 @@ type TxGroupMalformedError struct {
 // Error returns the transaction group validation failure message.
 func (e *TxGroupMalformedError) Error() string {
 	return e.Msg
-}
-
-func triggersResourceAvailability(tx *Transaction) bool {
-	return tx.Type == protocol.ApplicationCallTx ||
-		(tx.Type == protocol.AssetConfigTx && tx.ConfigAsset == 0)
 }
 
 // checkBasicStateProofPath enforces the Merkle proof parameters fixed by the
@@ -138,51 +132,29 @@ func checkStateProof(spType protocol.StateProofType, sp *stateproof.StateProof) 
 	}
 }
 
-func checkApplicationCallBoxes(tx *Transaction) error {
-	if tx.Access != nil {
-		return nil
-	}
-	for i := range tx.Boxes {
-		if tx.Boxes[i].Index > uint64(len(tx.ForeignApps)) {
-			return errMalformedApplicationBoxIndex
-		}
-	}
-	return nil
-}
-
+// checkTxnGroup screens a group on behalf of the agreement proposal filter,
+// which is the only caller: it validates proposal payloads without ever
+// calling WellFormed, so any check it needs must be repeated here.
 func checkTxnGroup(n int, txn func(i int) *Transaction) error {
-	heartbeat, availTrigger := false, false
 	for i := range n {
 		tx := txn(i)
-		switch tx.Type {
-		case protocol.HeartbeatTx:
-			heartbeat = true
-			if tx.HeartbeatTxnFields == nil {
-				return errMissingHeartbeatFields
-			}
-		case protocol.StateProofTx:
+		if tx.Type == protocol.StateProofTx {
 			if err := checkStateProof(tx.StateProofType, &tx.StateProof); err != nil {
 				return err
 			}
-		case protocol.ApplicationCallTx:
-			availTrigger = true
-			if err := checkApplicationCallBoxes(tx); err != nil {
-				return err
-			}
-		case protocol.PaymentTx, protocol.KeyRegistrationTx, protocol.AssetConfigTx, protocol.AssetTransferTx, protocol.AssetFreezeTx:
-			if triggersResourceAvailability(tx) {
-				availTrigger = true
-			}
-		default:
-			return errMalformedTxType
 		}
-	}
-	if heartbeat && availTrigger {
-		return errHeartbeatInResourceGroup
 	}
 	return checkTxnGroupID(n, txn)
 }
 
+// checkTxnGroupID verifies that a group's nonzero group ID commits to the
+// provided transaction order, and that no transaction appears twice within the
+// group.
+//
+// Both must run before the caller consults the VerifiedTransactionCache, which
+// keys entries by transaction ID: a full-group hit means the group itself was
+// verified only if the ID commits to this group and the transaction IDs within
+// it are distinct.
 func checkTxnGroupID(n int, txn func(i int) *Transaction) error {
 	if n == 0 {
 		return nil
@@ -215,7 +187,18 @@ func checkTxnGroupID(n int, txn func(i int) *Transaction) error {
 
 		current := *tx
 		current.Group = crypto.Digest{}
-		computed.TxGroupHashes = append(computed.TxGroupHashes, crypto.Digest(current.ID()))
+		// Within a group every transaction carries the same Group value, so
+		// these group-zeroed IDs are equal exactly when the real transaction
+		// IDs are.
+		txid := crypto.Digest(current.ID())
+		if j := slices.Index(computed.TxGroupHashes, txid); j >= 0 {
+			return &TxGroupMalformedError{
+				Msg:        fmt.Sprintf("transactionGroup: duplicate transaction: [%d] repeats [%d]", i, j),
+				Reason:     TxGroupMalformedErrorReasonDuplicateTxn,
+				GroupIndex: i,
+			}
+		}
+		computed.TxGroupHashes = append(computed.TxGroupHashes, txid)
 	}
 
 	computedID := hashTxGroup(computed)
@@ -239,10 +222,11 @@ func hashTxGroup(group TxGroup) crypto.Digest {
 	return digest
 }
 
-// CheckTxnGroup screens a transaction group for invalid transactions and
-// verifies that its nonzero group ID commits to the provided transaction order.
-func CheckTxnGroup(group []SignedTxn) error {
-	return checkTxnGroup(len(group), func(i int) *Transaction { return &group[i].Txn })
+// CheckTxnGroupID verifies a group's ID and transaction-ID uniqueness. Callers
+// must establish both before consulting the VerifiedTransactionCache -- see
+// checkTxnGroupID.
+func CheckTxnGroupID(group []SignedTxn) error {
+	return checkTxnGroupID(len(group), func(i int) *Transaction { return &group[i].Txn })
 }
 
 // CheckPaysetGroup screens a decoded block payset group for invalid transactions and

--- a/data/transactions/checks_test.go
+++ b/data/transactions/checks_test.go
@@ -50,26 +50,25 @@ func stateProofTxnForCheck() Transaction {
 	}
 }
 
-func TestCheckTxnGroupStateProofBasicSuite(t *testing.T) {
+func TestCheckPaysetGroupStateProofBasicSuite(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
 	valid := stateProofTxnForCheck()
-	require.NoError(t, CheckTxnGroup([]SignedTxn{{Txn: valid}}))
 	require.NoError(t, CheckPaysetGroup([]SignedTxnWithAD{SignedTxn{Txn: valid}.WithAD()}))
 
 	t.Run("unsupported state proof type", func(t *testing.T) {
 		t.Parallel()
 		malformed := stateProofTxnForCheck()
 		malformed.StateProofType = protocol.StateProofType(1)
-		require.ErrorIs(t, CheckTxnGroup([]SignedTxn{{Txn: malformed}}), errMalformedStateProofType)
+		require.ErrorIs(t, CheckPaysetGroup([]SignedTxnWithAD{SignedTxn{Txn: malformed}.WithAD()}), errMalformedStateProofType)
 	})
 
 	t.Run("signature commitment proof hash", func(t *testing.T) {
 		t.Parallel()
 		malformed := stateProofTxnForCheck()
 		malformed.StateProof.SigProofs = stateProofPathForCheck(crypto.Sha256, crypto.Sha256Size)
-		require.ErrorIs(t, CheckTxnGroup([]SignedTxn{{Txn: malformed}}), errMalformedStateProofHash)
+		require.ErrorIs(t, CheckPaysetGroup([]SignedTxnWithAD{SignedTxn{Txn: malformed}.WithAD()}), errMalformedStateProofHash)
 	})
 
 	t.Run("participant commitment proof hash", func(t *testing.T) {
@@ -83,14 +82,14 @@ func TestCheckTxnGroupStateProofBasicSuite(t *testing.T) {
 		t.Parallel()
 		malformed := stateProofTxnForCheck()
 		malformed.StateProof.PartProofs.Path[0] = make(crypto.GenericDigest, crypto.Sha256Size)
-		require.ErrorIs(t, CheckTxnGroup([]SignedTxn{{Txn: malformed}}), errMalformedStateProofPath)
+		require.ErrorIs(t, CheckPaysetGroup([]SignedTxnWithAD{SignedTxn{Txn: malformed}.WithAD()}), errMalformedStateProofPath)
 	})
 
 	t.Run("signature commitment size", func(t *testing.T) {
 		t.Parallel()
 		malformed := stateProofTxnForCheck()
 		malformed.StateProof.SigCommit = make(crypto.GenericDigest, crypto.Sha256Size)
-		require.ErrorIs(t, CheckTxnGroup([]SignedTxn{{Txn: malformed}}), errMalformedStateProofCommit)
+		require.ErrorIs(t, CheckPaysetGroup([]SignedTxnWithAD{SignedTxn{Txn: malformed}.WithAD()}), errMalformedStateProofCommit)
 	})
 
 	t.Run("nested Merkle signature proof hash", func(t *testing.T) {
@@ -102,7 +101,7 @@ func TestCheckTxnGroupStateProofBasicSuite(t *testing.T) {
 			Proof: stateProofPathForCheck(crypto.Sha256, crypto.Sha256Size),
 		}
 		malformed.StateProof.Reveals = map[uint64]stateproof.Reveal{0: reveal}
-		require.ErrorIs(t, CheckTxnGroup([]SignedTxn{{Txn: malformed}}), errMalformedStateProofHash)
+		require.ErrorIs(t, CheckPaysetGroup([]SignedTxnWithAD{SignedTxn{Txn: malformed}.WithAD()}), errMalformedStateProofHash)
 	})
 
 	t.Run("nested Merkle signature proof path size", func(t *testing.T) {
@@ -114,7 +113,7 @@ func TestCheckTxnGroupStateProofBasicSuite(t *testing.T) {
 			Proof: stateProofPathForCheck(stateproof.HashType, crypto.Sha256Size),
 		}
 		malformed.StateProof.Reveals = map[uint64]stateproof.Reveal{0: reveal}
-		require.ErrorIs(t, CheckTxnGroup([]SignedTxn{{Txn: malformed}}), errMalformedStateProofPath)
+		require.ErrorIs(t, CheckPaysetGroup([]SignedTxnWithAD{SignedTxn{Txn: malformed}.WithAD()}), errMalformedStateProofPath)
 	})
 
 	t.Run("nested Basic Merkle signature proof", func(t *testing.T) {
@@ -126,52 +125,8 @@ func TestCheckTxnGroupStateProofBasicSuite(t *testing.T) {
 			Proof: stateProofPathForCheck(stateproof.HashType, stateproof.HashSize),
 		}
 		valid.StateProof.Reveals = map[uint64]stateproof.Reveal{0: reveal}
-		require.NoError(t, CheckTxnGroup([]SignedTxn{{Txn: valid}}))
+		require.NoError(t, CheckPaysetGroup([]SignedTxnWithAD{SignedTxn{Txn: valid}.WithAD()}))
 	})
-}
-
-func TestCheckTxnGroupApplicationBoxIndex(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-
-	malformed := Transaction{
-		Type: protocol.ApplicationCallTx,
-		ApplicationCallTxnFields: ApplicationCallTxnFields{
-			Boxes: []BoxRef{{Index: 1}},
-		},
-	}
-	require.ErrorIs(t, CheckTxnGroup([]SignedTxn{{Txn: malformed}}), errMalformedApplicationBoxIndex)
-
-	currentApp := Transaction{
-		Type: protocol.ApplicationCallTx,
-		ApplicationCallTxnFields: ApplicationCallTxnFields{
-			Boxes: []BoxRef{{Index: 0}},
-		},
-	}
-	require.NoError(t, CheckTxnGroup([]SignedTxn{{Txn: currentApp}}))
-
-	foreignApp := Transaction{
-		Type: protocol.ApplicationCallTx,
-		ApplicationCallTxnFields: ApplicationCallTxnFields{
-			ForeignApps: []basics.AppIndex{1},
-			Boxes:       []BoxRef{{Index: 1}},
-		},
-	}
-	require.NoError(t, CheckTxnGroup([]SignedTxn{{Txn: foreignApp}}))
-}
-
-func TestCheckPaysetGroupApplicationBoxIndex(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-
-	malformed := Transaction{
-		Type: protocol.ApplicationCallTx,
-		ApplicationCallTxnFields: ApplicationCallTxnFields{
-			Boxes: []BoxRef{{Index: 1}},
-		},
-	}
-	group := []SignedTxnWithAD{SignedTxn{Txn: malformed}.WithAD()}
-	require.ErrorIs(t, CheckPaysetGroup(group), errMalformedApplicationBoxIndex)
 }
 
 func TestCheckPaysetGroupID(t *testing.T) {
@@ -251,35 +206,63 @@ func TestHashTxGroupMatchesHashObj(t *testing.T) {
 	}
 }
 
-func TestCheckTxnGroupUnknownType(t *testing.T) {
+func TestCheckTxnGroupIDDuplicateTxn(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 
-	// A lone unknown transaction type does NOT crash today: nothing triggers the group-wide
-	// computeAvailability, so resources.fill is never called on it (WellFormed / applyTransaction's
-	// default reject it). The screen rejects it anyway, since an unknown type is always invalid.
-	bogus := Transaction{Type: protocol.TxType("bogus")}
-	require.ErrorIs(t, CheckTxnGroup([]SignedTxn{{Txn: bogus}}), errMalformedTxType)
-
-	// The crash case: the unknown type grouped *after* an app call. The app call triggers the
-	// whole-group computeAvailability, whose fill walks the unknown member before its WellFormed
-	// runs (and outside the eval() recover) and hits resources.fill's default. Caught as a group
-	// and after block decoding.
-	appcall := Transaction{Type: protocol.ApplicationCallTx}
-	require.ErrorIs(t, CheckTxnGroup([]SignedTxn{{Txn: appcall}, {Txn: bogus}}), errMalformedTxType)
-	require.ErrorIs(t, CheckPaysetGroup([]SignedTxnWithAD{
-		SignedTxn{Txn: appcall}.WithAD(),
-		SignedTxn{Txn: bogus}.WithAD(),
-	}), errMalformedTxType)
-
-	// Every known type that fill handles must still be accepted (guard against over-rejection).
-	// Heartbeat is excluded here because it independently requires its fields (tested elsewhere).
-	for _, tt := range []protocol.TxType{
-		protocol.PaymentTx, protocol.KeyRegistrationTx, protocol.AssetConfigTx,
-		protocol.AssetTransferTx, protocol.AssetFreezeTx, protocol.ApplicationCallTx,
-	} {
-		require.NoError(t, CheckTxnGroup([]SignedTxn{{Txn: Transaction{Type: tt}}}), "type %q must be accepted", tt)
+	regroup := func(stxns []SignedTxn) {
+		group := TxGroup{}
+		for i := range stxns {
+			stxns[i].Txn.Group = crypto.Digest{}
+			group.TxGroupHashes = append(group.TxGroupHashes, crypto.Digest(stxns[i].Txn.ID()))
+		}
+		groupID := crypto.HashObj(group)
+		for i := range stxns {
+			stxns[i].Txn.Group = groupID
+		}
 	}
-	require.NoError(t, CheckTxnGroup([]SignedTxn{{Txn: stateProofTxnForCheck()}}),
-		"type %q must be accepted", protocol.StateProofTx)
+
+	// [A, A]: the same transaction twice, with a group ID that commits to
+	// both occurrences, so only the duplicate check can reject it.
+	txn := SignedTxn{Txn: Transaction{Type: protocol.PaymentTx, Header: Header{Sender: basics.Address{1}}}}
+	dup := []SignedTxn{txn, txn}
+	regroup(dup)
+	err := CheckTxnGroupID(dup)
+	require.ErrorContains(t, err, "duplicate transaction")
+	var malformed *TxGroupMalformedError
+	require.ErrorAs(t, err, &malformed)
+	require.Equal(t, TxGroupMalformedErrorReasonDuplicateTxn, malformed.Reason)
+	require.Equal(t, 1, malformed.GroupIndex)
+
+	// [A(0), A(1)]: identical transactions whose LogicSigs carry different
+	// args. Same transaction IDs, so still a duplicate.
+	argsDup := []SignedTxn{txn, txn}
+	regroup(argsDup)
+	argsDup[0].Lsig = LogicSig{Logic: []byte{0x01}, Args: [][]byte{{0}}}
+	argsDup[1].Lsig = LogicSig{Logic: []byte{0x01}, Args: [][]byte{{1}}}
+	require.Equal(t, argsDup[0].Txn.ID(), argsDup[1].Txn.ID())
+	err = CheckTxnGroupID(argsDup)
+	require.ErrorAs(t, err, &malformed)
+	require.Equal(t, TxGroupMalformedErrorReasonDuplicateTxn, malformed.Reason)
+
+	// The duplicate need not be adjacent.
+	other := SignedTxn{Txn: Transaction{Type: protocol.PaymentTx, Header: Header{Sender: basics.Address{2}}}}
+	spread := []SignedTxn{txn, other, txn}
+	regroup(spread)
+	err = CheckTxnGroupID(spread)
+	require.ErrorAs(t, err, &malformed)
+	require.Equal(t, TxGroupMalformedErrorReasonDuplicateTxn, malformed.Reason)
+	require.Equal(t, 2, malformed.GroupIndex)
+
+	// Distinct transactions still pass, as does a lone ungrouped transaction.
+	valid := []SignedTxn{txn, other}
+	regroup(valid)
+	require.NoError(t, CheckTxnGroupID(valid))
+	require.NoError(t, CheckTxnGroupID([]SignedTxn{{Txn: Transaction{Type: protocol.PaymentTx}}}))
+
+	// The payset form used by the agreement proposal filter rejects it too.
+	dupAD := []SignedTxnWithAD{dup[0].WithAD(), dup[1].WithAD()}
+	err = CheckPaysetGroup(dupAD)
+	require.ErrorAs(t, err, &malformed)
+	require.Equal(t, TxGroupMalformedErrorReasonDuplicateTxn, malformed.Reason)
 }

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -225,7 +225,7 @@ func txnGroupBatchPrep(stxs []transactions.SignedTxn, contextHdr *bookkeeping.Bl
 		}
 	}
 
-	if err := transactions.CheckTxnGroup(stxs); err != nil {
+	if err := transactions.CheckTxnGroupID(stxs); err != nil {
 		groupIndex := -1
 		var groupErr *transactions.TxGroupMalformedError
 		if errors.As(err, &groupErr) {

--- a/data/transactions/verify/verifiedTxnCache_test.go
+++ b/data/transactions/verify/verifiedTxnCache_test.go
@@ -687,3 +687,101 @@ func BenchmarkVerifiedCacheGC(b *testing.B) {
 	b.ReportMetric(float64(retained)/(1024*1024), "total-MB")
 	b.ReportMetric(float64(retained)/float64(live), "bytes/entry")
 }
+
+// TestTxnGroupRejectsDuplicateTxid checks that a group carrying the same
+// transaction twice, differing only in LogicSig args, fails verification and
+// leaves nothing in the cache. The cache keys entries by transaction ID, so
+// two such transactions would otherwise share one entry.
+func TestTxnGroupRejectsDuplicateTxid(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	blkHdr := createDummyBlockHeader()
+	cache := MakeVerifiedTransactionCache(10)
+	dummyLedger := DummyLedgerForSignature{}
+
+	_, signedTxns, _, _ := generateTestObjects(1, 2, 0, 50)
+
+	// two copies of one contract-account LogicSig transaction, with
+	// different args: same Txn, hence same transaction ID
+	a0 := transactions.SignedTxn{Txn: signedTxns[0].Txn}
+	a0.Lsig.Logic = []byte{0x06, 0x81, 0x01} // pushint 1
+	a0.Lsig.Args = [][]byte{{0}}
+	a1 := a0
+	a1.Lsig.Args = [][]byte{{1}}
+
+	group := []transactions.SignedTxn{a0, a1}
+	grpObj := transactions.TxGroup{}
+	for i := range group {
+		group[i].Txn.Group = crypto.Digest{}
+		grpObj.TxGroupHashes = append(grpObj.TxGroupHashes, crypto.Digest(group[i].Txn.ID()))
+	}
+	groupID := crypto.HashObj(grpObj)
+	for i := range group {
+		group[i].Txn.Group = groupID
+	}
+	require.Equal(t, group[0].ID(), group[1].ID())
+
+	// the group ID commits to both occurrences, so only the duplicate
+	// check can reject it
+	_, err := TxnGroup(group, &blkHdr, cache, &dummyLedger)
+	require.Error(t, err)
+	var malformed *transactions.TxGroupMalformedError
+	require.ErrorAs(t, err, &malformed)
+	require.Equal(t, transactions.TxGroupMalformedErrorReasonDuplicateTxn, malformed.Reason)
+
+	// nothing may arrive in the cache from the failed group
+	impl := cache.(*verifiedTransactionCache)
+	require.Empty(t, impl.pinned)
+	for _, bucket := range impl.buckets {
+		require.Empty(t, bucket)
+	}
+	unverified := cache.GetUnverifiedTransactionGroups(
+		[][]transactions.SignedTxn{{a1, a1}}, spec, blkHdr.CurrentProtocol)
+	require.Len(t, unverified, 1)
+}
+
+// TestGetUnverifiedTransactionGroupsMalformedGroups covers groups that reuse a
+// cached group's ID: a superset ([A,B,B]), a permutation ([B,A]) and a prefix
+// ([A]). The lookup must not panic on any of them, and CheckTxnGroupID must
+// reject all three: the cache is position-blind, so callers establish group-ID
+// validity and transaction-ID uniqueness before consulting it.
+func TestGetUnverifiedTransactionGroupsMalformedGroups(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	// cap the generator at two so pairs are the common outcome rather than a lucky draw
+	_, signedTxns, secrets, addrs := generateTestObjects(64, 8, 0, 50)
+	var ab []transactions.SignedTxn
+	for _, g := range generateTransactionGroups(2, signedTxns, secrets, addrs) {
+		if len(g) == 2 {
+			ab = g
+			break
+		}
+	}
+	require.NotNil(t, ab)
+
+	cache := MakeVerifiedTransactionCache(500)
+	groupCtx, err := PrepareGroupContext(ab, blockHeader, nil, nil)
+	require.NoError(t, err)
+	cache.Add(groupCtx)
+	require.Empty(t, cache.GetUnverifiedTransactionGroups(
+		[][]transactions.SignedTxn{ab}, groupCtx.specAddrs, groupCtx.consensusVersion),
+		"the honest group must hit the cache")
+
+	for _, test := range []struct {
+		name  string
+		group []transactions.SignedTxn
+	}{
+		{"superset", []transactions.SignedTxn{ab[0], ab[1], ab[1]}},
+		{"permutation", []transactions.SignedTxn{ab[1], ab[0]}},
+		{"prefix", []transactions.SignedTxn{ab[0]}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				cache.GetUnverifiedTransactionGroups(
+					[][]transactions.SignedTxn{test.group}, groupCtx.specAddrs, groupCtx.consensusVersion)
+			})
+			require.Error(t, transactions.CheckTxnGroupID(test.group),
+				"the group-ID and duplicate checks must reject this before the cache is consulted")
+		})
+	}
+}

--- a/ledger/eval/eval.go
+++ b/ledger/eval/eval.go
@@ -2144,6 +2144,13 @@ func (validator *evalTxValidator) run() {
 				return
 			}
 		}
+		// A group that fully hits the cache below skips verify.PaysetGroups,
+		// so the checks inside it would never run on that group. Run them
+		// here instead, ahead of the cache.
+		if err := transactions.CheckTxnGroupID(signedTxnGroup); err != nil {
+			validator.done <- err
+			return
+		}
 		unverifiedTxnGroups = append(unverifiedTxnGroups, signedTxnGroup)
 	}
 

--- a/ledger/eval/eval_test.go
+++ b/ledger/eval/eval_test.go
@@ -1965,3 +1965,85 @@ func TestComputeLoad(t *testing.T) {
 		require.Equal(t, tt.expected, result)
 	}
 }
+
+// TestEvalTxValidatorGroupChecksPrecedeCache checks that evalTxValidator
+// rejects a group whose ID does not commit to its contents, and a group that
+// repeats a transaction, before consulting the verified-txn cache. The cache is
+// mocked to report everything as verified, so a failure here means the checks
+// ran after it rather than before.
+func TestEvalTxValidatorGroupChecksPrecedeCache(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	var blk bookkeeping.Block
+	blk.BlockHeader.Round = 1
+	blk.BlockHeader.GenesisHash = crypto.Digest{0x01}
+	blk.BlockHeader.CurrentProtocol = protocol.ConsensusCurrentVersion
+
+	mkTxn := func(sender byte) transactions.SignedTxn {
+		return transactions.SignedTxn{Txn: transactions.Transaction{
+			Type: protocol.PaymentTx,
+			Header: transactions.Header{
+				Sender:      basics.Address{sender},
+				FirstValid:  1,
+				LastValid:   1000,
+				GenesisHash: blk.BlockHeader.GenesisHash,
+			},
+		}}
+	}
+	regroup := func(stxns []transactions.SignedTxn) {
+		group := transactions.TxGroup{}
+		for i := range stxns {
+			stxns[i].Txn.Group = crypto.Digest{}
+			group.TxGroupHashes = append(group.TxGroupHashes, crypto.Digest(stxns[i].Txn.ID()))
+		}
+		groupID := crypto.HashObj(group)
+		for i := range stxns {
+			stxns[i].Txn.Group = groupID
+		}
+	}
+	toADs := func(stxns []transactions.SignedTxn) []transactions.SignedTxnWithAD {
+		ads := make([]transactions.SignedTxnWithAD, len(stxns))
+		for i, stxn := range stxns {
+			ads[i] = stxn.WithAD()
+		}
+		return ads
+	}
+	validate := func(group []transactions.SignedTxnWithAD) error {
+		validator := evalTxValidator{
+			// alwaysVerified: every group presented to the cache hits in full
+			txcache:  verify.GetMockedCache(true),
+			block:    blk,
+			ctx:      context.Background(),
+			txgroups: [][]transactions.SignedTxnWithAD{group},
+			done:     make(chan error, 1),
+		}
+		validator.run()
+		return <-validator.done
+	}
+
+	a, b := mkTxn(1), mkTxn(2)
+
+	// control: a well-formed group passes (via the mocked cache hit).
+	good := []transactions.SignedTxn{a, b}
+	regroup(good)
+	require.NoError(t, validate(toADs(good)))
+
+	// [B, A] carrying the group ID of [A, B]: the ID does not commit to the
+	// presented order.
+	permuted := []transactions.SignedTxn{good[1], good[0]}
+	var malformed *ledgercore.TxGroupMalformedError
+	err := validate(toADs(permuted))
+	require.ErrorContains(t, err, "incomplete group")
+	require.ErrorAs(t, err, &malformed)
+	require.Equal(t, ledgercore.TxGroupMalformedErrorReasonIncompleteGroup, malformed.Reason)
+
+	// [A, A] with a group ID that commits to both occurrences, so only the
+	// duplicate check can reject it.
+	dup := []transactions.SignedTxn{a, a}
+	regroup(dup)
+	err = validate(toADs(dup))
+	require.ErrorContains(t, err, "duplicate transaction")
+	require.ErrorAs(t, err, &malformed)
+	require.Equal(t, ledgercore.TxGroupMalformedErrorReasonDuplicateTxn, malformed.Reason)
+}

--- a/ledger/ledgercore/error.go
+++ b/ledger/ledgercore/error.go
@@ -194,6 +194,8 @@ const (
 	TxGroupMalformedErrorReasonIncompleteGroup = transactions.TxGroupMalformedErrorReasonIncompleteGroup
 	// TxGroupErrorReasonInvalidFee indicates a group with improper fees
 	TxGroupErrorReasonInvalidFee = transactions.TxGroupErrorReasonInvalidFee
+	// TxGroupMalformedErrorReasonDuplicateTxn indicates a group that contains the same transaction twice
+	TxGroupMalformedErrorReasonDuplicateTxn = transactions.TxGroupMalformedErrorReasonDuplicateTxn
 )
 
 // TxGroupMalformedError indicates txgroup violates a group-wide rule (size, group hash, etc)


### PR DESCRIPTION
## Summary

Reject duplicate transaction IDs in checkTxnGroupID and check every group before evalTxValidator consults the verified transaction cache. The cache is keyed by transaction ID, so group commitments and distinct IDs must be validated before lookup. Duplicate detection reuses the existing hashes.

Remove checks covered by WellFormed and the overly strict ban on heartbeats in resource groups. Verify now calls CheckTxnGroupID directly; the proposal filter retains state-proof screening.

## Test Plan

New tests added.