### PR TITLE
config: don't fail restart when stateproof/crash DBs are already in HotDataDir

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1040,6 +1040,35 @@ func TestEnsureAndResolveGenesisDirs_migrateSPErr(t *testing.T) {
 	require.FileExists(t, filepath.Join(hotDir, "stateproof.sqlite-wal"))
 }
 
+// TestEnsureAndResolveGenesisDirs_migrateRestart confirms that once the crash and stateproof DB files
+// live in HotDataDir (and not in ColdDataDir), resolving again succeeds, as on a node restart.
+func TestEnsureAndResolveGenesisDirs_migrateRestart(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	cfg := GetDefaultLocal()
+	testDirectory := t.TempDir()
+	cfg.HotDataDir = filepath.Join(testDirectory, "hot")
+	cfg.ColdDataDir = filepath.Join(testDirectory, "cold")
+	coldDir := filepath.Join(cfg.ColdDataDir, "myGenesisID")
+	hotDir := filepath.Join(cfg.HotDataDir, "myGenesisID")
+	err := os.MkdirAll(coldDir, 0755)
+	require.NoError(t, err)
+	err = os.MkdirAll(hotDir, 0755)
+	require.NoError(t, err)
+	// put crash.sqlite and stateproof.sqlite files in the HotDataDir only
+	err = os.WriteFile(filepath.Join(hotDir, "crash.sqlite"), []byte("test"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(hotDir, "stateproof.sqlite"), []byte("test"), 0644)
+	require.NoError(t, err)
+	// Resolve
+	paths, err := cfg.EnsureAndResolveGenesisDirs(testDirectory, "myGenesisID", tLogger{t: t})
+	require.NoError(t, err)
+	require.Equal(t, hotDir, paths.CrashGenesisDir)
+	require.Equal(t, hotDir, paths.StateproofGenesisDir)
+	require.FileExists(t, filepath.Join(hotDir, "crash.sqlite"))
+	require.FileExists(t, filepath.Join(hotDir, "stateproof.sqlite"))
+}
+
 // TestEnsureAndResolveGenesisDirsError confirms that if a path can't be created, an error is returned
 func TestEnsureAndResolveGenesisDirsError(t *testing.T) {
 	partitiontest.PartitionTest(t)

--- a/config/localTemplate.go
+++ b/config/localTemplate.go
@@ -989,13 +989,25 @@ func (cfg *Local) EnsureAndResolveGenesisDirs(rootDir, genesisID string, logger 
 }
 
 func moveDirIfExists(logger logger, srcdir, dstdir string, files ...string) error {
-	// first, check if any files already exist in dstdir, and quit if so
+	// first, check if any files exist in srcdir; if none do, there is nothing to migrate
+	// (e.g. the files were already moved to dstdir on a previous startup)
+	srcExists := false
+	for _, file := range files {
+		if _, err := os.Stat(filepath.Join(srcdir, file)); err == nil {
+			srcExists = true
+			break
+		}
+	}
+	if !srcExists {
+		return nil
+	}
+	// then, check if any files already exist in dstdir, and quit if so
 	for _, file := range files {
 		if _, err := os.Stat(filepath.Join(dstdir, file)); err == nil {
 			return fmt.Errorf("destination file %s already exists, not overwriting", filepath.Join(dstdir, file))
 		}
 	}
-	// then, check if any files exist in srcdir, and move them to dstdir
+	// finally, move the files that exist in srcdir to dstdir
 	for _, file := range files {
 		if _, err := os.Stat(filepath.Join(srcdir, file)); err == nil {
 			if err := util.MoveFile(filepath.Join(srcdir, file), filepath.Join(dstdir, file)); err != nil {


### PR DESCRIPTION
## Summary

Fixes #6731.

A node with separate `HotDataDir` and `ColdDataDir`, and no explicit
`StateproofDir` or `CrashDBDir`, starts the first time but fails on every
restart after that:

    couldn't initialize the node: error moving stateproof DB files from
    ColdDataDir .../mainnet-v1.0 to HotDataDir .../mainnet-v1.0: destination
    file .../mainnet-v1.0/stateproof.sqlite already exists, not overwriting

#5817 added a one-time move of `stateproof.sqlite*` and `crash.sqlite*` from
`ColdDataDir` to `HotDataDir`. `EnsureAndResolveGenesisDirs` runs that move on
every startup, and `moveDirIfExists` fails if any of the files already exist
in the destination, even when there is nothing in the source to move. After
the first run the node has created those files in `HotDataDir`, so every
later startup trips the check. The crash DB has the same problem; its error
is just never reached because the stateproof move runs first.

`moveDirIfExists` now returns early when none of the files exist in the
source directory. If files exist in both directories it still refuses to
overwrite, so existing data is still protected.

Workaround for affected nodes: set `StateproofDir` and `CrashDBDir`
explicitly to the `HotDataDir` path, which skips the move logic.

## Test Plan

Added `TestEnsureAndResolveGenesisDirs_migrateRestart`, which puts
`crash.sqlite` and `stateproof.sqlite` only in the hot genesis dir (the state
after a first run) and checks that `EnsureAndResolveGenesisDirs` succeeds and
resolves both DB dirs to the hot dir. Without the fix it fails with the same
"already exists, not overwriting" error seen on the node.

The existing `TestEnsureAndResolveGenesisDirs_migrate`, `_migrateCrashErr` and
`_migrateSPErr` tests still pass, so the move itself and the refusal to
overwrite are unchanged. `go test ./config/`, `go vet ./config/` and `gofmt`
all pass.
