### PR TITLE
rpcs: use generated msgpack code for txsync and block services

### DIFF
--- a/catchup/universalFetcher.go
+++ b/catchup/universalFetcher.go
@@ -192,7 +192,7 @@ func (w *wsFetcherClient) requestBlock(ctx context.Context, round basics.Round) 
 		return nil, makeErrWsFetcherRequestFailed(round, w.target.GetAddress(), "Cert data not found")
 	}
 
-	blockCertBytes := protocol.EncodeReflect(rpcs.PreEncodedBlockCert{
+	blockCertBytes := protocol.Encode(&rpcs.PreEncodedBlockCert{
 		Block:       blk,
 		Certificate: cert})
 

--- a/catchup/universalFetcher_test.go
+++ b/catchup/universalFetcher_test.go
@@ -157,7 +157,7 @@ func TestProcessBlockBytesErrors(t *testing.T) {
 	}
 
 	blkData := protocol.Encode(&blk)
-	bc := protocol.EncodeReflect(rpcs.PreEncodedBlockCert{
+	bc := protocol.Encode(&rpcs.PreEncodedBlockCert{
 		Block: blkData,
 	})
 

--- a/rpcs/blockService.go
+++ b/rpcs/blockService.go
@@ -30,8 +30,8 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/algorand/go-codec/codec"
 	"github.com/algorand/go-deadlock"
+	"github.com/algorand/msgp/msgp"
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"
@@ -119,12 +119,13 @@ type EncodedBlockCert struct {
 }
 
 // PreEncodedBlockCert defines how GetBlockBytes encodes a block and its certificate,
-// using a pre-encoded Block and Certificate in msgpack format.
-//
-//msgp:ignore PreEncodedBlockCert
+// using a pre-encoded Block and Certificate in msgpack format. It must encode to the
+// same bytes as EncodedBlockCert, which is what the fetching side decodes into.
 type PreEncodedBlockCert struct {
-	Block       codec.Raw `codec:"block"`
-	Certificate codec.Raw `codec:"cert"`
+	_struct struct{} `codec:""`
+
+	Block       msgp.Raw `codec:"block"`
+	Certificate msgp.Raw `codec:"cert"`
 }
 
 type fallbackEndpoints struct {
@@ -489,7 +490,7 @@ func RawBlockBytes(l LedgerForBlockService, round basics.Round) ([]byte, error) 
 		return nil, ledgercore.ErrNoEntry{Round: round}
 	}
 
-	return protocol.EncodeReflect(PreEncodedBlockCert{
+	return protocol.Encode(&PreEncodedBlockCert{
 		Block:       blk,
 		Certificate: cert,
 	}), nil

--- a/rpcs/blockService_test.go
+++ b/rpcs/blockService_test.go
@@ -344,7 +344,7 @@ func TestRedirectOnFullCapacity(t *testing.T) {
 	require.NotEqual(t, 0, len(bodyData))
 	// parse the block to get the header timestamp, which tells us which node served it
 	var blkCert PreEncodedBlockCert
-	require.NoError(t, protocol.DecodeReflect(bodyData, &blkCert))
+	require.NoError(t, protocol.Decode(bodyData, &blkCert))
 	var blk bookkeeping.Block
 	require.NoError(t, protocol.Decode(blkCert.Block, &blk))
 	// check if redirection happened

--- a/rpcs/httpTxSync.go
+++ b/rpcs/httpTxSync.go
@@ -55,9 +55,7 @@ const baseResponseReadingBufferSize = uint64(1024)
 // several times what an honest response holds at the default TxSyncServeResponseSize.
 const maxTxSyncResponseTxns = 25000
 
-// txSyncResponse is a txsync response body, named so the decode goes through msgp and
-// the bound above. Decoding through reflection bypasses msgp allocbounds. The wire
-// format is unchanged.
+// txSyncResponse is a txsync response body, used for msgp encoding.
 //
 //msgp:allocbound txSyncResponse maxTxSyncResponseTxns
 type txSyncResponse []transactions.SignedTxn

--- a/rpcs/httpTxSync.go
+++ b/rpcs/httpTxSync.go
@@ -48,6 +48,20 @@ type HTTPTxSync struct {
 const requestContentType = "application/x-www-form-urlencoded"
 const baseResponseReadingBufferSize = uint64(1024)
 
+// maxTxSyncResponseTxns bounds how many transactions a txsync response may decode
+// into. The byte cap on the response body does not bound this on its own: a msgpack
+// element can be far smaller than the SignedTxn it decodes into, and the decoder
+// allocates from the declared array length before reading any element. The bound is
+// several times what an honest response holds at the default TxSyncServeResponseSize.
+const maxTxSyncResponseTxns = 25000
+
+// txSyncResponse is a txsync response body, named so the decode goes through msgp and
+// the bound above. Decoding through reflection bypasses msgp allocbounds. The wire
+// format is unchanged.
+//
+//msgp:allocbound txSyncResponse maxTxSyncResponseTxns
+type txSyncResponse []transactions.SignedTxn
+
 // ResponseBytes reads the content of the response object and return the body content
 // while obeying the read size limits
 func ResponseBytes(response *http.Response, log logging.Logger, limit uint64) (data []byte, err error) {
@@ -163,8 +177,8 @@ func (hts *HTTPTxSync) Sync(ctx context.Context, bloom *bloom.Filter) (txgroups 
 	}
 	hts.log.Debugf("http sync got %d bytes", len(data))
 
-	var txns []transactions.SignedTxn
-	err = protocol.DecodeReflect(data, &txns)
+	var txns txSyncResponse
+	err = protocol.Decode(data, &txns)
 	if err != nil {
 		hts.log.Warn("txSync protocol decode: ", err)
 	}

--- a/rpcs/httpTxSync_test.go
+++ b/rpcs/httpTxSync_test.go
@@ -50,7 +50,7 @@ func TestTxSyncResponseDecode(t *testing.T) {
 
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
-		txns := []transactions.SignedTxn{
+		txns := txSyncResponse{
 			{Txn: transactions.Transaction{
 				Type:             protocol.PaymentTx,
 				Header:           transactions.Header{Sender: basics.Address{1}, Fee: basics.MicroAlgos{Raw: 1000}},
@@ -62,22 +62,26 @@ func TestTxSyncResponseDecode(t *testing.T) {
 			}},
 		}
 		var decoded txSyncResponse
-		require.NoError(t, protocol.Decode(protocol.EncodeReflect(txns), &decoded))
-		require.Equal(t, txns, []transactions.SignedTxn(decoded))
+		require.NoError(t, protocol.Decode(protocol.Encode(txns), &decoded))
+		require.Equal(t, txns, decoded)
 	})
 
-	// a server with nothing to send encodes a nil slice, which is msgpack nil
+	// The serve side sends a non-nil empty slice, an empty array. msgpack nil is the other
+	// encoding of an absent array, and must decode to empty rather than error.
 	t.Run("empty response", func(t *testing.T) {
 		t.Parallel()
-		var none []transactions.SignedTxn
-		var decoded txSyncResponse
-		require.NoError(t, protocol.Decode(protocol.EncodeReflect(none), &decoded))
-		require.Empty(t, decoded)
+		require.Equal(t, []byte{0x90}, protocol.Encode(txSyncResponse{}))    // empty array
+		require.Equal(t, []byte{0xc0}, protocol.Encode(txSyncResponse(nil))) // nil
+
+		for _, none := range []txSyncResponse{{}, nil} {
+			var decoded txSyncResponse
+			require.NoError(t, protocol.Decode(protocol.Encode(none), &decoded))
+			require.Empty(t, decoded)
+		}
 	})
 
-	// Reflection decoded msgpack nil into a zero SignedTxn. The generated decoder
-	// rejects it, since txn is a required field, though only after allocating from
-	// the declared length, which is why the bound below is what limits the allocation.
+	// A nil element is rejected, txn being required, but only after the decoder allocates
+	// from the declared length. That is why the bound, not the error, caps the allocation.
 	t.Run("nil elements", func(t *testing.T) {
 		t.Parallel()
 		var decoded txSyncResponse
@@ -90,8 +94,8 @@ func TestTxSyncResponseDecode(t *testing.T) {
 		Type:   protocol.PaymentTx,
 		Header: transactions.Header{Sender: basics.Address{1}},
 	}}
-	repeated := func(n int) []transactions.SignedTxn {
-		txns := make([]transactions.SignedTxn, n)
+	repeated := func(n int) txSyncResponse {
+		txns := make(txSyncResponse, n)
 		for i := range txns {
 			txns[i] = minimal
 		}
@@ -101,15 +105,15 @@ func TestTxSyncResponseDecode(t *testing.T) {
 	t.Run("at the bound", func(t *testing.T) {
 		t.Parallel()
 		var decoded txSyncResponse
-		require.NoError(t, protocol.Decode(protocol.EncodeReflect(repeated(maxTxSyncResponseTxns)), &decoded))
+		require.NoError(t, protocol.Decode(protocol.Encode(repeated(maxTxSyncResponseTxns)), &decoded))
 		require.Len(t, decoded, maxTxSyncResponseTxns)
 	})
 
-	// This many transactions exceed the default byte cap when encoded, so the
-	// bound also covers a raised TxSyncServeResponseSize.
+	// Even at the smallest decodable SignedTxn, this many overrun the default
+	// TxSyncServeResponseSize, so the serve side cannot reach the bound.
 	t.Run("over the bound", func(t *testing.T) {
 		t.Parallel()
-		body := protocol.EncodeReflect(repeated(maxTxSyncResponseTxns + 1))
+		body := protocol.Encode(repeated(maxTxSyncResponseTxns + 1))
 		require.Greater(t, uint64(len(body)), uint64(config.GetDefaultLocal().TxSyncServeResponseSize))
 
 		var decoded txSyncResponse

--- a/rpcs/httpTxSync_test.go
+++ b/rpcs/httpTxSync_test.go
@@ -1,0 +1,120 @@
+// Copyright (C) 2019-2026 Algorand Foundation Ltd.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package rpcs
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/test/partitiontest"
+)
+
+// TestTxSyncResponseDecode covers decoding a txsync response body.
+func TestTxSyncResponseDecode(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	// emptyTxnArray encodes an array of n msgpack nil elements.
+	emptyTxnArray := func(n int) []byte {
+		var buf bytes.Buffer
+		buf.WriteByte(0xdd) // msgpack array32
+		var hdr [4]byte
+		binary.BigEndian.PutUint32(hdr[:], uint32(n))
+		buf.Write(hdr[:])
+		for i := 0; i < n; i++ {
+			buf.WriteByte(0xc0) // msgpack nil
+		}
+		return buf.Bytes()
+	}
+
+	t.Run("normal", func(t *testing.T) {
+		t.Parallel()
+		txns := []transactions.SignedTxn{
+			{Txn: transactions.Transaction{
+				Type:             protocol.PaymentTx,
+				Header:           transactions.Header{Sender: basics.Address{1}, Fee: basics.MicroAlgos{Raw: 1000}},
+				PaymentTxnFields: transactions.PaymentTxnFields{Receiver: basics.Address{2}, Amount: basics.MicroAlgos{Raw: 7}},
+			}},
+			{Txn: transactions.Transaction{
+				Type:   protocol.KeyRegistrationTx,
+				Header: transactions.Header{Sender: basics.Address{3}, Fee: basics.MicroAlgos{Raw: 1000}},
+			}},
+		}
+		var decoded txSyncResponse
+		require.NoError(t, protocol.Decode(protocol.EncodeReflect(txns), &decoded))
+		require.Equal(t, txns, []transactions.SignedTxn(decoded))
+	})
+
+	// a server with nothing to send encodes a nil slice, which is msgpack nil
+	t.Run("empty response", func(t *testing.T) {
+		t.Parallel()
+		var none []transactions.SignedTxn
+		var decoded txSyncResponse
+		require.NoError(t, protocol.Decode(protocol.EncodeReflect(none), &decoded))
+		require.Empty(t, decoded)
+	})
+
+	// Reflection decoded msgpack nil into a zero SignedTxn. The generated decoder
+	// rejects it, since txn is a required field, though only after allocating from
+	// the declared length, which is why the bound below is what limits the allocation.
+	t.Run("nil elements", func(t *testing.T) {
+		t.Parallel()
+		var decoded txSyncResponse
+		err := protocol.Decode(emptyTxnArray(8), &decoded)
+		require.ErrorContains(t, err, "missing required field: txn")
+	})
+
+	// minimal carries only the fields the decoder requires.
+	minimal := transactions.SignedTxn{Txn: transactions.Transaction{
+		Type:   protocol.PaymentTx,
+		Header: transactions.Header{Sender: basics.Address{1}},
+	}}
+	repeated := func(n int) []transactions.SignedTxn {
+		txns := make([]transactions.SignedTxn, n)
+		for i := range txns {
+			txns[i] = minimal
+		}
+		return txns
+	}
+
+	t.Run("at the bound", func(t *testing.T) {
+		t.Parallel()
+		var decoded txSyncResponse
+		require.NoError(t, protocol.Decode(protocol.EncodeReflect(repeated(maxTxSyncResponseTxns)), &decoded))
+		require.Len(t, decoded, maxTxSyncResponseTxns)
+	})
+
+	// This many transactions exceed the default byte cap when encoded, so the
+	// bound also covers a raised TxSyncServeResponseSize.
+	t.Run("over the bound", func(t *testing.T) {
+		t.Parallel()
+		body := protocol.EncodeReflect(repeated(maxTxSyncResponseTxns + 1))
+		require.Greater(t, uint64(len(body)), uint64(config.GetDefaultLocal().TxSyncServeResponseSize))
+
+		var decoded txSyncResponse
+		err := protocol.Decode(body, &decoded)
+		require.ErrorContains(t, err, "length overflow")
+		require.Empty(t, decoded, "oversized array was allocated before being rejected")
+	})
+}

--- a/rpcs/msgp_gen.go
+++ b/rpcs/msgp_gen.go
@@ -21,6 +21,16 @@ import (
 //         |-----> (*) MsgIsZero
 //         |-----> EncodedBlockCertMaxSize()
 //
+// PreEncodedBlockCert
+//          |-----> (*) MarshalMsg
+//          |-----> (*) CanMarshalMsg
+//          |-----> (*) UnmarshalMsg
+//          |-----> (*) UnmarshalMsgWithState
+//          |-----> (*) CanUnmarshalMsg
+//          |-----> (*) Msgsize
+//          |-----> (*) MsgIsZero
+//          |-----> PreEncodedBlockCertMaxSize()
+//
 // txSyncResponse
 //        |-----> MarshalMsg
 //        |-----> CanMarshalMsg
@@ -155,6 +165,131 @@ func (z *EncodedBlockCert) MsgIsZero() bool {
 func EncodedBlockCertMaxSize() (s int) {
 	s = 1 + 6 + bookkeeping.BlockMaxSize() + 5 + agreement.CertificateMaxSize()
 	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *PreEncodedBlockCert) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "block"
+	o = append(o, 0x82, 0xa5, 0x62, 0x6c, 0x6f, 0x63, 0x6b)
+	o = (*z).Block.MarshalMsg(o)
+	// string "cert"
+	o = append(o, 0xa4, 0x63, 0x65, 0x72, 0x74)
+	o = (*z).Certificate.MarshalMsg(o)
+	return
+}
+
+func (_ *PreEncodedBlockCert) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(*PreEncodedBlockCert)
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *PreEncodedBlockCert) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []byte, err error) {
+	if st.AllowableDepth == 0 {
+		err = msgp.ErrMaxDepthExceeded{}
+		return
+	}
+	st.AllowableDepth--
+	var field []byte
+	_ = field
+	var zb0001 int
+	var zb0002 bool
+	zb0001, zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if _, ok := err.(msgp.TypeError); ok {
+		zb0001, zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Block.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Block")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			zb0001--
+			bts, err = (*z).Certificate.UnmarshalMsgWithState(bts, st)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array", "Certificate")
+				return
+			}
+		}
+		if zb0001 > 0 {
+			err = msgp.ErrTooManyArrayFields(zb0001)
+			if err != nil {
+				err = msgp.WrapError(err, "struct-from-array")
+				return
+			}
+		}
+	} else {
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		if zb0002 {
+			(*z) = PreEncodedBlockCert{}
+		}
+		for zb0001 > 0 {
+			zb0001--
+			field, bts, err = msgp.ReadMapKeyZC(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+			switch string(field) {
+			case "block":
+				bts, err = (*z).Block.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Block")
+					return
+				}
+			case "cert":
+				bts, err = (*z).Certificate.UnmarshalMsgWithState(bts, st)
+				if err != nil {
+					err = msgp.WrapError(err, "Certificate")
+					return
+				}
+			default:
+				err = msgp.ErrNoField(string(field))
+				if err != nil {
+					err = msgp.WrapError(err)
+					return
+				}
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *PreEncodedBlockCert) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.UnmarshalMsgWithState(bts, msgp.DefaultUnmarshalState)
+}
+func (_ *PreEncodedBlockCert) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*PreEncodedBlockCert)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *PreEncodedBlockCert) Msgsize() (s int) {
+	s = 1 + 6 + (*z).Block.Msgsize() + 5 + (*z).Certificate.Msgsize()
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z *PreEncodedBlockCert) MsgIsZero() bool {
+	return ((*z).Block.MsgIsZero()) && ((*z).Certificate.MsgIsZero())
+}
+
+// PreEncodedBlockCertMaxSize returns a maximum valid message size for this message type
+func PreEncodedBlockCertMaxSize() (s int) {
+	s = 1 + 6
+	panic("Unable to determine max size: MaxSize() not implemented for Raw type")
 }
 
 // MarshalMsg implements msgp.Marshaler

--- a/rpcs/msgp_gen.go
+++ b/rpcs/msgp_gen.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/data/transactions"
 )
 
 // The following msgp objects are implemented in this file:
@@ -19,6 +20,16 @@ import (
 //         |-----> (*) Msgsize
 //         |-----> (*) MsgIsZero
 //         |-----> EncodedBlockCertMaxSize()
+//
+// txSyncResponse
+//        |-----> MarshalMsg
+//        |-----> CanMarshalMsg
+//        |-----> (*) UnmarshalMsg
+//        |-----> (*) UnmarshalMsgWithState
+//        |-----> (*) CanUnmarshalMsg
+//        |-----> Msgsize
+//        |-----> MsgIsZero
+//        |-----> TxSyncResponseMaxSize()
 //
 
 // MarshalMsg implements msgp.Marshaler
@@ -143,5 +154,93 @@ func (z *EncodedBlockCert) MsgIsZero() bool {
 // EncodedBlockCertMaxSize returns a maximum valid message size for this message type
 func EncodedBlockCertMaxSize() (s int) {
 	s = 1 + 6 + bookkeeping.BlockMaxSize() + 5 + agreement.CertificateMaxSize()
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z txSyncResponse) MarshalMsg(b []byte) (o []byte) {
+	o = msgp.Require(b, z.Msgsize())
+	if z == nil {
+		o = msgp.AppendNil(o)
+	} else {
+		o = msgp.AppendArrayHeader(o, uint32(len(z)))
+	}
+	for za0004 := range z {
+		o = z[za0004].MarshalMsg(o)
+	}
+	return
+}
+
+func (_ txSyncResponse) CanMarshalMsg(z interface{}) bool {
+	_, ok := (z).(txSyncResponse)
+	if !ok {
+		_, ok = (z).(*txSyncResponse)
+	}
+	return ok
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *txSyncResponse) UnmarshalMsgWithState(bts []byte, st msgp.UnmarshalState) (o []byte, err error) {
+	if st.AllowableDepth == 0 {
+		err = msgp.ErrMaxDepthExceeded{}
+		return
+	}
+	st.AllowableDepth--
+	var zb0002 int
+	var zb0003 bool
+	zb0002, zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	if zb0002 > maxTxSyncResponseTxns {
+		err = msgp.ErrOverflow(uint64(zb0002), uint64(maxTxSyncResponseTxns))
+		err = msgp.WrapError(err)
+		return
+	}
+	if zb0003 {
+		(*z) = nil
+	} else if (*z) != nil && cap((*z)) >= zb0002 {
+		(*z) = (*z)[:zb0002]
+	} else {
+		(*z) = make(txSyncResponse, zb0002)
+	}
+	for zb0001 := range *z {
+		bts, err = (*z)[zb0001].UnmarshalMsgWithState(bts, st)
+		if err != nil {
+			err = msgp.WrapError(err, zb0001)
+			return
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *txSyncResponse) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	return z.UnmarshalMsgWithState(bts, msgp.DefaultUnmarshalState)
+}
+func (_ *txSyncResponse) CanUnmarshalMsg(z interface{}) bool {
+	_, ok := (z).(*txSyncResponse)
+	return ok
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z txSyncResponse) Msgsize() (s int) {
+	s = msgp.ArrayHeaderSize
+	for za0004 := range z {
+		s += z[za0004].Msgsize()
+	}
+	return
+}
+
+// MsgIsZero returns whether this is a zero value
+func (z txSyncResponse) MsgIsZero() bool {
+	return len(z) == 0
+}
+
+// TxSyncResponseMaxSize returns a maximum valid message size for this message type
+func TxSyncResponseMaxSize() (s int) {
+	// Calculating size of slice: z
+	s += msgp.ArrayHeaderSize + ((maxTxSyncResponseTxns) * (transactions.SignedTxnMaxSize()))
 	return
 }

--- a/rpcs/msgp_gen_test.go
+++ b/rpcs/msgp_gen_test.go
@@ -72,3 +72,63 @@ func BenchmarkUnmarshalEncodedBlockCert(b *testing.B) {
 		}
 	}
 }
+
+func TestMarshalUnmarshaltxSyncResponse(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	v := txSyncResponse{}
+	bts := v.MarshalMsg(nil)
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func TestRandomizedEncodingtxSyncResponse(t *testing.T) {
+	protocol.RunEncodingTest(t, &txSyncResponse{})
+}
+
+func BenchmarkMarshalMsgtxSyncResponse(b *testing.B) {
+	v := txSyncResponse{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgtxSyncResponse(b *testing.B) {
+	v := txSyncResponse{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshaltxSyncResponse(b *testing.B) {
+	v := txSyncResponse{}
+	bts := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/rpcs/msgp_gen_test.go
+++ b/rpcs/msgp_gen_test.go
@@ -73,6 +73,66 @@ func BenchmarkUnmarshalEncodedBlockCert(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalPreEncodedBlockCert(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	v := PreEncodedBlockCert{}
+	bts := v.MarshalMsg(nil)
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func TestRandomizedEncodingPreEncodedBlockCert(t *testing.T) {
+	protocol.RunEncodingTest(t, &PreEncodedBlockCert{})
+}
+
+func BenchmarkMarshalMsgPreEncodedBlockCert(b *testing.B) {
+	v := PreEncodedBlockCert{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgPreEncodedBlockCert(b *testing.B) {
+	v := PreEncodedBlockCert{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalPreEncodedBlockCert(b *testing.B) {
+	v := PreEncodedBlockCert{}
+	bts := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshaltxSyncResponse(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	v := txSyncResponse{}

--- a/rpcs/txService.go
+++ b/rpcs/txService.go
@@ -136,7 +136,7 @@ func (txs *TxService) ServeHTTP(response http.ResponseWriter, request *http.Requ
 		return
 	}
 	txns := txs.getFilteredTxns(filter)
-	txblob := protocol.EncodeReflect(txns)
+	txblob := protocol.Encode(txns)
 	txs.log.Debugf("sending %d txns in %d bytes", len(txns), len(txblob))
 	response.Header().Set("Content-Length", strconv.Itoa(len(txblob)))
 	response.Header().Set("Content-Type", responseContentType)
@@ -147,7 +147,7 @@ func (txs *TxService) ServeHTTP(response http.ResponseWriter, request *http.Requ
 	}
 }
 
-func (txs *TxService) getFilteredTxns(bloom *bloom.Filter) (txns []transactions.SignedTxn) {
+func (txs *TxService) getFilteredTxns(bloom *bloom.Filter) (txns txSyncResponse) {
 	pendingTxGroups := txs.updateTxCache()
 
 	missingTxns := make([]transactions.SignedTxn, 0)

--- a/rpcs/txSyncer_test.go
+++ b/rpcs/txSyncer_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/algorand/go-algorand/components/mocks"
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/logging"
@@ -77,10 +78,13 @@ func makeMockPendingTxAggregate(txCount int) mockPendingTxAggregate {
 	for i := 0; i < txCount; i++ {
 		var note [16]byte
 		testRandBytes(note[:])
+		// Sender must be set: it is a required field, so a transaction without one
+		// does not survive a round trip through the txsync response encoding.
 		tx := transactions.Transaction{
 			Type: protocol.PaymentTx,
 			Header: transactions.Header{
-				Note: note[:],
+				Sender: basics.Address(sk.SignatureVerifier),
+				Note:   note[:],
 			},
 		}
 		stx := tx.Sign(sk)


### PR DESCRIPTION
## Summary

This uses the generated msgp marshal/unmarshal code in `HTTPTxSync.Sync`, and also in the block service that serves `PreEncodedBlockCert` for catchup. Now the `rpcs` package has no calls remaining to `DecodeReflect` or `EncodeReflect`.

## Test Plan

New file httpTxSync_test.go added with tests.