### PR TITLE
account: refactor participation db

### DIFF
--- a/cmd/algokey/keyreg.go
+++ b/cmd/algokey/keyreg.go
@@ -186,7 +186,8 @@ func run(params keyregCmdParams) error {
 			return fmt.Errorf("cannot open keyfile %s: %v", params.partkeyFile, err)
 		}
 
-		partkey, err := account.RestoreParticipation(partDB)
+		// read-only: do not migrate the file as a side effect of building a txn
+		partkey, err := account.RestoreParticipationUnmigrated(partDB)
 		if err != nil {
 			return fmt.Errorf("cannot load keyfile %s: %v", params.partkeyFile, err)
 		}

--- a/cmd/algokey/part.go
+++ b/cmd/algokey/part.go
@@ -120,7 +120,8 @@ var partInfoCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		partkey, err := account.RestoreParticipation(partdb)
+		// read-only: do not migrate the file as a side effect of printing info
+		partkey, err := account.RestoreParticipationUnmigrated(partdb)
 		partdb.Close()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Cannot load partkey database %s: %v\n", partKeyfile, err)
@@ -219,15 +220,21 @@ func runPartMigrate(keyfile string, noValidation bool, out io.Writer) (partkey a
 	if _, statErr := os.Stat(newFile); statErr == nil {
 		return partkey, false, fmt.Errorf("%s already exists; remove it before migrating", newFile)
 	}
+	// drop stale sidecars a previous failed run may have left, so they cannot
+	// be replayed into the fresh copy
+	for _, ext := range []string{"-wal", "-shm"} {
+		if err = os.Remove(newFile + ext); err != nil && !os.IsNotExist(err) {
+			return partkey, false, fmt.Errorf("cannot remove stale %s: %v", newFile+ext, err)
+		}
+	}
 	if _, err = util.CopyFile(keyfile, newFile); err != nil {
 		return partkey, false, fmt.Errorf("cannot copy %s to %s: %v", keyfile, newFile, err)
 	}
-	// copy WAL siblings so SQLite recovers an unclean close in the copy, not the original
-	for _, ext := range []string{"-wal", "-shm"} {
-		if _, statErr := os.Stat(keyfile + ext); statErr == nil {
-			if _, err = util.CopyFile(keyfile+ext, newFile+ext); err != nil {
-				return partkey, false, fmt.Errorf("cannot copy %s to %s: %v", keyfile+ext, newFile+ext, err)
-			}
+	// copy the WAL too so SQLite recovers an unclean close in the copy, not
+	// the original; the volatile -shm index is rebuilt by SQLite on open
+	if _, statErr := os.Stat(keyfile + "-wal"); statErr == nil {
+		if _, err = util.CopyFile(keyfile+"-wal", newFile+"-wal"); err != nil {
+			return partkey, false, fmt.Errorf("cannot copy %s to %s: %v", keyfile+"-wal", newFile+"-wal", err)
 		}
 	}
 
@@ -284,7 +291,12 @@ func comparePartkeys(expected, actual account.Participation) error {
 	if !bytes.Equal(protocol.Encode(&expectedVoting), protocol.Encode(&actualVoting)) {
 		return fmt.Errorf("voting secrets mismatch")
 	}
-	if !bytes.Equal(protocol.Encode(expected.StateProofSecrets), protocol.Encode(actual.StateProofSecrets)) {
+	// v1/v2 files (and v3 files upgraded from them) have no state proof secrets
+	if (expected.StateProofSecrets == nil) != (actual.StateProofSecrets == nil) {
+		return fmt.Errorf("state proof secrets presence mismatch")
+	}
+	if expected.StateProofSecrets != nil &&
+		!bytes.Equal(protocol.Encode(expected.StateProofSecrets), protocol.Encode(actual.StateProofSecrets)) {
 		return fmt.Errorf("state proof secrets mismatch")
 	}
 	return nil

--- a/cmd/algokey/part.go
+++ b/cmd/algokey/part.go
@@ -211,8 +211,8 @@ func runPartMigrate(keyfile string, noValidation bool, out io.Writer) (partkey a
 		fmt.Fprintf(out, "Already at the latest schema version; nothing to do.\n")
 		return partkey, false, nil
 	}
-	if version != account.PartTableSchemaVersion-1 {
-		return partkey, false, fmt.Errorf("unsupported schema version %d: only version %d files can be migrated (versions 1 and 2 predate state proofs and their keys expired long ago)", version, account.PartTableSchemaVersion-1)
+	if version != account.PartTableSchemaVersionVotingSplit-1 {
+		return partkey, false, fmt.Errorf("unsupported schema version %d: only version %d files can be migrated", version, account.PartTableSchemaVersionVotingSplit-1)
 	}
 
 	newFile := keyfile + ".new"
@@ -233,10 +233,6 @@ func runPartMigrate(keyfile string, noValidation bool, out io.Writer) (partkey a
 	if _, err = origdb.Handle.Exec("VACUUM INTO ?", newFile); err != nil {
 		return partkey, false, fmt.Errorf("cannot snapshot %s to %s: %v", keyfile, newFile, err)
 	}
-	// participation keys are secret material: the snapshot must not be more
-	// permissive than the original.  Setting this before the copy is first
-	// opened also makes SQLite create its -wal/-shm sidecars with the same
-	// permissions.
 	srcInfo, err := os.Stat(keyfile)
 	if err != nil {
 		return partkey, false, fmt.Errorf("cannot stat %s: %v", keyfile, err)
@@ -257,8 +253,7 @@ func runPartMigrate(keyfile string, noValidation bool, out io.Writer) (partkey a
 	if err != nil {
 		return partkey, false, fmt.Errorf("migration of %s failed: %v", newFile, err)
 	}
-	fmt.Fprintf(out, "Migrated %s to schema version %d\n", newFile, account.PartTableSchemaVersion)
-	fmt.Fprintf(out, "Pure migration time: %v (approximately what algod will spend migrating this file at startup)\n", migrationTime)
+	fmt.Fprintf(out, "Migrated %s to schema version %d, spent %v\n", newFile, account.PartTableSchemaVersion, migrationTime)
 
 	// load the state proof secret keys too, so validation covers them
 	restored, err := account.RestoreParticipationWithSecrets(newdb)

--- a/cmd/algokey/part.go
+++ b/cmd/algokey/part.go
@@ -220,22 +220,30 @@ func runPartMigrate(keyfile string, noValidation bool, out io.Writer) (partkey a
 	if _, statErr := os.Stat(newFile); statErr == nil {
 		return partkey, false, fmt.Errorf("%s already exists; remove it before migrating", newFile)
 	}
-	// drop stale sidecars a previous failed run may have left, so they cannot
-	// be replayed into the fresh copy
+	// drop stale sidecars a previous failed run may have left, so SQLite
+	// cannot replay them into the fresh snapshot
 	for _, ext := range []string{"-wal", "-shm"} {
 		if err = os.Remove(newFile + ext); err != nil && !os.IsNotExist(err) {
 			return partkey, false, fmt.Errorf("cannot remove stale %s: %v", newFile+ext, err)
 		}
 	}
-	if _, err = util.CopyFile(keyfile, newFile); err != nil {
-		return partkey, false, fmt.Errorf("cannot copy %s to %s: %v", keyfile, newFile, err)
+	// VACUUM INTO takes one transactionally consistent snapshot through
+	// SQLite itself, so a concurrently writing algod (which updates the file
+	// every round) cannot produce a torn copy the way independent file
+	// copies of the database and its WAL could.
+	if _, err = origdb.Handle.Exec("VACUUM INTO ?", newFile); err != nil {
+		return partkey, false, fmt.Errorf("cannot snapshot %s to %s: %v", keyfile, newFile, err)
 	}
-	// copy the WAL too so SQLite recovers an unclean close in the copy, not
-	// the original; the volatile -shm index is rebuilt by SQLite on open
-	if _, statErr := os.Stat(keyfile + "-wal"); statErr == nil {
-		if _, err = util.CopyFile(keyfile+"-wal", newFile+"-wal"); err != nil {
-			return partkey, false, fmt.Errorf("cannot copy %s to %s: %v", keyfile+"-wal", newFile+"-wal", err)
-		}
+	// participation keys are secret material: the snapshot must not be more
+	// permissive than the original.  Setting this before the copy is first
+	// opened also makes SQLite create its -wal/-shm sidecars with the same
+	// permissions.
+	srcInfo, err := os.Stat(keyfile)
+	if err != nil {
+		return partkey, false, fmt.Errorf("cannot stat %s: %v", keyfile, err)
+	}
+	if err = os.Chmod(newFile, srcInfo.Mode().Perm()); err != nil {
+		return partkey, false, fmt.Errorf("cannot set permissions on %s: %v", newFile, err)
 	}
 
 	newdb, err := db.MakeErasableAccessor(newFile)
@@ -253,7 +261,8 @@ func runPartMigrate(keyfile string, noValidation bool, out io.Writer) (partkey a
 	fmt.Fprintf(out, "Migrated %s to schema version %d\n", newFile, account.PartTableSchemaVersion)
 	fmt.Fprintf(out, "Pure migration time: %v (approximately what algod will spend migrating this file at startup)\n", migrationTime)
 
-	restored, err := account.RestoreParticipation(newdb)
+	// load the state proof secret keys too, so validation covers them
+	restored, err := account.RestoreParticipationWithSecrets(newdb)
 	if err != nil {
 		return partkey, false, fmt.Errorf("cannot load migrated partkey database %s: %v", newFile, err)
 	}
@@ -266,6 +275,11 @@ func runPartMigrate(keyfile string, noValidation bool, out io.Writer) (partkey a
 	original, err := account.RestoreParticipationUnmigrated(origdb)
 	if err != nil {
 		return partkey, false, fmt.Errorf("cannot load original partkey database %s for validation: %v", keyfile, err)
+	}
+	if original.StateProofSecrets != nil {
+		if err = original.StateProofSecrets.RestoreAllSecrets(origdb); err != nil {
+			return partkey, false, fmt.Errorf("cannot load state proof keys from %s for validation: %v", keyfile, err)
+		}
 	}
 	if err = comparePartkeys(original.Participation, partkey); err != nil {
 		return partkey, false, fmt.Errorf("validation FAILED: migrated keys differ from the original: %v", err)
@@ -295,9 +309,23 @@ func comparePartkeys(expected, actual account.Participation) error {
 	if (expected.StateProofSecrets == nil) != (actual.StateProofSecrets == nil) {
 		return fmt.Errorf("state proof secrets presence mismatch")
 	}
-	if expected.StateProofSecrets != nil &&
-		!bytes.Equal(protocol.Encode(expected.StateProofSecrets), protocol.Encode(actual.StateProofSecrets)) {
-		return fmt.Errorf("state proof secrets mismatch")
+	if expected.StateProofSecrets != nil {
+		// the encoding covers the SignerContext only
+		if !bytes.Equal(protocol.Encode(expected.StateProofSecrets), protocol.Encode(actual.StateProofSecrets)) {
+			return fmt.Errorf("state proof secrets mismatch")
+		}
+		// the secret keys live in their own table and must be compared
+		// explicitly (callers load them with RestoreAllSecrets)
+		expectedKeys := expected.StateProofSecrets.GetAllKeys()
+		actualKeys := actual.StateProofSecrets.GetAllKeys()
+		if len(expectedKeys) != len(actualKeys) {
+			return fmt.Errorf("state proof key count mismatch (%d != %d)", len(expectedKeys), len(actualKeys))
+		}
+		for i := range expectedKeys {
+			if !bytes.Equal(protocol.Encode(&expectedKeys[i]), protocol.Encode(&actualKeys[i])) {
+				return fmt.Errorf("state proof key %d mismatch", i)
+			}
+		}
 	}
 	return nil
 }

--- a/cmd/algokey/part.go
+++ b/cmd/algokey/part.go
@@ -174,11 +174,10 @@ var partMigrateCmd = &cobra.Command{
 	Short: "Migrate a participation key file to the latest schema version",
 	Long: `Migrate a copy of a participation key file to the latest schema version.
 
-The original file is never modified: the migrated database is written to
-<keyfile>.new.  The time spent in the migration itself is printed, which is
-approximately what algod will spend migrating the file automatically at
-startup.  Unless --no-validation is given, the keys reconstructed from the
-migrated copy are validated against the ones in the original file.`,
+The original file is not modified: the migrated database is written to <keyfile>.new.
+Prints out migration time in order to estimate algod's auto-migration time at startup.
+Unless --no-validation is given, the keys reconstructed from the migrated copy are validated
+against the ones in the original file.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, _ []string) {
 		partkey, migrated, err := runPartMigrate(partKeyfile, partNoValidation, os.Stdout)
@@ -212,8 +211,8 @@ func runPartMigrate(keyfile string, noValidation bool, out io.Writer) (partkey a
 		fmt.Fprintf(out, "Already at the latest schema version; nothing to do.\n")
 		return partkey, false, nil
 	}
-	if version < 1 || version > account.PartTableSchemaVersion {
-		return partkey, false, fmt.Errorf("unsupported schema version %d (this algokey supports up to %d)", version, account.PartTableSchemaVersion)
+	if version != account.PartTableSchemaVersion-1 {
+		return partkey, false, fmt.Errorf("unsupported schema version %d: only version %d files can be migrated (versions 1 and 2 predate state proofs and their keys expired long ago)", version, account.PartTableSchemaVersion-1)
 	}
 
 	newFile := keyfile + ".new"

--- a/cmd/algokey/part.go
+++ b/cmd/algokey/part.go
@@ -226,19 +226,33 @@ func runPartMigrate(keyfile string, noValidation bool, out io.Writer) (partkey a
 			return partkey, false, fmt.Errorf("cannot remove stale %s: %v", newFile+ext, err)
 		}
 	}
+	// pre-create the snapshot target as an empty file with the original's
+	// restrictive permissions (VACUUM INTO accepts an empty file, and SQLite
+	// creates the -wal/-shm sidecars with the database file's mode), so the
+	// secret material is never readable more broadly than the original —
+	// not even between the snapshot and a later chmod
+	srcInfo, err := os.Stat(keyfile)
+	if err != nil {
+		return partkey, false, fmt.Errorf("cannot stat %s: %v", keyfile, err)
+	}
+	f, err := os.OpenFile(newFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, srcInfo.Mode().Perm())
+	if err != nil {
+		return partkey, false, fmt.Errorf("cannot create %s: %v", newFile, err)
+	}
+	f.Close()
+	// the umask may have stripped bits during creation; force the exact mode
+	if err = os.Chmod(newFile, srcInfo.Mode().Perm()); err != nil {
+		return partkey, false, fmt.Errorf("cannot set permissions on %s: %v", newFile, err)
+	}
 	// VACUUM INTO takes one transactionally consistent snapshot through
 	// SQLite itself, so a concurrently writing algod (which updates the file
 	// every round) cannot produce a torn copy the way independent file
 	// copies of the database and its WAL could.
 	if _, err = origdb.Handle.Exec("VACUUM INTO ?", newFile); err != nil {
+		// remove the empty target so a retry is not refused by the
+		// already-exists guard
+		os.Remove(newFile)
 		return partkey, false, fmt.Errorf("cannot snapshot %s to %s: %v", keyfile, newFile, err)
-	}
-	srcInfo, err := os.Stat(keyfile)
-	if err != nil {
-		return partkey, false, fmt.Errorf("cannot stat %s: %v", keyfile, err)
-	}
-	if err = os.Chmod(newFile, srcInfo.Mode().Perm()); err != nil {
-		return partkey, false, fmt.Errorf("cannot set permissions on %s: %v", newFile, err)
 	}
 
 	newdb, err := db.MakeErasableAccessor(newFile)

--- a/cmd/algokey/part.go
+++ b/cmd/algokey/part.go
@@ -254,6 +254,16 @@ func runPartMigrate(keyfile string, noValidation bool, out io.Writer) (partkey a
 		os.Remove(newFile)
 		return partkey, false, fmt.Errorf("cannot snapshot %s to %s: %v", keyfile, newFile, err)
 	}
+	// a copy whose migration or validation failed is useless and would block
+	// a retry through the already-exists guard; keep it only on success
+	migrateOK := false
+	defer func() {
+		if !migrateOK {
+			os.Remove(newFile)
+			os.Remove(newFile + "-wal")
+			os.Remove(newFile + "-shm")
+		}
+	}()
 
 	newdb, err := db.MakeErasableAccessor(newFile)
 	if err != nil {
@@ -277,6 +287,7 @@ func runPartMigrate(keyfile string, noValidation bool, out io.Writer) (partkey a
 	partkey = restored.Participation
 
 	if noValidation {
+		migrateOK = true
 		return partkey, true, nil
 	}
 
@@ -293,6 +304,7 @@ func runPartMigrate(keyfile string, noValidation bool, out io.Writer) (partkey a
 		return partkey, false, fmt.Errorf("validation FAILED: migrated keys differ from the original: %v", err)
 	}
 	fmt.Fprintf(out, "Validation PASSED: keys reconstructed from %s match the original\n", newFile)
+	migrateOK = true
 	return partkey, true, nil
 }
 

--- a/cmd/algokey/part.go
+++ b/cmd/algokey/part.go
@@ -17,15 +17,19 @@
 package main
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/account"
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/util"
 	"github.com/algorand/go-algorand/util/db"
 )
@@ -35,6 +39,7 @@ var partFirstRound basics.Round
 var partLastRound basics.Round
 var partKeyDilution uint64
 var partParent string
+var partNoValidation bool
 
 var partCmd = &cobra.Command{
 	Use:   "part",
@@ -163,6 +168,128 @@ var partReparentCmd = &cobra.Command{
 	},
 }
 
+var partMigrateCmd = &cobra.Command{
+	Use:   "migrate",
+	Short: "Migrate a participation key file to the latest schema version",
+	Long: `Migrate a copy of a participation key file to the latest schema version.
+
+The original file is never modified: the migrated database is written to
+<keyfile>.new.  The time spent in the migration itself is printed, which is
+approximately what algod will spend migrating the file automatically at
+startup.  Unless --no-validation is given, the keys reconstructed from the
+migrated copy are validated against the ones in the original file.`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		partkey, migrated, err := runPartMigrate(partKeyfile, partNoValidation, os.Stdout)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
+		if migrated {
+			fmt.Println()
+			printPartkey(partkey)
+		}
+	},
+}
+
+// runPartMigrate migrates a copy of keyfile to <keyfile>.new and optionally
+// validates the copy against the original.  It returns the migrated key
+// (valid only when migrated is true).
+func runPartMigrate(keyfile string, noValidation bool, out io.Writer) (partkey account.Participation, migrated bool, err error) {
+	origdb, err := db.MakeErasableAccessor(keyfile)
+	if err != nil {
+		return partkey, false, fmt.Errorf("cannot open partkey database %s: %v", keyfile, err)
+	}
+	defer origdb.Close()
+
+	version, err := account.PartkeySchemaVersion(origdb)
+	if err != nil {
+		return partkey, false, fmt.Errorf("cannot read schema version of %s: %v", keyfile, err)
+	}
+	fmt.Fprintf(out, "Current schema version of %s: %d\n", keyfile, version)
+	if version == account.PartTableSchemaVersion {
+		fmt.Fprintf(out, "Already at the latest schema version; nothing to do.\n")
+		return partkey, false, nil
+	}
+	if version < 1 || version > account.PartTableSchemaVersion {
+		return partkey, false, fmt.Errorf("unsupported schema version %d (this algokey supports up to %d)", version, account.PartTableSchemaVersion)
+	}
+
+	newFile := keyfile + ".new"
+	if _, statErr := os.Stat(newFile); statErr == nil {
+		return partkey, false, fmt.Errorf("%s already exists; remove it before migrating", newFile)
+	}
+	if _, err = util.CopyFile(keyfile, newFile); err != nil {
+		return partkey, false, fmt.Errorf("cannot copy %s to %s: %v", keyfile, newFile, err)
+	}
+	// copy WAL siblings so SQLite recovers an unclean close in the copy, not the original
+	for _, ext := range []string{"-wal", "-shm"} {
+		if _, statErr := os.Stat(keyfile + ext); statErr == nil {
+			if _, err = util.CopyFile(keyfile+ext, newFile+ext); err != nil {
+				return partkey, false, fmt.Errorf("cannot copy %s to %s: %v", keyfile+ext, newFile+ext, err)
+			}
+		}
+	}
+
+	newdb, err := db.MakeErasableAccessor(newFile)
+	if err != nil {
+		return partkey, false, fmt.Errorf("cannot open copied partkey database %s: %v", newFile, err)
+	}
+	defer newdb.Close()
+
+	start := time.Now()
+	err = account.Migrate(newdb)
+	migrationTime := time.Since(start)
+	if err != nil {
+		return partkey, false, fmt.Errorf("migration of %s failed: %v", newFile, err)
+	}
+	fmt.Fprintf(out, "Migrated %s to schema version %d\n", newFile, account.PartTableSchemaVersion)
+	fmt.Fprintf(out, "Pure migration time: %v (approximately what algod will spend migrating this file at startup)\n", migrationTime)
+
+	restored, err := account.RestoreParticipation(newdb)
+	if err != nil {
+		return partkey, false, fmt.Errorf("cannot load migrated partkey database %s: %v", newFile, err)
+	}
+	partkey = restored.Participation
+
+	if noValidation {
+		return partkey, true, nil
+	}
+
+	original, err := account.RestoreParticipationUnmigrated(origdb)
+	if err != nil {
+		return partkey, false, fmt.Errorf("cannot load original partkey database %s for validation: %v", keyfile, err)
+	}
+	if err = comparePartkeys(original.Participation, partkey); err != nil {
+		return partkey, false, fmt.Errorf("validation FAILED: migrated keys differ from the original: %v", err)
+	}
+	fmt.Fprintf(out, "Validation PASSED: keys reconstructed from %s match the original\n", newFile)
+	return partkey, true, nil
+}
+
+// comparePartkeys verifies two participation keys carry identical key
+// material and metadata.
+func comparePartkeys(expected, actual account.Participation) error {
+	if expected.Parent != actual.Parent {
+		return fmt.Errorf("parent address mismatch")
+	}
+	if expected.FirstValid != actual.FirstValid || expected.LastValid != actual.LastValid || expected.KeyDilution != actual.KeyDilution {
+		return fmt.Errorf("validity metadata mismatch")
+	}
+	if !bytes.Equal(protocol.Encode(expected.VRF), protocol.Encode(actual.VRF)) {
+		return fmt.Errorf("VRF secrets mismatch")
+	}
+	expectedVoting := expected.Voting.Snapshot()
+	actualVoting := actual.Voting.Snapshot()
+	if !bytes.Equal(protocol.Encode(&expectedVoting), protocol.Encode(&actualVoting)) {
+		return fmt.Errorf("voting secrets mismatch")
+	}
+	if !bytes.Equal(protocol.Encode(expected.StateProofSecrets), protocol.Encode(actual.StateProofSecrets)) {
+		return fmt.Errorf("state proof secrets mismatch")
+	}
+	return nil
+}
+
 func printPartkey(partkey account.Participation) {
 	fmt.Printf("Parent address:    %s\n", partkey.Parent.String())
 	fmt.Printf("VRF public key:    %s\n", base64.StdEncoding.EncodeToString(partkey.VRF.PK[:]))
@@ -182,6 +309,7 @@ func init() {
 	partCmd.AddCommand(partGenerateCmd)
 	partCmd.AddCommand(partInfoCmd)
 	partCmd.AddCommand(partReparentCmd)
+	partCmd.AddCommand(partMigrateCmd)
 	partCmd.AddCommand(keyregCmd)
 
 	partGenerateCmd.Flags().StringVar(&partKeyfile, "keyfile", "", "Participation key filename")
@@ -200,4 +328,8 @@ func init() {
 	partReparentCmd.Flags().StringVar(&partParent, "parent", "", "Address of parent account")
 	partReparentCmd.MarkFlagRequired("keyfile")
 	partReparentCmd.MarkFlagRequired("parent")
+
+	partMigrateCmd.Flags().StringVar(&partKeyfile, "keyfile", "", "Participation key filename")
+	partMigrateCmd.Flags().BoolVar(&partNoValidation, "no-validation", false, "Skip validating the migrated keys against the original file")
+	partMigrateCmd.MarkFlagRequired("keyfile")
 }

--- a/cmd/algokey/part_test.go
+++ b/cmd/algokey/part_test.go
@@ -111,6 +111,11 @@ func makeLegacyPartkeyFile(t *testing.T, keyfile string, opts legacyPartkeyOptio
 		return err
 	})
 	a.NoError(err)
+
+	// real v3 files carry the state proof secret keys in their own table
+	if part.StateProofSecrets != nil {
+		a.NoError(part.StateProofSecrets.Persist(partdb))
+	}
 	return part
 }
 
@@ -186,6 +191,55 @@ func TestPartMigrateNilStateProof(t *testing.T) {
 		a.NoError(err)
 		a.Equal(opts.version, version, name)
 	}
+}
+
+// TestPartMigratePreservesPermissions verifies the snapshot is not more
+// permissive than the original key file.
+func TestPartMigratePreservesPermissions(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+	a := require.New(t)
+
+	keyfile := filepath.Join(t.TempDir(), "test.partkey")
+	makeV3PartkeyFile(t, keyfile, false)
+	a.NoError(os.Chmod(keyfile, 0600))
+
+	var out bytes.Buffer
+	_, migrated, err := runPartMigrate(keyfile, false, &out)
+	a.NoError(err)
+	a.True(migrated)
+
+	info, err := os.Stat(keyfile + ".new")
+	a.NoError(err)
+	a.Equal(os.FileMode(0600), info.Mode().Perm())
+}
+
+// TestComparePartkeysMissingStateProofKeys verifies validation detects a copy
+// whose state proof secret keys are missing, even though the Participation
+// encoding itself covers only the SignerContext.
+func TestComparePartkeysMissingStateProofKeys(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+	a := require.New(t)
+
+	keyfile := filepath.Join(t.TempDir(), "test.partkey")
+	makeV3PartkeyFile(t, keyfile, false)
+
+	partdb, err := db.MakeErasableAccessor(keyfile)
+	a.NoError(err)
+	defer partdb.Close()
+
+	withKeys, err := account.RestoreParticipationUnmigrated(partdb)
+	a.NoError(err)
+	a.NoError(withKeys.StateProofSecrets.RestoreAllSecrets(partdb))
+	a.NotEmpty(withKeys.StateProofSecrets.GetAllKeys())
+
+	withoutKeys, err := account.RestoreParticipationUnmigrated(partdb)
+	a.NoError(err)
+	a.Empty(withoutKeys.StateProofSecrets.GetAllKeys())
+
+	a.NoError(comparePartkeys(withKeys.Participation, withKeys.Participation))
+	a.ErrorContains(comparePartkeys(withKeys.Participation, withoutKeys.Participation), "state proof key count mismatch")
 }
 
 func TestPartMigrateNoValidation(t *testing.T) {

--- a/cmd/algokey/part_test.go
+++ b/cmd/algokey/part_test.go
@@ -1,0 +1,222 @@
+// Copyright (C) 2019-2026 Algorand Foundation Ltd.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/crypto/merklesignature"
+	"github.com/algorand/go-algorand/data/account"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/algorand/go-algorand/util/db"
+)
+
+// makeV3PartkeyFile creates a legacy (schema version 3) participation key
+// file, as an old algokey would have written it, and returns the key.
+func makeV3PartkeyFile(t *testing.T, keyfile string, mangleVoting bool) account.Participation {
+	t.Helper()
+	a := require.New(t)
+
+	const first, last, dilution = 1, 200, 10
+	stateProofSecrets, err := merklesignature.New(first, last, (last+1)/2)
+	a.NoError(err)
+
+	firstID := basics.OneTimeIDForRound(first, dilution)
+	lastID := basics.OneTimeIDForRound(last, dilution)
+	votingSecrets := crypto.GenerateOneTimeSignatureSecrets(firstID.Batch, lastID.Batch-firstID.Batch+1)
+	// make the key mid-life so both batch and offset subkeys exist
+	votingSecrets.DeleteBeforeFineGrained(basics.OneTimeIDForRound(42, dilution), dilution)
+
+	part := account.Participation{
+		FirstValid:        first,
+		LastValid:         last,
+		KeyDilution:       dilution,
+		Voting:            votingSecrets,
+		VRF:               crypto.GenerateVRFSecrets(),
+		StateProofSecrets: stateProofSecrets,
+	}
+	crypto.RandBytes(part.Parent[:])
+
+	voting := part.Voting.Snapshot()
+	rawVoting := protocol.Encode(&voting)
+	if mangleVoting {
+		rawVoting = rawVoting[:len(rawVoting)/2]
+	}
+
+	partdb, err := db.MakeErasableAccessor(keyfile)
+	a.NoError(err)
+	defer partdb.Close()
+
+	err = partdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.Exec(`CREATE TABLE ParticipationAccount (
+			parent BLOB, vrf BLOB, voting BLOB,
+			firstValid INTEGER, lastValid INTEGER,
+			keyDilution INTEGER NOT NULL DEFAULT 0, stateProof BLOB);`); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(`CREATE TABLE schema (tablename TEXT PRIMARY KEY, version INTEGER);`); err != nil {
+			return err
+		}
+		if _, err := tx.Exec("INSERT INTO schema (tablename, version) VALUES (?, ?)", account.PartTableSchemaName, 3); err != nil {
+			return err
+		}
+		_, err := tx.Exec("INSERT INTO ParticipationAccount (parent, vrf, voting, firstValid, lastValid, keyDilution, stateProof) VALUES (?, ?, ?, ?, ?, ?, ?)",
+			part.Parent[:], protocol.Encode(part.VRF), rawVoting, part.FirstValid, part.LastValid, part.KeyDilution,
+			protocol.Encode(&part.StateProofSecrets.SignerContext))
+		return err
+	})
+	a.NoError(err)
+	return part
+}
+
+func TestPartMigrate(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+	a := require.New(t)
+
+	keyfile := filepath.Join(t.TempDir(), "test.partkey")
+	original := makeV3PartkeyFile(t, keyfile, false)
+
+	bytesBefore, err := os.ReadFile(keyfile)
+	a.NoError(err)
+
+	var out bytes.Buffer
+	partkey, migrated, err := runPartMigrate(keyfile, false, &out)
+	a.NoError(err)
+	a.True(migrated)
+
+	// original untouched
+	bytesAfter, err := os.ReadFile(keyfile)
+	a.NoError(err)
+	a.Equal(bytesBefore, bytesAfter)
+
+	// the .new copy is at the latest version
+	newFile := keyfile + ".new"
+	newdb, err := db.MakeErasableAccessor(newFile)
+	a.NoError(err)
+	version, err := account.PartkeySchemaVersion(newdb)
+	newdb.Close()
+	a.NoError(err)
+	a.Equal(account.PartTableSchemaVersion, version)
+
+	// migrated key matches the original
+	a.NoError(comparePartkeys(original, partkey))
+
+	a.Contains(out.String(), "Pure migration time")
+	a.Contains(out.String(), "Validation PASSED")
+}
+
+func TestPartMigrateNoValidation(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+	a := require.New(t)
+
+	keyfile := filepath.Join(t.TempDir(), "test.partkey")
+	makeV3PartkeyFile(t, keyfile, false)
+
+	var out bytes.Buffer
+	_, migrated, err := runPartMigrate(keyfile, true, &out)
+	a.NoError(err)
+	a.True(migrated)
+	a.NotContains(out.String(), "Validation PASSED")
+	a.NotContains(out.String(), "Validation FAILED")
+}
+
+func TestPartMigrateNoopOnLatest(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+	a := require.New(t)
+
+	keyfile := filepath.Join(t.TempDir(), "test.partkey")
+	partdb, err := db.MakeErasableAccessor(keyfile)
+	a.NoError(err)
+	var addr basics.Address
+	crypto.RandBytes(addr[:])
+	_, err = account.FillDBWithParticipationKeys(partdb, addr, 1, 200, 10)
+	a.NoError(err)
+	partdb.Close()
+
+	var out bytes.Buffer
+	_, migrated, err := runPartMigrate(keyfile, false, &out)
+	a.NoError(err)
+	a.False(migrated)
+	a.Contains(out.String(), "nothing to do")
+	_, err = os.Stat(keyfile + ".new")
+	a.True(os.IsNotExist(err))
+}
+
+func TestPartMigrateRefusesExistingNew(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+	a := require.New(t)
+
+	keyfile := filepath.Join(t.TempDir(), "test.partkey")
+	makeV3PartkeyFile(t, keyfile, false)
+	a.NoError(os.WriteFile(keyfile+".new", []byte("occupied"), 0600))
+
+	var out bytes.Buffer
+	_, _, err := runPartMigrate(keyfile, false, &out)
+	a.ErrorContains(err, "already exists")
+}
+
+func TestPartMigrateCorruptVotingBlob(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+	a := require.New(t)
+
+	keyfile := filepath.Join(t.TempDir(), "test.partkey")
+	makeV3PartkeyFile(t, keyfile, true)
+
+	var out bytes.Buffer
+	_, _, err := runPartMigrate(keyfile, false, &out)
+	a.ErrorContains(err, "migration")
+
+	// original still untouched at version 3
+	origdb, err := db.MakeErasableAccessor(keyfile)
+	a.NoError(err)
+	version, err := account.PartkeySchemaVersion(origdb)
+	origdb.Close()
+	a.NoError(err)
+	a.Equal(3, version)
+}
+
+func TestComparePartkeysMismatch(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+	a := require.New(t)
+
+	dir := t.TempDir()
+	p1 := makeV3PartkeyFile(t, filepath.Join(dir, "a.partkey"), false)
+	p2 := makeV3PartkeyFile(t, filepath.Join(dir, "b.partkey"), false)
+
+	a.NoError(comparePartkeys(p1, p1))
+	a.Error(comparePartkeys(p1, p2))
+
+	tweaked := p1
+	tweaked.KeyDilution++
+	a.ErrorContains(comparePartkeys(p1, tweaked), "metadata")
+}

--- a/cmd/algokey/part_test.go
+++ b/cmd/algokey/part_test.go
@@ -143,13 +143,12 @@ func TestPartMigrate(t *testing.T) {
 	// migrated key matches the original
 	a.NoError(comparePartkeys(original, partkey))
 
-	a.Contains(out.String(), "Pure migration time")
+	a.Contains(out.String(), "Migrated")
 	a.Contains(out.String(), "Validation PASSED")
 }
 
-// TestPartMigrateNilStateProof covers v3 files whose stateProof column is
-// NULL (upgraded from v1/v2 by old releases). Validation must not crash on
-// them.
+// TestPartMigrateNilStateProof covers v3 files whose stateProof column is NULL
+// are handled without crashing.
 func TestPartMigrateNilStateProof(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
@@ -172,46 +171,6 @@ func TestPartMigrateNilStateProof(t *testing.T) {
 	origdb.Close()
 	a.NoError(err)
 	a.Equal(3, version)
-}
-
-// TestPartMigrateRejectsPreStateProofVersions verifies schema versions 1 and
-// 2 (whose keys expired years ago) are refused rather than migrated.
-func TestPartMigrateRejectsPreStateProofVersions(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-	a := require.New(t)
-
-	for _, version := range []int{1, 2} {
-		keyfile := filepath.Join(t.TempDir(), "old.partkey")
-		makeLegacyPartkeyFile(t, keyfile, legacyPartkeyOptions{version: version})
-
-		var out bytes.Buffer
-		_, _, err := runPartMigrate(keyfile, false, &out)
-		a.ErrorContains(err, "unsupported schema version", "version %d", version)
-		_, statErr := os.Stat(keyfile + ".new")
-		a.True(os.IsNotExist(statErr), "version %d", version)
-	}
-}
-
-// TestPartMigratePreservesPermissions verifies the snapshot is not more
-// permissive than the original key file.
-func TestPartMigratePreservesPermissions(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-	a := require.New(t)
-
-	keyfile := filepath.Join(t.TempDir(), "test.partkey")
-	makeV3PartkeyFile(t, keyfile)
-	a.NoError(os.Chmod(keyfile, 0600))
-
-	var out bytes.Buffer
-	_, migrated, err := runPartMigrate(keyfile, false, &out)
-	a.NoError(err)
-	a.True(migrated)
-
-	info, err := os.Stat(keyfile + ".new")
-	a.NoError(err)
-	a.Equal(os.FileMode(0600), info.Mode().Perm())
 }
 
 // TestComparePartkeys covers the validation comparator: whole-key and
@@ -249,29 +208,6 @@ func TestComparePartkeys(t *testing.T) {
 	a.Empty(withoutKeys.StateProofSecrets.GetAllKeys())
 
 	a.ErrorContains(comparePartkeys(withKeys.Participation, withoutKeys.Participation), "state proof key count mismatch")
-}
-
-func TestPartMigrateNoopOnLatest(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-	a := require.New(t)
-
-	keyfile := filepath.Join(t.TempDir(), "test.partkey")
-	partdb, err := db.MakeErasableAccessor(keyfile)
-	a.NoError(err)
-	var addr basics.Address
-	crypto.RandBytes(addr[:])
-	_, err = account.FillDBWithParticipationKeys(partdb, addr, 1, 200, 10)
-	a.NoError(err)
-	partdb.Close()
-
-	var out bytes.Buffer
-	_, migrated, err := runPartMigrate(keyfile, false, &out)
-	a.NoError(err)
-	a.False(migrated)
-	a.Contains(out.String(), "nothing to do")
-	_, err = os.Stat(keyfile + ".new")
-	a.True(os.IsNotExist(err))
 }
 
 func TestPartMigrateRefusesExistingNew(t *testing.T) {

--- a/cmd/algokey/part_test.go
+++ b/cmd/algokey/part_test.go
@@ -36,8 +36,7 @@ import (
 )
 
 type legacyPartkeyOptions struct {
-	version        int  // 1 or 3
-	mangleVoting   bool // truncate the voting blob so migration fails
+	version        int  // schema version to record; the table shape is always v3
 	nullStateProof bool // v3 file with a NULL stateProof column (upgraded from v1/v2 by old code)
 }
 
@@ -62,7 +61,7 @@ func makeLegacyPartkeyFile(t *testing.T, keyfile string, opts legacyPartkeyOptio
 		VRF:         crypto.GenerateVRFSecrets(),
 	}
 	crypto.RandBytes(part.Parent[:])
-	if opts.version >= 3 && !opts.nullStateProof {
+	if !opts.nullStateProof {
 		stateProofSecrets, err := merklesignature.New(first, last, (last+1)/2)
 		a.NoError(err)
 		part.StateProofSecrets = stateProofSecrets
@@ -70,9 +69,6 @@ func makeLegacyPartkeyFile(t *testing.T, keyfile string, opts legacyPartkeyOptio
 
 	voting := part.Voting.Snapshot()
 	rawVoting := protocol.Encode(&voting)
-	if opts.mangleVoting {
-		rawVoting = rawVoting[:len(rawVoting)/2]
-	}
 
 	partdb, err := db.MakeErasableAccessor(keyfile)
 	a.NoError(err)
@@ -83,16 +79,6 @@ func makeLegacyPartkeyFile(t *testing.T, keyfile string, opts legacyPartkeyOptio
 			return err
 		}
 		if _, err := tx.Exec("INSERT INTO schema (tablename, version) VALUES (?, ?)", account.PartTableSchemaName, opts.version); err != nil {
-			return err
-		}
-		if opts.version == 1 {
-			if _, err := tx.Exec(`CREATE TABLE ParticipationAccount (
-				parent BLOB, vrf BLOB, voting BLOB,
-				firstValid INTEGER, lastValid INTEGER);`); err != nil {
-				return err
-			}
-			_, err := tx.Exec("INSERT INTO ParticipationAccount (parent, vrf, voting, firstValid, lastValid) VALUES (?, ?, ?, ?, ?)",
-				part.Parent[:], protocol.Encode(part.VRF), rawVoting, part.FirstValid, part.LastValid)
 			return err
 		}
 		if _, err := tx.Exec(`CREATE TABLE ParticipationAccount (
@@ -119,9 +105,9 @@ func makeLegacyPartkeyFile(t *testing.T, keyfile string, opts legacyPartkeyOptio
 	return part
 }
 
-func makeV3PartkeyFile(t *testing.T, keyfile string, mangleVoting bool) account.Participation {
+func makeV3PartkeyFile(t *testing.T, keyfile string) account.Participation {
 	t.Helper()
-	return makeLegacyPartkeyFile(t, keyfile, legacyPartkeyOptions{version: 3, mangleVoting: mangleVoting})
+	return makeLegacyPartkeyFile(t, keyfile, legacyPartkeyOptions{version: 3})
 }
 
 func TestPartMigrate(t *testing.T) {
@@ -130,7 +116,7 @@ func TestPartMigrate(t *testing.T) {
 	a := require.New(t)
 
 	keyfile := filepath.Join(t.TempDir(), "test.partkey")
-	original := makeV3PartkeyFile(t, keyfile, false)
+	original := makeV3PartkeyFile(t, keyfile)
 
 	bytesBefore, err := os.ReadFile(keyfile)
 	a.NoError(err)
@@ -161,35 +147,49 @@ func TestPartMigrate(t *testing.T) {
 	a.Contains(out.String(), "Validation PASSED")
 }
 
-// TestPartMigrateNilStateProof covers the file populations with no state
-// proof secrets: v1 files, and v3 files whose stateProof column is NULL
-// (upgraded from v1/v2 by old releases). Validation must not crash on them.
+// TestPartMigrateNilStateProof covers v3 files whose stateProof column is
+// NULL (upgraded from v1/v2 by old releases). Validation must not crash on
+// them.
 func TestPartMigrateNilStateProof(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 	a := require.New(t)
 
-	for name, opts := range map[string]legacyPartkeyOptions{
-		"v1":               {version: 1},
-		"v3NullStateProof": {version: 3, nullStateProof: true},
-	} {
-		keyfile := filepath.Join(t.TempDir(), name+".partkey")
-		makeLegacyPartkeyFile(t, keyfile, opts)
+	keyfile := filepath.Join(t.TempDir(), "v3null.partkey")
+	makeLegacyPartkeyFile(t, keyfile, legacyPartkeyOptions{version: 3, nullStateProof: true})
+
+	var out bytes.Buffer
+	partkey, migrated, err := runPartMigrate(keyfile, false, &out)
+	a.NoError(err)
+	a.True(migrated)
+	a.Nil(partkey.StateProofSecrets)
+	a.Contains(out.String(), "Validation PASSED")
+
+	// validation reads the original without migrating it
+	origdb, err := db.MakeErasableAccessor(keyfile)
+	a.NoError(err)
+	version, err := account.PartkeySchemaVersion(origdb)
+	origdb.Close()
+	a.NoError(err)
+	a.Equal(3, version)
+}
+
+// TestPartMigrateRejectsPreStateProofVersions verifies schema versions 1 and
+// 2 (whose keys expired years ago) are refused rather than migrated.
+func TestPartMigrateRejectsPreStateProofVersions(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+	a := require.New(t)
+
+	for _, version := range []int{1, 2} {
+		keyfile := filepath.Join(t.TempDir(), "old.partkey")
+		makeLegacyPartkeyFile(t, keyfile, legacyPartkeyOptions{version: version})
 
 		var out bytes.Buffer
-		partkey, migrated, err := runPartMigrate(keyfile, false, &out)
-		a.NoError(err, name)
-		a.True(migrated, name)
-		a.Nil(partkey.StateProofSecrets, name)
-		a.Contains(out.String(), "Validation PASSED", name)
-
-		// validation reads the original without migrating it
-		origdb, err := db.MakeErasableAccessor(keyfile)
-		a.NoError(err)
-		version, err := account.PartkeySchemaVersion(origdb)
-		origdb.Close()
-		a.NoError(err)
-		a.Equal(opts.version, version, name)
+		_, _, err := runPartMigrate(keyfile, false, &out)
+		a.ErrorContains(err, "unsupported schema version", "version %d", version)
+		_, statErr := os.Stat(keyfile + ".new")
+		a.True(os.IsNotExist(statErr), "version %d", version)
 	}
 }
 
@@ -201,7 +201,7 @@ func TestPartMigratePreservesPermissions(t *testing.T) {
 	a := require.New(t)
 
 	keyfile := filepath.Join(t.TempDir(), "test.partkey")
-	makeV3PartkeyFile(t, keyfile, false)
+	makeV3PartkeyFile(t, keyfile)
 	a.NoError(os.Chmod(keyfile, 0600))
 
 	var out bytes.Buffer
@@ -214,18 +214,28 @@ func TestPartMigratePreservesPermissions(t *testing.T) {
 	a.Equal(os.FileMode(0600), info.Mode().Perm())
 }
 
-// TestComparePartkeysMissingStateProofKeys verifies validation detects a copy
-// whose state proof secret keys are missing, even though the Participation
-// encoding itself covers only the SignerContext.
-func TestComparePartkeysMissingStateProofKeys(t *testing.T) {
+// TestComparePartkeys covers the validation comparator: whole-key and
+// metadata mismatches, and a copy whose state proof secret keys are missing
+// (the Participation encoding itself covers only the SignerContext).
+func TestComparePartkeys(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	t.Parallel()
 	a := require.New(t)
 
-	keyfile := filepath.Join(t.TempDir(), "test.partkey")
-	makeV3PartkeyFile(t, keyfile, false)
+	dir := t.TempDir()
+	p1 := makeV3PartkeyFile(t, filepath.Join(dir, "a.partkey"))
+	p2 := makeV3PartkeyFile(t, filepath.Join(dir, "b.partkey"))
 
-	partdb, err := db.MakeErasableAccessor(keyfile)
+	a.NoError(comparePartkeys(p1, p1))
+	a.Error(comparePartkeys(p1, p2))
+
+	tweaked := p1
+	tweaked.KeyDilution++
+	a.ErrorContains(comparePartkeys(p1, tweaked), "metadata")
+
+	// state proof secret keys live in their own table and are compared only
+	// when loaded; a copy missing them must be detected
+	partdb, err := db.MakeErasableAccessor(filepath.Join(dir, "a.partkey"))
 	a.NoError(err)
 	defer partdb.Close()
 
@@ -238,24 +248,7 @@ func TestComparePartkeysMissingStateProofKeys(t *testing.T) {
 	a.NoError(err)
 	a.Empty(withoutKeys.StateProofSecrets.GetAllKeys())
 
-	a.NoError(comparePartkeys(withKeys.Participation, withKeys.Participation))
 	a.ErrorContains(comparePartkeys(withKeys.Participation, withoutKeys.Participation), "state proof key count mismatch")
-}
-
-func TestPartMigrateNoValidation(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-	a := require.New(t)
-
-	keyfile := filepath.Join(t.TempDir(), "test.partkey")
-	makeV3PartkeyFile(t, keyfile, false)
-
-	var out bytes.Buffer
-	_, migrated, err := runPartMigrate(keyfile, true, &out)
-	a.NoError(err)
-	a.True(migrated)
-	a.NotContains(out.String(), "Validation PASSED")
-	a.NotContains(out.String(), "Validation FAILED")
 }
 
 func TestPartMigrateNoopOnLatest(t *testing.T) {
@@ -287,48 +280,10 @@ func TestPartMigrateRefusesExistingNew(t *testing.T) {
 	a := require.New(t)
 
 	keyfile := filepath.Join(t.TempDir(), "test.partkey")
-	makeV3PartkeyFile(t, keyfile, false)
+	makeV3PartkeyFile(t, keyfile)
 	a.NoError(os.WriteFile(keyfile+".new", []byte("occupied"), 0600))
 
 	var out bytes.Buffer
 	_, _, err := runPartMigrate(keyfile, false, &out)
 	a.ErrorContains(err, "already exists")
-}
-
-func TestPartMigrateCorruptVotingBlob(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-	a := require.New(t)
-
-	keyfile := filepath.Join(t.TempDir(), "test.partkey")
-	makeV3PartkeyFile(t, keyfile, true)
-
-	var out bytes.Buffer
-	_, _, err := runPartMigrate(keyfile, false, &out)
-	a.ErrorContains(err, "migration")
-
-	// original still untouched at version 3
-	origdb, err := db.MakeErasableAccessor(keyfile)
-	a.NoError(err)
-	version, err := account.PartkeySchemaVersion(origdb)
-	origdb.Close()
-	a.NoError(err)
-	a.Equal(3, version)
-}
-
-func TestComparePartkeysMismatch(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-	a := require.New(t)
-
-	dir := t.TempDir()
-	p1 := makeV3PartkeyFile(t, filepath.Join(dir, "a.partkey"), false)
-	p2 := makeV3PartkeyFile(t, filepath.Join(dir, "b.partkey"), false)
-
-	a.NoError(comparePartkeys(p1, p1))
-	a.Error(comparePartkeys(p1, p2))
-
-	tweaked := p1
-	tweaked.KeyDilution++
-	a.ErrorContains(comparePartkeys(p1, tweaked), "metadata")
 }

--- a/cmd/algokey/part_test.go
+++ b/cmd/algokey/part_test.go
@@ -35,16 +35,19 @@ import (
 	"github.com/algorand/go-algorand/util/db"
 )
 
-// makeV3PartkeyFile creates a legacy (schema version 3) participation key
-// file, as an old algokey would have written it, and returns the key.
-func makeV3PartkeyFile(t *testing.T, keyfile string, mangleVoting bool) account.Participation {
+type legacyPartkeyOptions struct {
+	version        int  // 1 or 3
+	mangleVoting   bool // truncate the voting blob so migration fails
+	nullStateProof bool // v3 file with a NULL stateProof column (upgraded from v1/v2 by old code)
+}
+
+// makeLegacyPartkeyFile creates an old-schema participation key file, as an
+// old algokey would have written it, and returns the key.
+func makeLegacyPartkeyFile(t *testing.T, keyfile string, opts legacyPartkeyOptions) account.Participation {
 	t.Helper()
 	a := require.New(t)
 
 	const first, last, dilution = 1, 200, 10
-	stateProofSecrets, err := merklesignature.New(first, last, (last+1)/2)
-	a.NoError(err)
-
 	firstID := basics.OneTimeIDForRound(first, dilution)
 	lastID := basics.OneTimeIDForRound(last, dilution)
 	votingSecrets := crypto.GenerateOneTimeSignatureSecrets(firstID.Batch, lastID.Batch-firstID.Batch+1)
@@ -52,18 +55,22 @@ func makeV3PartkeyFile(t *testing.T, keyfile string, mangleVoting bool) account.
 	votingSecrets.DeleteBeforeFineGrained(basics.OneTimeIDForRound(42, dilution), dilution)
 
 	part := account.Participation{
-		FirstValid:        first,
-		LastValid:         last,
-		KeyDilution:       dilution,
-		Voting:            votingSecrets,
-		VRF:               crypto.GenerateVRFSecrets(),
-		StateProofSecrets: stateProofSecrets,
+		FirstValid:  first,
+		LastValid:   last,
+		KeyDilution: dilution,
+		Voting:      votingSecrets,
+		VRF:         crypto.GenerateVRFSecrets(),
 	}
 	crypto.RandBytes(part.Parent[:])
+	if opts.version >= 3 && !opts.nullStateProof {
+		stateProofSecrets, err := merklesignature.New(first, last, (last+1)/2)
+		a.NoError(err)
+		part.StateProofSecrets = stateProofSecrets
+	}
 
 	voting := part.Voting.Snapshot()
 	rawVoting := protocol.Encode(&voting)
-	if mangleVoting {
+	if opts.mangleVoting {
 		rawVoting = rawVoting[:len(rawVoting)/2]
 	}
 
@@ -72,25 +79,44 @@ func makeV3PartkeyFile(t *testing.T, keyfile string, mangleVoting bool) account.
 	defer partdb.Close()
 
 	err = partdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.Exec(`CREATE TABLE schema (tablename TEXT PRIMARY KEY, version INTEGER);`); err != nil {
+			return err
+		}
+		if _, err := tx.Exec("INSERT INTO schema (tablename, version) VALUES (?, ?)", account.PartTableSchemaName, opts.version); err != nil {
+			return err
+		}
+		if opts.version == 1 {
+			if _, err := tx.Exec(`CREATE TABLE ParticipationAccount (
+				parent BLOB, vrf BLOB, voting BLOB,
+				firstValid INTEGER, lastValid INTEGER);`); err != nil {
+				return err
+			}
+			_, err := tx.Exec("INSERT INTO ParticipationAccount (parent, vrf, voting, firstValid, lastValid) VALUES (?, ?, ?, ?, ?)",
+				part.Parent[:], protocol.Encode(part.VRF), rawVoting, part.FirstValid, part.LastValid)
+			return err
+		}
 		if _, err := tx.Exec(`CREATE TABLE ParticipationAccount (
 			parent BLOB, vrf BLOB, voting BLOB,
 			firstValid INTEGER, lastValid INTEGER,
 			keyDilution INTEGER NOT NULL DEFAULT 0, stateProof BLOB);`); err != nil {
 			return err
 		}
-		if _, err := tx.Exec(`CREATE TABLE schema (tablename TEXT PRIMARY KEY, version INTEGER);`); err != nil {
-			return err
-		}
-		if _, err := tx.Exec("INSERT INTO schema (tablename, version) VALUES (?, ?)", account.PartTableSchemaName, 3); err != nil {
-			return err
+		var rawStateProof []byte
+		if part.StateProofSecrets != nil {
+			rawStateProof = protocol.Encode(&part.StateProofSecrets.SignerContext)
 		}
 		_, err := tx.Exec("INSERT INTO ParticipationAccount (parent, vrf, voting, firstValid, lastValid, keyDilution, stateProof) VALUES (?, ?, ?, ?, ?, ?, ?)",
 			part.Parent[:], protocol.Encode(part.VRF), rawVoting, part.FirstValid, part.LastValid, part.KeyDilution,
-			protocol.Encode(&part.StateProofSecrets.SignerContext))
+			rawStateProof)
 		return err
 	})
 	a.NoError(err)
 	return part
+}
+
+func makeV3PartkeyFile(t *testing.T, keyfile string, mangleVoting bool) account.Participation {
+	t.Helper()
+	return makeLegacyPartkeyFile(t, keyfile, legacyPartkeyOptions{version: 3, mangleVoting: mangleVoting})
 }
 
 func TestPartMigrate(t *testing.T) {
@@ -128,6 +154,38 @@ func TestPartMigrate(t *testing.T) {
 
 	a.Contains(out.String(), "Pure migration time")
 	a.Contains(out.String(), "Validation PASSED")
+}
+
+// TestPartMigrateNilStateProof covers the file populations with no state
+// proof secrets: v1 files, and v3 files whose stateProof column is NULL
+// (upgraded from v1/v2 by old releases). Validation must not crash on them.
+func TestPartMigrateNilStateProof(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+	a := require.New(t)
+
+	for name, opts := range map[string]legacyPartkeyOptions{
+		"v1":               {version: 1},
+		"v3NullStateProof": {version: 3, nullStateProof: true},
+	} {
+		keyfile := filepath.Join(t.TempDir(), name+".partkey")
+		makeLegacyPartkeyFile(t, keyfile, opts)
+
+		var out bytes.Buffer
+		partkey, migrated, err := runPartMigrate(keyfile, false, &out)
+		a.NoError(err, name)
+		a.True(migrated, name)
+		a.Nil(partkey.StateProofSecrets, name)
+		a.Contains(out.String(), "Validation PASSED", name)
+
+		// validation reads the original without migrating it
+		origdb, err := db.MakeErasableAccessor(keyfile)
+		a.NoError(err)
+		version, err := account.PartkeySchemaVersion(origdb)
+		origdb.Close()
+		a.NoError(err)
+		a.Equal(opts.version, version, name)
+	}
 }
 
 func TestPartMigrateNoValidation(t *testing.T) {

--- a/cmd/goal/account.go
+++ b/cmd/goal/account.go
@@ -1002,7 +1002,8 @@ var changeOnlineCmd = &cobra.Command{
 				reportErrorf("Cannot open partkey %s: %v\n", partKeyFile, err)
 			}
 
-			partkey, err := algodAcct.RestoreParticipation(partdb)
+			// read-only: do not migrate the file as a side effect of a status change
+			partkey, err := algodAcct.RestoreParticipationUnmigrated(partdb)
 			if err != nil {
 				reportErrorf("Cannot load partkey %s: %v\n", partKeyFile, err)
 			}

--- a/crypto/onetimesig.go
+++ b/crypto/onetimesig.go
@@ -407,7 +407,11 @@ func (s *OneTimeSignatureSecrets) DeleteBeforeFineGrained(current OneTimeSignatu
 	}
 
 	// We are trying to move forward into a new batch.  The plan is fourfold:
-	// 1. Delete existing offsets.
+	// 1. Delete existing offsets.  Consuming them advances FirstOffset to the
+	//    end of their batch, so a key that runs out of batches below leaves a
+	//    cursor that is distinguishable from a live, partially used final
+	//    batch (persistent storage relies on this to tell the two apart).
+	s.FirstOffset += uint64(len(s.Offsets))
 	s.Offsets = nil
 
 	// 2. Delete any whole batches that we are jumping over.

--- a/crypto/onetimesigpersist.go
+++ b/crypto/onetimesigpersist.go
@@ -33,16 +33,16 @@ type KeyedSubkey struct {
 	Key   []byte
 }
 
-// PersistentScalars returns a copy of the persistent fields with the Batches
-// and Offsets slices nil'ed out, consistent with respect to concurrent
-// mutating calls (specifically, DeleteBefore*).  This is the cheap per-round
-// snapshot for row-oriented storage: the scalars plus the individually stored
-// subkey rows (see PersistentParts) together reconstruct the full secrets.
-func (s *OneTimeSignatureSecrets) PersistentScalars() OneTimeSignatureSecretsPersistent {
+// PersistentState returns a copy of the persistent scalar fields (with the
+// Batches and Offsets slices nil'ed out) plus the number of live batch and
+// offset subkeys, captured atomically with respect to concurrent mutating
+// calls (specifically, DeleteBefore*).  This is the cheap per-round probe for
+// row-oriented storage: no subkey is encoded.
+func (s *OneTimeSignatureSecrets) PersistentState() (scalars OneTimeSignatureSecretsPersistent, numBatches int, numOffsets int) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.persistentScalarsLocked()
+	return s.persistentScalarsLocked(), len(s.Batches), len(s.Offsets)
 }
 
 func (s *OneTimeSignatureSecrets) persistentScalarsLocked() OneTimeSignatureSecretsPersistent {
@@ -50,6 +50,34 @@ func (s *OneTimeSignatureSecrets) persistentScalarsLocked() OneTimeSignatureSecr
 	scalars.Batches = nil
 	scalars.Offsets = nil
 	return scalars
+}
+
+func (s *OneTimeSignatureSecrets) encodedBatchesLocked() []KeyedSubkey {
+	if len(s.Batches) == 0 {
+		return nil
+	}
+	batches := make([]KeyedSubkey, len(s.Batches))
+	for i := range s.Batches {
+		batches[i] = KeyedSubkey{
+			Index: s.FirstBatch + uint64(i),
+			Key:   protocol.Encode(&s.Batches[i]),
+		}
+	}
+	return batches
+}
+
+func (s *OneTimeSignatureSecrets) encodedOffsetsLocked() []KeyedSubkey {
+	if len(s.Offsets) == 0 {
+		return nil
+	}
+	offsets := make([]KeyedSubkey, len(s.Offsets))
+	for j := range s.Offsets {
+		offsets[j] = KeyedSubkey{
+			Index: s.FirstOffset + uint64(j),
+			Key:   protocol.Encode(&s.Offsets[j]),
+		}
+	}
+	return offsets
 }
 
 // PersistentParts returns the scalar fields plus every subkey encoded as its
@@ -62,26 +90,18 @@ func (s *OneTimeSignatureSecrets) PersistentParts() (scalars OneTimeSignatureSec
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	scalars = s.persistentScalarsLocked()
-	if len(s.Batches) > 0 {
-		batches = make([]KeyedSubkey, len(s.Batches))
-		for i := range s.Batches {
-			batches[i] = KeyedSubkey{
-				Index: s.FirstBatch + uint64(i),
-				Key:   protocol.Encode(&s.Batches[i]),
-			}
-		}
-	}
-	if len(s.Offsets) > 0 {
-		offsets = make([]KeyedSubkey, len(s.Offsets))
-		for j := range s.Offsets {
-			offsets[j] = KeyedSubkey{
-				Index: s.FirstOffset + uint64(j),
-				Key:   protocol.Encode(&s.Offsets[j]),
-			}
-		}
-	}
-	return scalars, batches, offsets
+	return s.persistentScalarsLocked(), s.encodedBatchesLocked(), s.encodedOffsetsLocked()
+}
+
+// PersistentScalarsAndOffsets is PersistentParts without encoding the batch
+// subkeys.  Batch rows are immutable in storage after the initial insert
+// (they are only ever deleted), so steady-state persistence such as a batch
+// rollover never needs them re-encoded.
+func (s *OneTimeSignatureSecrets) PersistentScalarsAndOffsets() (scalars OneTimeSignatureSecretsPersistent, offsets []KeyedSubkey) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.persistentScalarsLocked(), s.encodedOffsetsLocked()
 }
 
 // OneTimeSignatureSecretsFromParts reassembles OneTimeSignatureSecrets from

--- a/crypto/onetimesigpersist.go
+++ b/crypto/onetimesigpersist.go
@@ -1,0 +1,122 @@
+// Copyright (C) 2019-2026 Algorand Foundation Ltd.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package crypto
+
+import (
+	"fmt"
+
+	"github.com/algorand/go-algorand/protocol"
+)
+
+//msgp:ignore KeyedSubkey
+
+// KeyedSubkey is one ephemeral subkey prepared for row-oriented persistent
+// storage.  Index is the absolute batch number for batch subkeys, or the
+// absolute offset (within batch FirstBatch-1) for offset subkeys.  Key is the
+// msgpack encoding of the subkey.
+type KeyedSubkey struct {
+	Index uint64
+	Key   []byte
+}
+
+// PersistentScalars returns a copy of the persistent fields with the Batches
+// and Offsets slices nil'ed out, consistent with respect to concurrent
+// mutating calls (specifically, DeleteBefore*).  This is the cheap per-round
+// snapshot for row-oriented storage: the scalars plus the individually stored
+// subkey rows (see PersistentParts) together reconstruct the full secrets.
+func (s *OneTimeSignatureSecrets) PersistentScalars() OneTimeSignatureSecretsPersistent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.persistentScalarsLocked()
+}
+
+func (s *OneTimeSignatureSecrets) persistentScalarsLocked() OneTimeSignatureSecretsPersistent {
+	scalars := s.OneTimeSignatureSecretsPersistent
+	scalars.Batches = nil
+	scalars.Offsets = nil
+	return scalars
+}
+
+// PersistentParts returns the scalar fields plus every subkey encoded as its
+// own row, all captured atomically under a single lock acquisition so the
+// scalars and rows are mutually consistent even while DeleteBefore* runs
+// concurrently.  batches[i].Index == scalars.FirstBatch+i, and
+// offsets[j].Index == scalars.FirstOffset+j (offset subkeys belong to batch
+// scalars.FirstBatch-1).
+func (s *OneTimeSignatureSecrets) PersistentParts() (scalars OneTimeSignatureSecretsPersistent, batches []KeyedSubkey, offsets []KeyedSubkey) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	scalars = s.persistentScalarsLocked()
+	if len(s.Batches) > 0 {
+		batches = make([]KeyedSubkey, len(s.Batches))
+		for i := range s.Batches {
+			batches[i] = KeyedSubkey{
+				Index: s.FirstBatch + uint64(i),
+				Key:   protocol.Encode(&s.Batches[i]),
+			}
+		}
+	}
+	if len(s.Offsets) > 0 {
+		offsets = make([]KeyedSubkey, len(s.Offsets))
+		for j := range s.Offsets {
+			offsets[j] = KeyedSubkey{
+				Index: s.FirstOffset + uint64(j),
+				Key:   protocol.Encode(&s.Offsets[j]),
+			}
+		}
+	}
+	return scalars, batches, offsets
+}
+
+// OneTimeSignatureSecretsFromParts reassembles OneTimeSignatureSecrets from
+// scalars and subkey rows produced by PersistentParts (possibly trimmed by
+// row deletions in storage).  Zero rows reassemble to nil slices, preserving
+// the DeleteBeforeFineGrained semantics that an exhausted key's FirstBatch is
+// never spuriously bumped.
+func OneTimeSignatureSecretsFromParts(scalars OneTimeSignatureSecretsPersistent, batches []KeyedSubkey, offsets []KeyedSubkey) (*OneTimeSignatureSecrets, error) {
+	if len(scalars.Batches) != 0 || len(scalars.Offsets) != 0 {
+		return nil, fmt.Errorf("OneTimeSignatureSecretsFromParts: scalars carry %d batch and %d offset subkeys, expected none", len(scalars.Batches), len(scalars.Offsets))
+	}
+
+	if len(batches) > 0 {
+		scalars.Batches = make([]ephemeralSubkey, len(batches))
+		for i, row := range batches {
+			if want := scalars.FirstBatch + uint64(i); row.Index != want {
+				return nil, fmt.Errorf("OneTimeSignatureSecretsFromParts: batch row %d has index %d, expected %d", i, row.Index, want)
+			}
+			if err := protocol.Decode(row.Key, &scalars.Batches[i]); err != nil {
+				return nil, fmt.Errorf("OneTimeSignatureSecretsFromParts: batch row %d (index %d) failed to decode: %w", i, row.Index, err)
+			}
+		}
+	}
+
+	if len(offsets) > 0 {
+		scalars.Offsets = make([]ephemeralSubkey, len(offsets))
+		for j, row := range offsets {
+			if want := scalars.FirstOffset + uint64(j); row.Index != want {
+				return nil, fmt.Errorf("OneTimeSignatureSecretsFromParts: offset row %d has index %d, expected %d", j, row.Index, want)
+			}
+			if err := protocol.Decode(row.Key, &scalars.Offsets[j]); err != nil {
+				return nil, fmt.Errorf("OneTimeSignatureSecretsFromParts: offset row %d (index %d) failed to decode: %w", j, row.Index, err)
+			}
+		}
+	}
+
+	return &OneTimeSignatureSecrets{OneTimeSignatureSecretsPersistent: scalars}, nil
+}

--- a/crypto/onetimesigpersist.go
+++ b/crypto/onetimesigpersist.go
@@ -80,6 +80,13 @@ func (s *OneTimeSignatureSecrets) encodedOffsetsLocked() []KeyedSubkey {
 	return offsets
 }
 
+// OffsetsExpanded returns whether a batch has ever been expanded into offset
+// subkeys: OffsetsPK2 is set on the first expansion and never cleared.  A key
+// that was never expanded legitimately has no offset subkeys.
+func (s *OneTimeSignatureSecretsPersistent) OffsetsExpanded() bool {
+	return s.OffsetsPK2 != (ed25519PublicKey{})
+}
+
 // PersistentParts returns the scalar fields plus every subkey encoded as its
 // own row, all captured atomically under a single lock acquisition so the
 // scalars and rows are mutually consistent even while DeleteBefore* runs

--- a/crypto/onetimesigpersist_test.go
+++ b/crypto/onetimesigpersist_test.go
@@ -1,0 +1,209 @@
+// Copyright (C) 2019-2026 Algorand Foundation Ltd.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package crypto
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/test/partitiontest"
+)
+
+// reassemble runs a secrets through PersistentParts/FromParts and returns the result.
+func reassemble(t *testing.T, s *OneTimeSignatureSecrets) *OneTimeSignatureSecrets {
+	t.Helper()
+	scalars, batches, offsets := s.PersistentParts()
+	restored, err := OneTimeSignatureSecretsFromParts(scalars, batches, offsets)
+	require.NoError(t, err)
+	return restored
+}
+
+// requireSameSecrets compares two secrets by their canonical msgpack encoding.
+func requireSameSecrets(t *testing.T, expected, actual *OneTimeSignatureSecrets) {
+	t.Helper()
+	e := expected.Snapshot()
+	a := actual.Snapshot()
+	require.Equal(t, protocol.Encode(&e), protocol.Encode(&a))
+}
+
+// TestOneTimeSignatureSecretsBlobRoundTrip covers the legacy whole-blob
+// encoding path: encode/decode fidelity of a full secrets struct.
+func TestOneTimeSignatureSecretsBlobRoundTrip(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	s := GenerateOneTimeSignatureSecrets(0, 100)
+	s.DeleteBeforeFineGrained(OneTimeSignatureIdentifier{Batch: 3, Offset: 5}, 256)
+
+	snap := s.Snapshot()
+	blob := protocol.Encode(&snap)
+	var restored OneTimeSignatureSecrets
+	require.NoError(t, protocol.Decode(blob, &restored))
+	requireSameSecrets(t, s, &restored)
+}
+
+func TestPersistentPartsRoundTrip(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	const numKeysPerBatch = 16
+
+	// fresh: batches only, no offsets
+	fresh := GenerateOneTimeSignatureSecrets(0, 10)
+	requireSameSecrets(t, fresh, reassemble(t, fresh))
+
+	// immediately after a batch rollover: offsets freshly expanded
+	rolled := GenerateOneTimeSignatureSecrets(0, 10)
+	rolled.DeleteBeforeFineGrained(OneTimeSignatureIdentifier{Batch: 1, Offset: 0}, numKeysPerBatch)
+	require.NotEmpty(t, rolled.Offsets)
+	requireSameSecrets(t, rolled, reassemble(t, rolled))
+
+	// mid-batch: offsets partially consumed, FirstOffset > 0
+	mid := GenerateOneTimeSignatureSecrets(0, 10)
+	mid.DeleteBeforeFineGrained(OneTimeSignatureIdentifier{Batch: 2, Offset: 7}, numKeysPerBatch)
+	require.NotZero(t, mid.FirstOffset)
+	requireSameSecrets(t, mid, reassemble(t, mid))
+
+	// exhausted: everything deleted
+	spent := GenerateOneTimeSignatureSecrets(0, 3)
+	spent.DeleteBeforeFineGrained(OneTimeSignatureIdentifier{Batch: 100, Offset: 0}, numKeysPerBatch)
+	require.Empty(t, spent.Batches)
+	require.Empty(t, spent.Offsets)
+	requireSameSecrets(t, spent, reassemble(t, spent))
+}
+
+// TestFromPartsNilBatchesEdge verifies that zero rows reassemble to nil
+// slices, so an exhausted key's FirstBatch is not spuriously bumped by a
+// later far-future DeleteBeforeFineGrained (which skips the bump only when
+// Batches is nil).
+func TestFromPartsNilBatchesEdge(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	const numKeysPerBatch = 16
+
+	spent := GenerateOneTimeSignatureSecrets(0, 3)
+	spent.DeleteBeforeFineGrained(OneTimeSignatureIdentifier{Batch: 50, Offset: 0}, numKeysPerBatch)
+	require.Nil(t, spent.Batches)
+	firstBatchAfterExhaustion := spent.FirstBatch
+
+	restored := reassemble(t, spent)
+	require.Nil(t, restored.Batches)
+	require.Nil(t, restored.Offsets)
+
+	restored.DeleteBeforeFineGrained(OneTimeSignatureIdentifier{Batch: 200, Offset: 0}, numKeysPerBatch)
+	require.Equal(t, firstBatchAfterExhaustion, restored.FirstBatch)
+}
+
+func TestFromPartsValidation(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	const numKeysPerBatch = 16
+	s := GenerateOneTimeSignatureSecrets(0, 10)
+	s.DeleteBeforeFineGrained(OneTimeSignatureIdentifier{Batch: 2, Offset: 3}, numKeysPerBatch)
+	scalars, batches, offsets := s.PersistentParts()
+	require.NotEmpty(t, batches)
+	require.NotEmpty(t, offsets)
+
+	// good baseline
+	_, err := OneTimeSignatureSecretsFromParts(scalars, batches, offsets)
+	require.NoError(t, err)
+
+	// scalars carrying subkeys
+	badScalars := s.Snapshot().OneTimeSignatureSecretsPersistent
+	require.NotEmpty(t, badScalars.Batches)
+	_, err = OneTimeSignatureSecretsFromParts(badScalars, batches, offsets)
+	require.ErrorContains(t, err, "expected none")
+
+	// gap in batch rows
+	gapped := append([]KeyedSubkey{}, batches...)
+	gapped[1].Index++
+	_, err = OneTimeSignatureSecretsFromParts(scalars, gapped, offsets)
+	require.ErrorContains(t, err, "batch row")
+
+	// wrong anchor for offset rows
+	shifted := append([]KeyedSubkey{}, offsets...)
+	for i := range shifted {
+		shifted[i].Index++
+	}
+	_, err = OneTimeSignatureSecretsFromParts(scalars, batches, shifted)
+	require.ErrorContains(t, err, "offset row")
+
+	// corrupt row bytes
+	corrupt := append([]KeyedSubkey{}, batches...)
+	corrupt[0].Key = []byte{0xff, 0x00, 0x01}
+	_, err = OneTimeSignatureSecretsFromParts(scalars, corrupt, offsets)
+	require.ErrorContains(t, err, "failed to decode")
+}
+
+// TestPersistentPartsSignAfterReassembly walks a simulated sequence of rounds
+// (crossing several batch boundaries), reassembling from parts at every step
+// and checking the restored secrets still produce verifiable signatures.
+func TestPersistentPartsSignAfterReassembly(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	const numKeysPerBatch = 8
+	s := GenerateOneTimeSignatureSecrets(0, 6)
+	pub := s.OneTimeSignatureVerifier
+
+	msg := randString()
+	for round := uint64(0); round < 4*numKeysPerBatch; round += 3 {
+		id := OneTimeSignatureIdentifier{Batch: round / numKeysPerBatch, Offset: round % numKeysPerBatch}
+		s.DeleteBeforeFineGrained(id, numKeysPerBatch)
+
+		restored := reassemble(t, s)
+		require.Equal(t, pub, restored.OneTimeSignatureVerifier)
+		sig := restored.Sign(id, msg)
+		require.True(t, pub.Verify(id, msg, sig), "restored secrets failed to sign round %d", round)
+		requireSameSecrets(t, s, restored)
+	}
+}
+
+// TestPersistentPartsConcurrentDelete exercises PersistentParts racing
+// DeleteBeforeFineGrained under -race; it verifies every captured snapshot is
+// internally consistent (reassembles without contiguity errors).
+func TestPersistentPartsConcurrentDelete(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	const numKeysPerBatch = 8
+	s := GenerateOneTimeSignatureSecrets(0, 64)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for round := uint64(0); round < 32*numKeysPerBatch; round++ {
+			id := OneTimeSignatureIdentifier{Batch: round / numKeysPerBatch, Offset: round % numKeysPerBatch}
+			s.DeleteBeforeFineGrained(id, numKeysPerBatch)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			scalars, batches, offsets := s.PersistentParts()
+			_, err := OneTimeSignatureSecretsFromParts(scalars, batches, offsets)
+			require.NoError(t, err)
+		}
+	}()
+	wg.Wait()
+}

--- a/crypto/onetimesigpersist_test.go
+++ b/crypto/onetimesigpersist_test.go
@@ -43,52 +43,6 @@ func requireSameSecrets(t *testing.T, expected, actual *OneTimeSignatureSecrets)
 	require.Equal(t, protocol.Encode(&e), protocol.Encode(&a))
 }
 
-// TestOneTimeSignatureSecretsBlobRoundTrip covers the legacy whole-blob
-// encoding path: encode/decode fidelity of a full secrets struct.
-func TestOneTimeSignatureSecretsBlobRoundTrip(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-
-	s := GenerateOneTimeSignatureSecrets(0, 100)
-	s.DeleteBeforeFineGrained(OneTimeSignatureIdentifier{Batch: 3, Offset: 5}, 256)
-
-	snap := s.Snapshot()
-	blob := protocol.Encode(&snap)
-	var restored OneTimeSignatureSecrets
-	require.NoError(t, protocol.Decode(blob, &restored))
-	requireSameSecrets(t, s, &restored)
-}
-
-func TestPersistentPartsRoundTrip(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	t.Parallel()
-
-	const numKeysPerBatch = 16
-
-	// fresh: batches only, no offsets
-	fresh := GenerateOneTimeSignatureSecrets(0, 10)
-	requireSameSecrets(t, fresh, reassemble(t, fresh))
-
-	// immediately after a batch rollover: offsets freshly expanded
-	rolled := GenerateOneTimeSignatureSecrets(0, 10)
-	rolled.DeleteBeforeFineGrained(OneTimeSignatureIdentifier{Batch: 1, Offset: 0}, numKeysPerBatch)
-	require.NotEmpty(t, rolled.Offsets)
-	requireSameSecrets(t, rolled, reassemble(t, rolled))
-
-	// mid-batch: offsets partially consumed, FirstOffset > 0
-	mid := GenerateOneTimeSignatureSecrets(0, 10)
-	mid.DeleteBeforeFineGrained(OneTimeSignatureIdentifier{Batch: 2, Offset: 7}, numKeysPerBatch)
-	require.NotZero(t, mid.FirstOffset)
-	requireSameSecrets(t, mid, reassemble(t, mid))
-
-	// exhausted: everything deleted
-	spent := GenerateOneTimeSignatureSecrets(0, 3)
-	spent.DeleteBeforeFineGrained(OneTimeSignatureIdentifier{Batch: 100, Offset: 0}, numKeysPerBatch)
-	require.Empty(t, spent.Batches)
-	require.Empty(t, spent.Offsets)
-	requireSameSecrets(t, spent, reassemble(t, spent))
-}
-
 // TestFromPartsNilBatchesEdge verifies that zero rows reassemble to nil
 // slices, so an exhausted key's FirstBatch is not spuriously bumped by a
 // later far-future DeleteBeforeFineGrained (which skips the bump only when
@@ -164,6 +118,9 @@ func TestPersistentPartsSignAfterReassembly(t *testing.T) {
 	const numKeysPerBatch = 8
 	s := GenerateOneTimeSignatureSecrets(0, 6)
 	pub := s.OneTimeSignatureVerifier
+
+	// fresh state (batch subkeys only, no offsets) round-trips
+	requireSameSecrets(t, s, reassemble(t, s))
 
 	msg := randString()
 	for round := uint64(0); round < 4*numKeysPerBatch; round += 3 {

--- a/crypto/onetimesigpersist_test.go
+++ b/crypto/onetimesigpersist_test.go
@@ -187,9 +187,10 @@ func TestPersistentPartsConcurrentDelete(t *testing.T) {
 
 	const numKeysPerBatch = 8
 	s := GenerateOneTimeSignatureSecrets(0, 64)
+	msg := randString()
 
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(3)
 	go func() {
 		defer wg.Done()
 		for round := uint64(0); round < 32*numKeysPerBatch; round++ {
@@ -203,6 +204,15 @@ func TestPersistentPartsConcurrentDelete(t *testing.T) {
 			scalars, batches, offsets := s.PersistentParts()
 			_, err := OneTimeSignatureSecretsFromParts(scalars, batches, offsets)
 			require.NoError(t, err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		// signing (as agreement does) must be safe against concurrent
+		// deletion and persistence snapshots
+		for round := uint64(0); round < 16*numKeysPerBatch; round++ {
+			id := OneTimeSignatureIdentifier{Batch: round / numKeysPerBatch, Offset: round % numKeysPerBatch}
+			s.Sign(id, msg)
 		}
 	}()
 	wg.Wait()

--- a/data/account/account.go
+++ b/data/account/account.go
@@ -134,7 +134,7 @@ func (root Root) Address() basics.Address {
 }
 
 // RestoreParticipation restores a Participation from a database
-// handle.  The file is migrated to the latest schema version first.
+// handle. The file is migrated to the latest schema version first.
 func RestoreParticipation(store db.Accessor) (acc PersistedParticipation, err error) {
 	err = Migrate(store)
 	if err != nil {
@@ -145,15 +145,15 @@ func RestoreParticipation(store db.Accessor) (acc PersistedParticipation, err er
 }
 
 // RestoreParticipationUnmigrated restores a Participation without migrating
-// the file, reading whichever supported schema version it is at.  This keeps
-// the file byte-identical, e.g. for validating a migration against the
-// original.
+// the file, reading whichever supported schema version (3 or 4) it is at.
+// This keeps the file byte-identical, e.g. for validating a migration
+// against the original.
 func RestoreParticipationUnmigrated(store db.Accessor) (PersistedParticipation, error) {
 	version, err := PartkeySchemaVersion(store)
 	if err != nil {
 		return PersistedParticipation{}, err
 	}
-	if version < 1 || version > PartTableSchemaVersion {
+	if version != PartTableSchemaVersion && version != PartTableSchemaVersion-1 {
 		return PersistedParticipation{}, ErrUnsupportedSchema
 	}
 	return restoreParticipationAtVersion(store, version)
@@ -175,19 +175,9 @@ func restoreParticipationAtVersion(store db.Accessor, version int) (acc Persiste
 			return fmt.Errorf("RestoreParticipation: expected exactly one account row, found %d", nrows)
 		}
 
-		columns := "parent, vrf, voting, firstValid, lastValid"
-		dest := []any{&rawParent, &rawVRF, &rawVoting, &acc.FirstValid, &acc.LastValid}
-		if version >= 2 {
-			columns += ", keyDilution"
-			dest = append(dest, &acc.KeyDilution)
-		}
-		if version >= 3 {
-			columns += ", stateProof"
-			dest = append(dest, &rawStateProof)
-		}
-		row = tx.QueryRow("select " + columns + " from ParticipationAccount")
+		row = tx.QueryRow("select parent, vrf, voting, firstValid, lastValid, keyDilution, stateProof from ParticipationAccount")
 
-		err1 = row.Scan(dest...)
+		err1 = row.Scan(&rawParent, &rawVRF, &rawVoting, &acc.FirstValid, &acc.LastValid, &acc.KeyDilution, &rawStateProof)
 		if err1 != nil {
 			return fmt.Errorf("RestoreParticipation: could not read account raw data: %v", err1)
 		}

--- a/data/account/account.go
+++ b/data/account/account.go
@@ -134,14 +134,34 @@ func (root Root) Address() basics.Address {
 }
 
 // RestoreParticipation restores a Participation from a database
-// handle.
+// handle.  The file is migrated to the latest schema version first.
 func RestoreParticipation(store db.Accessor) (acc PersistedParticipation, err error) {
-	var rawParent, rawVRF, rawVoting, rawStateProof []byte
-
 	err = Migrate(store)
 	if err != nil {
-		return
+		return PersistedParticipation{}, err
 	}
+
+	return restoreParticipationAtVersion(store, PartTableSchemaVersion)
+}
+
+// RestoreParticipationUnmigrated restores a Participation without migrating
+// the file, reading whichever supported schema version it is at.  This keeps
+// the file byte-identical, e.g. for validating a migration against the
+// original.
+func RestoreParticipationUnmigrated(store db.Accessor) (PersistedParticipation, error) {
+	version, err := PartkeySchemaVersion(store)
+	if err != nil {
+		return PersistedParticipation{}, err
+	}
+	if version < 1 || version > PartTableSchemaVersion {
+		return PersistedParticipation{}, ErrUnsupportedSchema
+	}
+	return restoreParticipationAtVersion(store, version)
+}
+
+func restoreParticipationAtVersion(store db.Accessor, version int) (acc PersistedParticipation, err error) {
+	var rawParent, rawVRF, rawVoting, rawStateProof []byte
+	var batches, offsets []crypto.KeyedSubkey
 
 	err = store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 		var nrows int
@@ -154,11 +174,28 @@ func RestoreParticipation(store db.Accessor) (acc PersistedParticipation, err er
 			logging.Base().Infof("RestoreParticipation: state not found (n = %v)", nrows)
 		}
 
-		row = tx.QueryRow("select parent, vrf, voting, firstValid, lastValid, keyDilution, stateProof from ParticipationAccount")
+		columns := "parent, vrf, voting, firstValid, lastValid"
+		dest := []interface{}{&rawParent, &rawVRF, &rawVoting, &acc.FirstValid, &acc.LastValid}
+		if version >= 2 {
+			columns += ", keyDilution"
+			dest = append(dest, &acc.KeyDilution)
+		}
+		if version >= 3 {
+			columns += ", stateProof"
+			dest = append(dest, &rawStateProof)
+		}
+		row = tx.QueryRow("select " + columns + " from ParticipationAccount")
 
-		err1 = row.Scan(&rawParent, &rawVRF, &rawVoting, &acc.FirstValid, &acc.LastValid, &acc.KeyDilution, &rawStateProof)
+		err1 = row.Scan(dest...)
 		if err1 != nil {
 			return fmt.Errorf("RestoreParticipation: could not read account raw data: %v", err1)
+		}
+
+		if version >= 4 {
+			batches, offsets, err1 = readVotingRowsFromPartkeyFile(tx)
+			if err1 != nil {
+				return fmt.Errorf("RestoreParticipation: could not read voting subkey rows: %v", err1)
+			}
 		}
 
 		copy(acc.Parent[:32], rawParent)
@@ -176,8 +213,7 @@ func RestoreParticipation(store db.Accessor) (acc PersistedParticipation, err er
 		return PersistedParticipation{}, err
 	}
 
-	acc.Voting = &crypto.OneTimeSignatureSecrets{}
-	err = protocol.Decode(rawVoting, acc.Voting)
+	acc.Voting, err = decodeRowOrientedVoting(rawVoting, batches, offsets)
 	if err != nil {
 		return PersistedParticipation{}, err
 	}
@@ -192,6 +228,21 @@ func RestoreParticipation(store db.Accessor) (acc PersistedParticipation, err er
 	}
 
 	return acc, nil
+}
+
+// decodeRowOrientedVoting reconstructs voting secrets from a voting blob plus
+// subkey rows.  A blob that itself carries subkeys is a legacy whole-secrets
+// encoding and is used as-is.
+func decodeRowOrientedVoting(rawVoting []byte, batches, offsets []crypto.KeyedSubkey) (*crypto.OneTimeSignatureSecrets, error) {
+	voting := &crypto.OneTimeSignatureSecrets{}
+	err := protocol.Decode(rawVoting, voting)
+	if err != nil {
+		return nil, err
+	}
+	if len(voting.Batches) != 0 || len(voting.Offsets) != 0 || (len(batches) == 0 && len(offsets) == 0) {
+		return voting, nil
+	}
+	return crypto.OneTimeSignatureSecretsFromParts(voting.OneTimeSignatureSecretsPersistent, batches, offsets)
 }
 
 // RestoreParticipationWithSecrets restores a Participation from a database

--- a/data/account/account.go
+++ b/data/account/account.go
@@ -20,6 +20,7 @@ package account
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/algorand/go-algorand/crypto"
@@ -144,10 +145,20 @@ func RestoreParticipation(store db.Accessor) (acc PersistedParticipation, err er
 	return restoreParticipationAtVersion(store, PartTableSchemaVersion)
 }
 
+// ErrCorruptedVotingRows is returned when a participation file's voting
+// subkey rows are inconsistent with its scalars (missing, extra, or
+// misattributed rows).  Callers may quarantine such a file the same way an
+// unsupported-schema file is quarantined.
+var ErrCorruptedVotingRows = errors.New("participation file voting subkey rows are corrupt")
+
 // RestoreParticipationUnmigrated restores a Participation without migrating
 // the file, reading whichever supported schema version (3 or 4) it is at.
 // This keeps the file byte-identical, e.g. for validating a migration
 // against the original.
+//
+// The returned value must be treated as read-only: the mutating helpers
+// (DeleteOldKeys, Persist, PersistNewParent) assume the latest schema and
+// fail on an older store.
 func RestoreParticipationUnmigrated(store db.Accessor) (PersistedParticipation, error) {
 	version, err := PartkeySchemaVersion(store)
 	if err != nil {
@@ -212,7 +223,7 @@ func restoreParticipationAtVersion(store db.Accessor, version int) (acc Persiste
 	if rowBased {
 		err = validateVotingRowCounts(&acc.Voting.OneTimeSignatureSecretsPersistent, acc.LastValid, acc.KeyDilution, len(batches), len(offsets))
 		if err != nil {
-			return PersistedParticipation{}, fmt.Errorf("RestoreParticipation: %v", err)
+			return PersistedParticipation{}, fmt.Errorf("RestoreParticipation: %w: %v", ErrCorruptedVotingRows, err)
 		}
 	}
 
@@ -242,13 +253,16 @@ func decodeRowOrientedVoting(rawVoting []byte, batches, offsets []crypto.KeyedSu
 		return voting, false, nil
 	}
 	if err = validateOffsetRowBatches(&voting.OneTimeSignatureSecretsPersistent, offsetBatches); err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("%w: %v", ErrCorruptedVotingRows, err)
 	}
 	if len(batches) == 0 && len(offsets) == 0 {
 		return voting, true, nil
 	}
 	voting, err = crypto.OneTimeSignatureSecretsFromParts(voting.OneTimeSignatureSecretsPersistent, batches, offsets)
-	return voting, true, err
+	if err != nil {
+		return nil, true, fmt.Errorf("%w: %v", ErrCorruptedVotingRows, err)
+	}
+	return voting, true, nil
 }
 
 // RestoreParticipationWithSecrets restores a Participation from a database

--- a/data/account/account.go
+++ b/data/account/account.go
@@ -145,11 +145,11 @@ func RestoreParticipation(store db.Accessor) (acc PersistedParticipation, err er
 	return restoreParticipationAtVersion(store, PartTableSchemaVersion)
 }
 
-// ErrCorruptedVotingRows is returned when a participation file's voting
-// subkey rows are inconsistent with its scalars (missing, extra, or
-// misattributed rows).  Callers may quarantine such a file the same way an
-// unsupported-schema file is quarantined.
-var ErrCorruptedVotingRows = errors.New("participation file voting subkey rows are corrupt")
+// ErrCorruptedVotingData is returned when a participation file's voting data
+// is corrupt: an undecodable voting blob, or subkey rows inconsistent with the
+// scalars (missing, extra, or misattributed rows).  Callers may quarantine
+// such a file the same way an unsupported-schema file is quarantined.
+var ErrCorruptedVotingData = errors.New("participation file voting data is corrupt")
 
 // RestoreParticipationUnmigrated restores a Participation without migrating
 // the file, reading whichever supported schema version (3 or 4) it is at.
@@ -223,7 +223,7 @@ func restoreParticipationAtVersion(store db.Accessor, version int) (acc Persiste
 	if rowBased {
 		err = validateVotingRowCounts(&acc.Voting.OneTimeSignatureSecretsPersistent, acc.LastValid, acc.KeyDilution, len(batches), len(offsets))
 		if err != nil {
-			return PersistedParticipation{}, fmt.Errorf("RestoreParticipation: %w: %v", ErrCorruptedVotingRows, err)
+			return PersistedParticipation{}, fmt.Errorf("RestoreParticipation: %w: %v", ErrCorruptedVotingData, err)
 		}
 	}
 
@@ -247,20 +247,20 @@ func decodeRowOrientedVoting(rawVoting []byte, batches, offsets []crypto.KeyedSu
 	voting = &crypto.OneTimeSignatureSecrets{}
 	err = protocol.Decode(rawVoting, voting)
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("%w: undecodable voting blob: %v", ErrCorruptedVotingData, err)
 	}
 	if len(voting.Batches) != 0 || len(voting.Offsets) != 0 {
 		return voting, false, nil
 	}
 	if err = validateOffsetRowBatches(&voting.OneTimeSignatureSecretsPersistent, offsetBatches); err != nil {
-		return nil, false, fmt.Errorf("%w: %v", ErrCorruptedVotingRows, err)
+		return nil, false, fmt.Errorf("%w: %v", ErrCorruptedVotingData, err)
 	}
 	if len(batches) == 0 && len(offsets) == 0 {
 		return voting, true, nil
 	}
 	voting, err = crypto.OneTimeSignatureSecretsFromParts(voting.OneTimeSignatureSecretsPersistent, batches, offsets)
 	if err != nil {
-		return nil, true, fmt.Errorf("%w: %v", ErrCorruptedVotingRows, err)
+		return nil, true, fmt.Errorf("%w: %v", ErrCorruptedVotingData, err)
 	}
 	return voting, true, nil
 }

--- a/data/account/account.go
+++ b/data/account/account.go
@@ -175,7 +175,7 @@ func restoreParticipationAtVersion(store db.Accessor, version int) (acc Persiste
 		}
 
 		columns := "parent, vrf, voting, firstValid, lastValid"
-		dest := []interface{}{&rawParent, &rawVRF, &rawVoting, &acc.FirstValid, &acc.LastValid}
+		dest := []any{&rawParent, &rawVRF, &rawVoting, &acc.FirstValid, &acc.LastValid}
 		if version >= 2 {
 			columns += ", keyDilution"
 			dest = append(dest, &acc.KeyDilution)

--- a/data/account/account.go
+++ b/data/account/account.go
@@ -162,6 +162,7 @@ func RestoreParticipationUnmigrated(store db.Accessor) (PersistedParticipation, 
 func restoreParticipationAtVersion(store db.Accessor, version int) (acc PersistedParticipation, err error) {
 	var rawParent, rawVRF, rawVoting, rawStateProof []byte
 	var batches, offsets []crypto.KeyedSubkey
+	var offsetBatches []uint64
 
 	err = store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 		var nrows int
@@ -171,7 +172,7 @@ func restoreParticipationAtVersion(store db.Accessor, version int) (acc Persiste
 			return fmt.Errorf("RestoreParticipation: could not query storage: %v", err1)
 		}
 		if nrows != 1 {
-			logging.Base().Infof("RestoreParticipation: state not found (n = %v)", nrows)
+			return fmt.Errorf("RestoreParticipation: expected exactly one account row, found %d", nrows)
 		}
 
 		columns := "parent, vrf, voting, firstValid, lastValid"
@@ -192,7 +193,7 @@ func restoreParticipationAtVersion(store db.Accessor, version int) (acc Persiste
 		}
 
 		if version >= 4 {
-			batches, offsets, err1 = readVotingRowsFromPartkeyFile(tx)
+			batches, offsets, offsetBatches, err1 = readVotingRowsFromPartkeyFile(tx)
 			if err1 != nil {
 				return fmt.Errorf("RestoreParticipation: could not read voting subkey rows: %v", err1)
 			}
@@ -213,9 +214,16 @@ func restoreParticipationAtVersion(store db.Accessor, version int) (acc Persiste
 		return PersistedParticipation{}, err
 	}
 
-	acc.Voting, err = decodeRowOrientedVoting(rawVoting, batches, offsets)
+	var rowBased bool
+	acc.Voting, rowBased, err = decodeRowOrientedVoting(rawVoting, batches, offsets, offsetBatches)
 	if err != nil {
 		return PersistedParticipation{}, err
+	}
+	if rowBased {
+		err = validateVotingRowCounts(&acc.Voting.OneTimeSignatureSecretsPersistent, acc.LastValid, acc.KeyDilution, len(batches), len(offsets))
+		if err != nil {
+			return PersistedParticipation{}, fmt.Errorf("RestoreParticipation: %v", err)
+		}
 	}
 
 	if len(rawStateProof) == 0 {
@@ -232,17 +240,25 @@ func restoreParticipationAtVersion(store db.Accessor, version int) (acc Persiste
 
 // decodeRowOrientedVoting reconstructs voting secrets from a voting blob plus
 // subkey rows.  A blob that itself carries subkeys is a legacy whole-secrets
-// encoding and is used as-is.
-func decodeRowOrientedVoting(rawVoting []byte, batches, offsets []crypto.KeyedSubkey) (*crypto.OneTimeSignatureSecrets, error) {
-	voting := &crypto.OneTimeSignatureSecrets{}
-	err := protocol.Decode(rawVoting, voting)
+// encoding and is used as-is (rowBased false); otherwise the rows are
+// validated against the scalars and reassembled.
+func decodeRowOrientedVoting(rawVoting []byte, batches, offsets []crypto.KeyedSubkey, offsetBatches []uint64) (voting *crypto.OneTimeSignatureSecrets, rowBased bool, err error) {
+	voting = &crypto.OneTimeSignatureSecrets{}
+	err = protocol.Decode(rawVoting, voting)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	if len(voting.Batches) != 0 || len(voting.Offsets) != 0 || (len(batches) == 0 && len(offsets) == 0) {
-		return voting, nil
+	if len(voting.Batches) != 0 || len(voting.Offsets) != 0 {
+		return voting, false, nil
 	}
-	return crypto.OneTimeSignatureSecretsFromParts(voting.OneTimeSignatureSecretsPersistent, batches, offsets)
+	if err = validateOffsetRowBatches(&voting.OneTimeSignatureSecretsPersistent, offsetBatches); err != nil {
+		return nil, false, err
+	}
+	if len(batches) == 0 && len(offsets) == 0 {
+		return voting, true, nil
+	}
+	voting, err = crypto.OneTimeSignatureSecretsFromParts(voting.OneTimeSignatureSecretsPersistent, batches, offsets)
+	return voting, true, err
 }
 
 // RestoreParticipationWithSecrets restores a Participation from a database

--- a/data/account/partInstall.go
+++ b/data/account/partInstall.go
@@ -17,15 +17,20 @@
 package account
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/util/db"
 )
 
 // PartTableSchemaName is the name of the table in the Schema Versions table storing the table + version details
 const PartTableSchemaName = "parttable"
 
 // PartTableSchemaVersion is the latest version of the PartTable schema
-const PartTableSchemaVersion = 3
+const PartTableSchemaVersion = 4
 
 // ErrUnsupportedSchema is the error returned when the PartTable schema version is wrong.
 var ErrUnsupportedSchema = fmt.Errorf("unsupported participation file schema version (expected %d)", PartTableSchemaVersion)
@@ -38,7 +43,7 @@ func partInstallDatabase(tx *sql.Tx) error {
 
 		--* participation keys
 		vrf BLOB,         --*  msgpack encoding of ParticipationAccount.vrf
-		voting BLOB,      --*  msgpack encoding of ParticipationAccount.voting
+		voting BLOB,      --*  msgpack encoding of the voting key scalars (whole secrets before schema v4)
 
 		firstValid INTEGER,
 		lastValid INTEGER,
@@ -46,6 +51,11 @@ func partInstallDatabase(tx *sql.Tx) error {
 		keyDilution INTEGER NOT NULL DEFAULT 0,
 		stateProof BLOB  --*  msgpack encoding of ParticipationAccount.StateProof
 	);`)
+	if err != nil {
+		return err
+	}
+
+	err = createVotingSubkeyTables(tx)
 	if err != nil {
 		return err
 	}
@@ -133,5 +143,77 @@ func updateDB(tx *sql.Tx, partVersion int) (int, error) {
 			return 0, err
 		}
 	}
+
+	if partVersion == 3 {
+		err := migrateVotingBlobToRows(tx)
+		if err != nil {
+			return 0, err
+		}
+
+		partVersion = 4
+		_, err = tx.Exec("UPDATE schema SET version=? WHERE tablename=?", partVersion, PartTableSchemaName)
+		if err != nil {
+			return 0, err
+		}
+	}
 	return partVersion, nil
+}
+
+func createVotingSubkeyTables(tx *sql.Tx) error {
+	_, err := tx.Exec(`CREATE TABLE OtsBatches (
+		batch INTEGER PRIMARY KEY, --* absolute batch number
+		data BLOB NOT NULL         --* msgpack encoding of the batch subkey
+	);`)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Exec(`CREATE TABLE OtsOffsets (
+		off INTEGER PRIMARY KEY, --* absolute offset within batch FirstBatch-1
+		data BLOB NOT NULL       --* msgpack encoding of the offset subkey
+	);`)
+	return err
+}
+
+// migrateVotingBlobToRows converts the whole-secrets voting blob into
+// per-subkey rows, leaving only the scalar fields in the voting column.
+func migrateVotingBlobToRows(tx *sql.Tx) error {
+	err := createVotingSubkeyTables(tx)
+	if err != nil {
+		return err
+	}
+
+	var rawVoting []byte
+	err = tx.QueryRow("SELECT voting FROM ParticipationAccount").Scan(&rawVoting)
+	if err == sql.ErrNoRows {
+		// no account row (partially initialized file); nothing to convert
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if len(rawVoting) == 0 {
+		return nil
+	}
+
+	voting := &crypto.OneTimeSignatureSecrets{}
+	err = protocol.Decode(rawVoting, voting)
+	if err != nil {
+		return fmt.Errorf("migrateVotingBlobToRows: failed to decode voting blob: %w", err)
+	}
+
+	return applyVotingDeltaToPartkeyFile(tx, computeVotingDelta(nil, voting))
+}
+
+// PartkeySchemaVersion reads the participation file's schema version without
+// migrating it.  Returns ErrUnsupportedSchema if no version is recorded.
+func PartkeySchemaVersion(store db.Accessor) (version int, err error) {
+	err = store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		serr := tx.QueryRow("SELECT version FROM schema WHERE tablename=?", PartTableSchemaName).Scan(&version)
+		if serr == sql.ErrNoRows {
+			return ErrUnsupportedSchema
+		}
+		return serr
+	})
+	return version, err
 }

--- a/data/account/partInstall.go
+++ b/data/account/partInstall.go
@@ -32,6 +32,9 @@ const PartTableSchemaName = "parttable"
 
 // PartTableSchemaVersion is the latest version of the PartTable schema
 const PartTableSchemaVersion = 4
+
+// PartTableSchemaVersionVotingSplit is the schema version that split the
+// voting secrets into per-subkey rows.
 const PartTableSchemaVersionVotingSplit = 4
 
 // ErrUnsupportedSchema is the error returned when the PartTable schema version is wrong.
@@ -191,7 +194,7 @@ func migrateVotingBlobToRows(tx *sql.Tx) error {
 	if err != nil {
 		return fmt.Errorf("migrateVotingBlobToRows: %w", err)
 	}
-	err = applyVotingDeltaToPartkeyFile(tx, delta)
+	err = applyVotingDeltaToPartkeyFile(tx, delta, voting)
 	if err != nil {
 		return err
 	}

--- a/data/account/partInstall.go
+++ b/data/account/partInstall.go
@@ -17,6 +17,7 @@
 package account
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
@@ -169,14 +170,18 @@ func createVotingSubkeyTables(tx *sql.Tx) error {
 	}
 
 	_, err = tx.Exec(`CREATE TABLE OtsOffsets (
-		off INTEGER PRIMARY KEY, --* absolute offset within batch FirstBatch-1
-		data BLOB NOT NULL       --* msgpack encoding of the offset subkey
+		batch INTEGER NOT NULL, --* the batch these offsets belong to (FirstBatch-1)
+		off INTEGER NOT NULL,   --* absolute offset within batch
+		data BLOB NOT NULL,     --* msgpack encoding of the offset subkey
+		PRIMARY KEY (batch, off)
 	);`)
 	return err
 }
 
 // migrateVotingBlobToRows converts the whole-secrets voting blob into
-// per-subkey rows, leaving only the scalar fields in the voting column.
+// per-subkey rows, leaving only the scalar fields in the voting column.  The
+// converted state is read back and compared against the original key
+// material before the transaction is allowed to commit.
 func migrateVotingBlobToRows(tx *sql.Tx) error {
 	err := createVotingSubkeyTables(tx)
 	if err != nil {
@@ -202,7 +207,36 @@ func migrateVotingBlobToRows(tx *sql.Tx) error {
 		return fmt.Errorf("migrateVotingBlobToRows: failed to decode voting blob: %w", err)
 	}
 
-	return applyVotingDeltaToPartkeyFile(tx, computeVotingDelta(nil, voting))
+	delta, err := computeVotingDelta(nil, voting)
+	if err != nil {
+		return fmt.Errorf("migrateVotingBlobToRows: %w", err)
+	}
+	err = applyVotingDeltaToPartkeyFile(tx, delta)
+	if err != nil {
+		return err
+	}
+
+	// validate inside the transaction: reconstruct from what was written and
+	// compare the complete key material against the original blob
+	var storedScalars []byte
+	err = tx.QueryRow("SELECT voting FROM ParticipationAccount").Scan(&storedScalars)
+	if err != nil {
+		return fmt.Errorf("migrateVotingBlobToRows: failed to read back scalars: %w", err)
+	}
+	batches, offsets, offsetBatches, err := readVotingRowsFromPartkeyFile(tx)
+	if err != nil {
+		return fmt.Errorf("migrateVotingBlobToRows: failed to read back subkey rows: %w", err)
+	}
+	reconstructed, rowBased, err := decodeRowOrientedVoting(storedScalars, batches, offsets, offsetBatches)
+	if err != nil || !rowBased {
+		return fmt.Errorf("migrateVotingBlobToRows: reconstruction of the converted state failed: %v", err)
+	}
+	origSnap := voting.Snapshot()
+	newSnap := reconstructed.Snapshot()
+	if !bytes.Equal(protocol.Encode(&origSnap), protocol.Encode(&newSnap)) {
+		return fmt.Errorf("migrateVotingBlobToRows: converted state does not match the original key material")
+	}
+	return nil
 }
 
 // PartkeySchemaVersion reads the participation file's schema version without

--- a/data/account/partInstall.go
+++ b/data/account/partInstall.go
@@ -32,6 +32,7 @@ const PartTableSchemaName = "parttable"
 
 // PartTableSchemaVersion is the latest version of the PartTable schema
 const PartTableSchemaVersion = 4
+const PartTableSchemaVersionVotingSplit = 4
 
 // ErrUnsupportedSchema is the error returned when the PartTable schema version is wrong.
 var ErrUnsupportedSchema = fmt.Errorf("unsupported participation file schema version (expected %d)", PartTableSchemaVersion)

--- a/data/account/partInstall.go
+++ b/data/account/partInstall.go
@@ -119,31 +119,10 @@ func partMigrate(tx *sql.Tx) (err error) {
 }
 
 func updateDB(tx *sql.Tx, partVersion int) (int, error) {
-	if partVersion == 1 {
-		_, err := tx.Exec("ALTER TABLE ParticipationAccount ADD keyDilution INTEGER NOT NULL DEFAULT 0")
-		if err != nil {
-			return 0, err
-		}
-
-		partVersion = 2
-		_, err = tx.Exec("UPDATE schema SET version=? WHERE tablename=?", partVersion, PartTableSchemaName)
-		if err != nil {
-			return 0, err
-		}
-	}
-
-	if partVersion == 2 {
-		_, err := tx.Exec("ALTER TABLE ParticipationAccount ADD stateProof BLOB")
-		if err != nil {
-			return 0, err
-		}
-
-		partVersion = 3
-		_, err = tx.Exec("UPDATE schema SET version=? WHERE tablename=?", partVersion, PartTableSchemaName)
-		if err != nil {
-			return 0, err
-		}
-	}
+	// Schema versions 1 and 2 predate state proofs; any key stored in such a
+	// file expired years ago and cannot be registered on today's network, so
+	// those versions are no longer migrated (partMigrate reports them as
+	// ErrUnsupportedSchema).
 
 	if partVersion == 3 {
 		err := migrateVotingBlobToRows(tx)

--- a/data/account/participation.go
+++ b/data/account/participation.go
@@ -203,12 +203,14 @@ func (part PersistedParticipation) DeleteOldKeys(current basics.Round, proto con
 			}
 			var old *crypto.OneTimeSignatureSecretsPersistent
 			if len(rawVoting) > 0 {
+				// Fail closed: without the persisted cursor there is no way to
+				// tell whether memory lags storage, and rewriting from memory
+				// could resurrect keys the file already retired.
 				var decoded crypto.OneTimeSignatureSecrets
-				// a decode failure deliberately leaves old nil, which
-				// degrades to a full rewrite of the rows from memory
-				if protocol.Decode(rawVoting, &decoded) == nil {
-					old = &decoded.OneTimeSignatureSecretsPersistent
+				if err := protocol.Decode(rawVoting, &decoded); err != nil {
+					return fmt.Errorf("Participation.DeleteOldKeys: persisted voting scalars are undecodable; refusing to rewrite voting rows from memory: %v", err)
 				}
+				old = &decoded.OneTimeSignatureSecretsPersistent
 			}
 			delta, err := computeVotingDelta(old, part.Voting)
 			if err != nil {

--- a/data/account/participation.go
+++ b/data/account/participation.go
@@ -212,7 +212,7 @@ func (part PersistedParticipation) DeleteOldKeys(current basics.Round, proto con
 			if err != nil {
 				return fmt.Errorf("Participation.DeleteOldKeys: %v", err)
 			}
-			err = applyVotingDeltaToPartkeyFile(tx, delta)
+			err = applyVotingDeltaToPartkeyFile(tx, delta, part.Voting)
 			if err != nil {
 				return fmt.Errorf("Participation.DeleteOldKeys: failed to update account: %v", err)
 			}

--- a/data/account/participation.go
+++ b/data/account/participation.go
@@ -192,9 +192,23 @@ func (part PersistedParticipation) DeleteOldKeys(current basics.Round, proto con
 	part.Voting.DeleteBeforeFineGrained(basics.OneTimeIDForRound(current, keyDilution), keyDilution)
 
 	errorCh := make(chan error, 1)
-	deleteOldKeys := func(encodedVotingSecrets []byte) {
+	deleteOldKeys := func() {
 		errorCh <- part.Store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-			_, err := tx.Exec("UPDATE ParticipationAccount SET voting=?", encodedVotingSecrets)
+			// read the last-persisted scalars to compute an incremental delta
+			// instead of rewriting the whole keyset
+			var rawVoting []byte
+			err := tx.QueryRow("SELECT voting FROM ParticipationAccount").Scan(&rawVoting)
+			if err != nil {
+				return fmt.Errorf("Participation.DeleteOldKeys: failed to read persisted voting scalars: %v", err)
+			}
+			var old *crypto.OneTimeSignatureSecretsPersistent
+			if len(rawVoting) > 0 {
+				var decoded crypto.OneTimeSignatureSecrets
+				if protocol.Decode(rawVoting, &decoded) == nil {
+					old = &decoded.OneTimeSignatureSecretsPersistent
+				}
+			}
+			err = applyVotingDeltaToPartkeyFile(tx, computeVotingDelta(old, part.Voting))
 			if err != nil {
 				return fmt.Errorf("Participation.DeleteOldKeys: failed to update account: %v", err)
 			}
@@ -202,9 +216,7 @@ func (part PersistedParticipation) DeleteOldKeys(current basics.Round, proto con
 		})
 		close(errorCh)
 	}
-	voting := part.Voting.Snapshot()
-	encodedVotingSecrets := protocol.Encode(&voting)
-	go deleteOldKeys(encodedVotingSecrets)
+	go deleteOldKeys()
 	return errorCh
 }
 
@@ -280,8 +292,8 @@ func (part PersistedParticipation) PersistWithSecrets() error {
 // Persist writes a Participation out to a database on the disk
 func (part PersistedParticipation) Persist() error {
 	rawVRF := protocol.Encode(part.VRF)
-	voting := part.Voting.Snapshot()
-	rawVoting := protocol.Encode(&voting)
+	scalars, batches, offsets := part.Voting.PersistentParts()
+	rawVoting := protocol.Encode(&scalars)
 	rawStateProof := protocol.Encode(part.StateProofSecrets)
 
 	err := part.Store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
@@ -294,6 +306,15 @@ func (part PersistedParticipation) Persist() error {
 			part.Parent[:], rawVRF, rawVoting, part.FirstValid, part.LastValid, part.KeyDilution, rawStateProof)
 		if err != nil {
 			return fmt.Errorf("failed to insert account: %w", err)
+		}
+
+		err = insertKeyedSubkeys(tx, "INSERT INTO OtsBatches (batch, data) VALUES (?, ?)", nil, batches)
+		if err != nil {
+			return fmt.Errorf("failed to insert voting batch subkeys: %w", err)
+		}
+		err = insertKeyedSubkeys(tx, "INSERT INTO OtsOffsets (off, data) VALUES (?, ?)", nil, offsets)
+		if err != nil {
+			return fmt.Errorf("failed to insert voting offset subkeys: %w", err)
 		}
 		return nil
 	})

--- a/data/account/participation.go
+++ b/data/account/participation.go
@@ -208,7 +208,11 @@ func (part PersistedParticipation) DeleteOldKeys(current basics.Round, proto con
 					old = &decoded.OneTimeSignatureSecretsPersistent
 				}
 			}
-			err = applyVotingDeltaToPartkeyFile(tx, computeVotingDelta(old, part.Voting))
+			delta, err := computeVotingDelta(old, part.Voting)
+			if err != nil {
+				return fmt.Errorf("Participation.DeleteOldKeys: %v", err)
+			}
+			err = applyVotingDeltaToPartkeyFile(tx, delta)
 			if err != nil {
 				return fmt.Errorf("Participation.DeleteOldKeys: failed to update account: %v", err)
 			}
@@ -312,9 +316,12 @@ func (part PersistedParticipation) Persist() error {
 		if err != nil {
 			return fmt.Errorf("failed to insert voting batch subkeys: %w", err)
 		}
-		err = insertKeyedSubkeys(tx, "INSERT INTO OtsOffsets (off, data) VALUES (?, ?)", nil, offsets)
-		if err != nil {
-			return fmt.Errorf("failed to insert voting offset subkeys: %w", err)
+		if len(offsets) > 0 {
+			// offset subkeys belong to the batch preceding FirstBatch
+			err = insertKeyedSubkeys(tx, "INSERT INTO OtsOffsets (batch, off, data) VALUES (?, ?, ?)", []any{scalars.FirstBatch - 1}, offsets)
+			if err != nil {
+				return fmt.Errorf("failed to insert voting offset subkeys: %w", err)
+			}
 		}
 		return nil
 	})

--- a/data/account/participation.go
+++ b/data/account/participation.go
@@ -204,6 +204,8 @@ func (part PersistedParticipation) DeleteOldKeys(current basics.Round, proto con
 			var old *crypto.OneTimeSignatureSecretsPersistent
 			if len(rawVoting) > 0 {
 				var decoded crypto.OneTimeSignatureSecrets
+				// a decode failure deliberately leaves old nil, which
+				// degrades to a full rewrite of the rows from memory
 				if protocol.Decode(rawVoting, &decoded) == nil {
 					old = &decoded.OneTimeSignatureSecretsPersistent
 				}
@@ -318,7 +320,11 @@ func (part PersistedParticipation) Persist() error {
 		}
 		if len(offsets) > 0 {
 			// offset subkeys belong to the batch preceding FirstBatch
-			err = insertKeyedSubkeys(tx, "INSERT INTO OtsOffsets (batch, off, data) VALUES (?, ?, ?)", []any{scalars.FirstBatch - 1}, offsets)
+			owningBatch, err := offsetsOwningBatch(scalars.FirstBatch)
+			if err != nil {
+				return err
+			}
+			err = insertKeyedSubkeys(tx, "INSERT INTO OtsOffsets (batch, off, data) VALUES (?, ?, ?)", []any{owningBatch}, offsets)
 			if err != nil {
 				return fmt.Errorf("failed to insert voting offset subkeys: %w", err)
 			}

--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -1092,12 +1092,15 @@ func updateRollingFields(ctx context.Context, tx *sql.Tx, record ParticipationRe
 
 	var old *crypto.OneTimeSignatureSecretsPersistent
 	if len(rawVoting) > 0 {
+		// Fail closed: without the persisted cursor there is no way to tell
+		// whether memory lags storage, and rewriting from memory could
+		// resurrect keys the registry already retired.
 		var decoded crypto.OneTimeSignatureSecrets
-		// a decode failure deliberately leaves old nil, which degrades to a
-		// full rewrite of the rows from memory
-		if protocol.Decode(rawVoting, &decoded) == nil {
-			old = &decoded.OneTimeSignatureSecretsPersistent
+		if err := protocol.Decode(rawVoting, &decoded); err != nil {
+			return fmt.Errorf("stored voting scalars for key %s are undecodable; refusing to rewrite voting rows from memory (delete %s and restart to rebuild the registry): %v",
+				record.ParticipationID, config.ParticipationRegistryFilename, err)
 		}
+		old = &decoded.OneTimeSignatureSecretsPersistent
 	}
 	delta, err := computeVotingDelta(old, record.Voting)
 	if err != nil {

--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -286,6 +286,7 @@ func makeParticipationRegistry(accessor db.Pair, log logging.Logger) (*participa
 
 	migrations := []db.Migration{
 		dbSchemaUpgrade0,
+		dbSchemaUpgrade1,
 	}
 
 	err := db.Initialize(accessor.Wdb, migrations)
@@ -347,6 +348,22 @@ const (
 			key   BLOB    NOT NULL, --*  msgpack encoding of ParticipationAccount.BlockProof.SignatureAlgorithm
 			PRIMARY KEY (pk, round)
 		)`
+
+	// VotingBatches/VotingOffsets hold one row per ephemeral voting subkey,
+	// so per-round key deletion is a row delete instead of a rewrite of the
+	// whole keyset (Rolling.voting holds only the scalar fields).
+	createVotingBatches = `CREATE TABLE VotingBatches (
+			pk    INTEGER NOT NULL,
+			batch INTEGER NOT NULL, --* absolute batch number
+			data  BLOB    NOT NULL, --* msgpack encoding of the batch subkey
+			PRIMARY KEY (pk, batch)
+		)`
+	createVotingOffsets = `CREATE TABLE VotingOffsets (
+			pk   INTEGER NOT NULL,
+			off  INTEGER NOT NULL, --* absolute offset within batch FirstBatch-1
+			data BLOB    NOT NULL, --* msgpack encoding of the offset subkey
+			PRIMARY KEY (pk, off)
+		)`
 	insertKeysetQuery         = `INSERT INTO Keysets (participationID, account, firstValidRound, lastValidRound, keyDilution, vrf, stateProof) VALUES (?, ?, ?, ?, ?, ?, ?)`
 	insertRollingQuery        = `INSERT INTO Rolling (pk, voting) VALUES (?, ?)`
 	appendStateProofKeysQuery = `INSERT INTO StateProofKeys (pk, round, key) VALUES(?, ?, ?)`
@@ -356,7 +373,7 @@ const (
 	selectPK      = `SELECT pk FROM Keysets WHERE participationID = ? LIMIT 1`
 	selectLastPK  = `SELECT pk FROM Keysets ORDER BY pk DESC LIMIT 1`
 	selectRecords = `SELECT
-			k.participationID, k.account, k.firstValidRound,
+			k.pk, k.participationID, k.account, k.firstValidRound,
        		k.lastValidRound, k.keyDilution, k.vrf, k.stateProof,
 			r.lastVoteRound, r.lastBlockProposalRound, r.lastStateProofRound,
 			r.effectiveFirstRound, r.effectiveLastRound, r.voting
@@ -368,17 +385,23 @@ const (
 		FROM StateProofKeys s
 		WHERE round=?
 		   AND pk IN (SELECT pk FROM Keysets WHERE participationID=?)`
+	selectRollingVotingByID = `SELECT r.pk, r.voting
+		FROM Rolling r
+		WHERE r.pk IN (SELECT pk FROM Keysets WHERE participationID=?)`
+	selectVotingBatches    = `SELECT batch, data FROM VotingBatches WHERE pk=? ORDER BY batch`
+	selectVotingOffsets    = `SELECT off, data FROM VotingOffsets WHERE pk=? ORDER BY off`
 	deleteKeysets          = `DELETE FROM Keysets WHERE pk=?`
 	deleteRolling          = `DELETE FROM Rolling WHERE pk=?`
 	deleteStateProofByPK   = `DELETE FROM StateProofKeys WHERE pk=?`
+	deleteVotingBatchesPK  = `DELETE FROM VotingBatches WHERE pk=?`
+	deleteVotingOffsetsPK  = `DELETE FROM VotingOffsets WHERE pk=?`
 	updateRollingFieldsSQL = `UPDATE Rolling
 		 SET lastVoteRound=?,
 		     lastBlockProposalRound=?,
 		     lastStateProofRound=?,
 		     effectiveFirstRound=?,
-		     effectiveLastRound=?,
-		     voting=?
-		 WHERE pk IN (SELECT pk FROM Keysets WHERE participationID=?)`
+		     effectiveLastRound=?
+		 WHERE pk=?`
 )
 
 // dbSchemaUpgrade0 initialize the tables.
@@ -399,6 +422,61 @@ func dbSchemaUpgrade0(ctx context.Context, tx *sql.Tx, newDatabase bool) error {
 	_, err = tx.Exec(createStateProof)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// dbSchemaUpgrade1 moves the voting subkeys out of the Rolling.voting blob
+// into per-subkey rows, leaving only the scalar fields in the blob.
+func dbSchemaUpgrade1(ctx context.Context, tx *sql.Tx, newDatabase bool) error {
+	_, err := tx.Exec(createVotingBatches)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(createVotingOffsets)
+	if err != nil {
+		return err
+	}
+
+	if newDatabase {
+		return nil
+	}
+
+	// convert every existing whole-secrets blob into rows
+	type pkVoting struct {
+		pk        int64
+		rawVoting []byte
+	}
+	var blobs []pkVoting
+	rows, err := tx.Query("SELECT pk, voting FROM Rolling")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var entry pkVoting
+		if err := rows.Scan(&entry.pk, &entry.rawVoting); err != nil {
+			return err
+		}
+		blobs = append(blobs, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	rows.Close()
+
+	for _, entry := range blobs {
+		if len(entry.rawVoting) == 0 {
+			continue
+		}
+		voting := &crypto.OneTimeSignatureSecrets{}
+		if err := protocol.Decode(entry.rawVoting, voting); err != nil {
+			return fmt.Errorf("dbSchemaUpgrade1: failed to decode voting blob for pk %d: %w", entry.pk, err)
+		}
+		if err := applyVotingDeltaToRegistry(tx, entry.pk, computeVotingDelta(nil, voting)); err != nil {
+			return fmt.Errorf("dbSchemaUpgrade1: failed to convert voting blob for pk %d: %w", entry.pk, err)
+		}
 	}
 
 	return nil
@@ -621,9 +699,13 @@ func (db *participationDB) DeleteExpired(latestRound basics.Round, agreementProt
 }
 
 // scanRecords is a helper to manage scanning participation records.
-func scanRecords(rows *sql.Rows) ([]ParticipationRecord, error) {
+// It returns the records along with their Rolling/Keysets primary keys,
+// which callers use to load the per-subkey voting rows.
+func scanRecords(rows *sql.Rows) ([]ParticipationRecord, []int64, error) {
 	results := make([]ParticipationRecord, 0)
+	pks := make([]int64, 0)
 	for rows.Next() {
+		var pk int64
 		var record ParticipationRecord
 		var rawParticipation []byte
 		var rawAccount []byte
@@ -638,6 +720,7 @@ func scanRecords(rows *sql.Rows) ([]ParticipationRecord, error) {
 		var effectiveLast sql.NullInt64
 
 		err := rows.Scan(
+			&pk,
 			&rawParticipation,
 			&rawAccount,
 			&record.FirstValid,
@@ -653,7 +736,7 @@ func scanRecords(rows *sql.Rows) ([]ParticipationRecord, error) {
 			&rawVoting,
 		)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		copy(record.ParticipationID[:], rawParticipation)
@@ -663,7 +746,7 @@ func scanRecords(rows *sql.Rows) ([]ParticipationRecord, error) {
 			record.VRF = &crypto.VRFSecrets{}
 			err = protocol.Decode(rawVRF, record.VRF)
 			if err != nil {
-				return nil, fmt.Errorf("unable to decode VRF: %w", err)
+				return nil, nil, fmt.Errorf("unable to decode VRF: %w", err)
 			}
 		}
 
@@ -671,7 +754,7 @@ func scanRecords(rows *sql.Rows) ([]ParticipationRecord, error) {
 			stateProof := merklesignature.Signer{}
 			err = protocol.Decode(rawStateProof, &stateProof.SignerContext)
 			if err != nil {
-				return nil, fmt.Errorf("unable to decode stateproof: %w", err)
+				return nil, nil, fmt.Errorf("unable to decode stateproof: %w", err)
 			}
 			var stateProofVerifer merklesignature.Verifier
 			copy(stateProofVerifer.Commitment[:], stateProof.GetVerifier().Commitment[:])
@@ -683,7 +766,7 @@ func scanRecords(rows *sql.Rows) ([]ParticipationRecord, error) {
 			record.Voting = &crypto.OneTimeSignatureSecrets{}
 			err = protocol.Decode(rawVoting, record.Voting)
 			if err != nil {
-				return nil, fmt.Errorf("unable to decode Voting: %w", err)
+				return nil, nil, fmt.Errorf("unable to decode Voting: %w", err)
 			}
 		}
 
@@ -709,9 +792,10 @@ func scanRecords(rows *sql.Rows) ([]ParticipationRecord, error) {
 		}
 
 		results = append(results, record)
+		pks = append(pks, pk)
 	}
 
-	return results, nil
+	return results, pks, nil
 }
 
 func (db *participationDB) getAllFromDB() (records []ParticipationRecord, err error) {
@@ -721,10 +805,39 @@ func (db *participationDB) getAllFromDB() (records []ParticipationRecord, err er
 			return fmt.Errorf("unable to query records: %w", err)
 		}
 
-		records, err = scanRecords(rows)
+		var pks []int64
+		records, pks, err = scanRecords(rows)
 		if err != nil {
 			records = nil
 			return fmt.Errorf("problem scanning records: %w", err)
+		}
+		rows.Close()
+
+		// reattach the per-subkey voting rows; a blob that itself carries
+		// subkeys is a legacy whole-secrets encoding and is used as-is
+		for i := range records {
+			voting := records[i].Voting
+			if voting == nil || len(voting.Batches) != 0 || len(voting.Offsets) != 0 {
+				continue
+			}
+			batches, err := readKeyedSubkeys(tx, selectVotingBatches, pks[i])
+			if err != nil {
+				records = nil
+				return fmt.Errorf("unable to read voting batch subkeys for pk %d: %w", pks[i], err)
+			}
+			offsets, err := readKeyedSubkeys(tx, selectVotingOffsets, pks[i])
+			if err != nil {
+				records = nil
+				return fmt.Errorf("unable to read voting offset subkeys for pk %d: %w", pks[i], err)
+			}
+			if len(batches) == 0 && len(offsets) == 0 {
+				continue
+			}
+			records[i].Voting, err = crypto.OneTimeSignatureSecretsFromParts(voting.OneTimeSignatureSecretsPersistent, batches, offsets)
+			if err != nil {
+				records = nil
+				return fmt.Errorf("unable to reassemble voting secrets for pk %d: %w", pks[i], err)
+			}
 		}
 
 		return nil
@@ -849,10 +962,38 @@ func (db *participationDB) GetForRound(id ParticipationID, round basics.Round) (
 	return result, nil
 }
 
-// updateRollingFields sets all of the rolling fields according to the record object.
+// updateRollingFields sets all of the rolling fields according to the record
+// object, persisting the voting secrets incrementally: the last-persisted
+// scalars are compared against the record's secrets and only the difference
+// (consumed subkey rows, refreshed offsets, new scalars) is written.
 func updateRollingFields(ctx context.Context, tx *sql.Tx, record ParticipationRecord) error {
-	voting := record.Voting.Snapshot()
-	encodedVotingSecrets := protocol.Encode(&voting)
+	// resolve the primary key and last-persisted voting scalars, keeping the
+	// legacy ErrNoKeyForID/ErrMultipleKeysForID semantics
+	rows, err := tx.QueryContext(ctx, selectRollingVotingByID, record.ParticipationID[:])
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var pk int64
+	var rawVoting []byte
+	numRows := 0
+	for rows.Next() {
+		if err := rows.Scan(&pk, &rawVoting); err != nil {
+			return err
+		}
+		numRows++
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if numRows > 1 {
+		return ErrMultipleKeysForID
+	}
+	if numRows < 1 {
+		return ErrNoKeyForID
+	}
+	rows.Close()
 
 	result, err := tx.ExecContext(ctx, updateRollingFieldsSQL,
 		record.LastVote,
@@ -860,27 +1001,26 @@ func updateRollingFields(ctx context.Context, tx *sql.Tx, record ParticipationRe
 		record.LastStateProof,
 		record.EffectiveFirst,
 		record.EffectiveLast,
-		encodedVotingSecrets,
-		record.ParticipationID[:])
-
+		pk)
 	if err != nil {
 		return err
 	}
-
-	numRows, err := result.RowsAffected()
-	if err != nil {
+	if err := verifyExecWithOneRowEffected(err, result, "update rolling fields"); err != nil {
 		return err
 	}
 
-	if numRows > 1 {
-		return ErrMultipleKeysForID
+	if record.Voting == nil {
+		return nil
 	}
 
-	if numRows < 1 {
-		return ErrNoKeyForID
+	var old *crypto.OneTimeSignatureSecretsPersistent
+	if len(rawVoting) > 0 {
+		var decoded crypto.OneTimeSignatureSecrets
+		if protocol.Decode(rawVoting, &decoded) == nil {
+			old = &decoded.OneTimeSignatureSecretsPersistent
+		}
 	}
-
-	return nil
+	return applyVotingDeltaToRegistry(tx, pk, computeVotingDelta(old, record.Voting))
 }
 
 func recordActive(record ParticipationRecord, on basics.Round) bool {

--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -414,6 +414,10 @@ const (
 		     effectiveFirstRound=?,
 		     effectiveLastRound=?
 		 WHERE pk=?`
+	updateRegistrationFieldsSQL = `UPDATE Rolling
+		 SET effectiveFirstRound=?,
+		     effectiveLastRound=?
+		 WHERE pk=?`
 )
 
 // dbSchemaUpgrade0 initialize the tables.
@@ -1018,38 +1022,58 @@ func (db *participationDB) GetForRound(id ParticipationID, round basics.Round) (
 	return result, nil
 }
 
+// resolveRollingPK looks up the Rolling primary key and last-persisted voting
+// scalars for a participation ID, keeping the legacy ErrNoKeyForID and
+// ErrMultipleKeysForID semantics that callers special-case.
+func resolveRollingPK(ctx context.Context, tx *sql.Tx, id ParticipationID) (pk int64, rawVoting []byte, err error) {
+	rows, err := tx.QueryContext(ctx, selectRollingVotingByID, id[:])
+	if err != nil {
+		return 0, nil, err
+	}
+	defer rows.Close()
+
+	numRows := 0
+	for rows.Next() {
+		if err = rows.Scan(&pk, &rawVoting); err != nil {
+			return 0, nil, err
+		}
+		numRows++
+	}
+	if err = rows.Err(); err != nil {
+		return 0, nil, err
+	}
+	if numRows > 1 {
+		return 0, nil, ErrMultipleKeysForID
+	}
+	if numRows < 1 {
+		return 0, nil, ErrNoKeyForID
+	}
+	return pk, rawVoting, nil
+}
+
+// updateRegistrationFields persists only the registration window
+// (EffectiveFirst/EffectiveLast) of the record.  Registration deliberately
+// does not touch the voting secrets or the last-used rounds: the record it
+// carries is a snapshot taken when Register was called, and a flush that ran
+// in between may already have persisted a newer deletion cursor.
+func updateRegistrationFields(ctx context.Context, tx *sql.Tx, record ParticipationRecord) error {
+	pk, _, err := resolveRollingPK(ctx, tx, record.ParticipationID)
+	if err != nil {
+		return err
+	}
+	result, err := tx.ExecContext(ctx, updateRegistrationFieldsSQL, record.EffectiveFirst, record.EffectiveLast, pk)
+	return verifyExecWithOneRowEffected(err, result, "update registration fields")
+}
+
 // updateRollingFields sets all of the rolling fields according to the record
 // object, persisting the voting secrets incrementally: the last-persisted
 // scalars are compared against the record's secrets and only the difference
 // (consumed subkey rows, refreshed offsets, new scalars) is written.
 func updateRollingFields(ctx context.Context, tx *sql.Tx, record ParticipationRecord) error {
-	// resolve the primary key and last-persisted voting scalars, keeping the
-	// legacy ErrNoKeyForID/ErrMultipleKeysForID semantics
-	rows, err := tx.QueryContext(ctx, selectRollingVotingByID, record.ParticipationID[:])
+	pk, rawVoting, err := resolveRollingPK(ctx, tx, record.ParticipationID)
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
-
-	var pk int64
-	var rawVoting []byte
-	numRows := 0
-	for rows.Next() {
-		if err = rows.Scan(&pk, &rawVoting); err != nil {
-			return err
-		}
-		numRows++
-	}
-	if err = rows.Err(); err != nil {
-		return err
-	}
-	if numRows > 1 {
-		return ErrMultipleKeysForID
-	}
-	if numRows < 1 {
-		return ErrNoKeyForID
-	}
-	rows.Close()
 
 	result, err := tx.ExecContext(ctx, updateRollingFieldsSQL,
 		record.LastVote,
@@ -1139,10 +1163,22 @@ func (db *participationDB) Register(id ParticipationID, on basics.Round) error {
 	if len(updated) != 0 {
 		db.writeQueue <- makeOpRequest(&registerOp{updated: updated})
 
+		// Merge only the registration window into the live cache entries.
+		// The snapshots in updated predate this lock: a DeleteExpired in
+		// between may have advanced the cached voting secrets, and
+		// overwriting them would rewind the cache.  The dirty flags stay
+		// set — registration persists nothing else, so pending changes
+		// still need the next flush.
 		db.mutex.Lock()
 		for id, record := range updated {
-			delete(db.dirty, id)
-			db.cache[id] = record.ParticipationRecord
+			current, ok := db.cache[id]
+			if !ok {
+				// deleted meanwhile; do not resurrect it in the cache
+				continue
+			}
+			current.EffectiveFirst = record.EffectiveFirst
+			current.EffectiveLast = record.EffectiveLast
+			db.cache[id] = current
 		}
 		db.mutex.Unlock()
 	}

--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -487,14 +487,14 @@ func dbSchemaUpgrade1(ctx context.Context, tx *sql.Tx, newDatabase bool) error {
 		if err != nil {
 			return fmt.Errorf("dbSchemaUpgrade1: failed to compute conversion for pk %d: %w", entry.pk, err)
 		}
-		if err := applyVotingDeltaToRegistry(tx, entry.pk, delta); err != nil {
+		if err = applyVotingDeltaToRegistry(tx, entry.pk, delta); err != nil {
 			return fmt.Errorf("dbSchemaUpgrade1: failed to convert voting blob for pk %d: %w", entry.pk, err)
 		}
 
 		// validate inside the transaction: reconstruct from what was written
 		// and compare the complete key material against the original blob
 		var storedScalars []byte
-		if err := tx.QueryRow("SELECT voting FROM Rolling WHERE pk=?", entry.pk).Scan(&storedScalars); err != nil {
+		if err = tx.QueryRow("SELECT voting FROM Rolling WHERE pk=?", entry.pk).Scan(&storedScalars); err != nil {
 			return fmt.Errorf("dbSchemaUpgrade1: failed to read back scalars for pk %d: %w", entry.pk, err)
 		}
 		batches, err := readKeyedSubkeys(tx, selectVotingBatches, entry.pk)
@@ -881,12 +881,12 @@ func (db *participationDB) getAllFromDB() (records []ParticipationRecord, err er
 			offsets := offsetsByPK[pks[i]]
 
 			scalars := &voting.OneTimeSignatureSecretsPersistent
-			if err := validateOffsetRowBatches(scalars, offsets.batches); err != nil {
+			if err = validateOffsetRowBatches(scalars, offsets.batches); err != nil {
 				err = fmt.Errorf("voting rows for key %s (pk %d) are corrupt: %w", records[i].ParticipationID, pks[i], err)
 				records = nil
 				return err
 			}
-			if err := validateVotingRowCounts(scalars, records[i].LastValid, records[i].KeyDilution, len(batches.subkeys), len(offsets.subkeys)); err != nil {
+			if err = validateVotingRowCounts(scalars, records[i].LastValid, records[i].KeyDilution, len(batches.subkeys), len(offsets.subkeys)); err != nil {
 				err = fmt.Errorf("voting rows for key %s (pk %d) are corrupt: %w", records[i].ParticipationID, pks[i], err)
 				records = nil
 				return err

--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -399,6 +399,14 @@ const (
 	deleteStateProofByPK   = `DELETE FROM StateProofKeys WHERE pk=?`
 	deleteVotingBatchesPK  = `DELETE FROM VotingBatches WHERE pk=?`
 	deleteVotingOffsetsPK  = `DELETE FROM VotingOffsets WHERE pk=?`
+
+	// insert-time clearing of any pre-existing rows for a participation ID
+	// (child tables first — their subqueries depend on Keysets)
+	clearRollingByID       = `DELETE FROM Rolling WHERE pk IN (SELECT pk FROM Keysets WHERE participationID=?)`
+	clearStateProofByID    = `DELETE FROM StateProofKeys WHERE pk IN (SELECT pk FROM Keysets WHERE participationID=?)`
+	clearVotingBatchesByID = `DELETE FROM VotingBatches WHERE pk IN (SELECT pk FROM Keysets WHERE participationID=?)`
+	clearVotingOffsetsByID = `DELETE FROM VotingOffsets WHERE pk IN (SELECT pk FROM Keysets WHERE participationID=?)`
+	clearKeysetsByID       = `DELETE FROM Keysets WHERE participationID=?`
 	updateRollingFieldsSQL = `UPDATE Rolling
 		 SET lastVoteRound=?,
 		     lastBlockProposalRound=?,
@@ -1061,6 +1069,8 @@ func updateRollingFields(ctx context.Context, tx *sql.Tx, record ParticipationRe
 	var old *crypto.OneTimeSignatureSecretsPersistent
 	if len(rawVoting) > 0 {
 		var decoded crypto.OneTimeSignatureSecrets
+		// a decode failure deliberately leaves old nil, which degrades to a
+		// full rewrite of the rows from memory
 		if protocol.Decode(rawVoting, &decoded) == nil {
 			old = &decoded.OneTimeSignatureSecretsPersistent
 		}

--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -979,12 +979,12 @@ func updateRollingFields(ctx context.Context, tx *sql.Tx, record ParticipationRe
 	var rawVoting []byte
 	numRows := 0
 	for rows.Next() {
-		if err := rows.Scan(&pk, &rawVoting); err != nil {
+		if err = rows.Scan(&pk, &rawVoting); err != nil {
 			return err
 		}
 		numRows++
 	}
-	if err := rows.Err(); err != nil {
+	if err = rows.Err(); err != nil {
 		return err
 	}
 	if numRows > 1 {
@@ -1005,7 +1005,7 @@ func updateRollingFields(ctx context.Context, tx *sql.Tx, record ParticipationRe
 	if err != nil {
 		return err
 	}
-	if err := verifyExecWithOneRowEffected(err, result, "update rolling fields"); err != nil {
+	if err = verifyExecWithOneRowEffected(err, result, "update rolling fields"); err != nil {
 		return err
 	}
 

--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -479,15 +479,15 @@ func dbSchemaUpgrade1(ctx context.Context, tx *sql.Tx, newDatabase bool) error {
 			// Leave an undecodable blob in place rather than failing the
 			// whole migration (db.Initialize would mask this error as a
 			// generic upgrade failure with no quarantine path).  The record
-			// stays readable through the legacy whole-blob tolerance and is
-			// converted lazily by the next flush.
+			// is excluded from the cache with a warning at load time, so it
+			// does not block the registry from opening.
 			continue
 		}
 		delta, err := computeVotingDelta(nil, voting)
 		if err != nil {
 			return fmt.Errorf("dbSchemaUpgrade1: failed to compute conversion for pk %d: %w", entry.pk, err)
 		}
-		if err = applyVotingDeltaToRegistry(tx, entry.pk, delta); err != nil {
+		if err = applyVotingDeltaToRegistry(tx, entry.pk, delta, voting); err != nil {
 			return fmt.Errorf("dbSchemaUpgrade1: failed to convert voting blob for pk %d: %w", entry.pk, err)
 		}
 
@@ -623,11 +623,6 @@ func (db *participationDB) Insert(record Participation) (id ParticipationID, err
 		return id, ErrAlreadyInserted
 	}
 
-	db.writeQueue <- makeOpRequest(&insertOp{
-		id:     id,
-		record: record,
-	})
-
 	// Make some copies.
 	var vrf *crypto.VRFSecrets
 	if record.VRF != nil {
@@ -641,6 +636,16 @@ func (db *participationDB) Insert(record Participation) (id ParticipationID, err
 		voting = new(crypto.OneTimeSignatureSecrets)
 		*voting = record.Voting.Snapshot()
 	}
+
+	// hand the write op the same frozen snapshot the cache gets: the caller
+	// may keep advancing the live secrets (e.g. the partkey file's copy),
+	// and persisting a newer state than the cache holds would trip the
+	// monotonicity guard on the next flush
+	record.Voting = voting
+	db.writeQueue <- makeOpRequest(&insertOp{
+		id:     id,
+		record: record,
+	})
 
 	var stateProofVerifierPtr *merklesignature.Verifier
 	if record.StateProofSecrets != nil {
@@ -736,11 +741,13 @@ func (db *participationDB) DeleteExpired(latestRound basics.Round, agreementProt
 }
 
 // scanRecords is a helper to manage scanning participation records.
-// It returns the records along with their Rolling/Keysets primary keys,
-// which callers use to load the per-subkey voting rows.
-func scanRecords(rows *sql.Rows) ([]ParticipationRecord, []int64, error) {
+// It returns the records along with their Rolling/Keysets primary keys and
+// raw voting blobs; the caller decodes the voting secrets so that a corrupt
+// record can be excluded instead of failing the whole scan.
+func scanRecords(rows *sql.Rows) ([]ParticipationRecord, []int64, [][]byte, error) {
 	results := make([]ParticipationRecord, 0)
 	pks := make([]int64, 0)
+	rawVotings := make([][]byte, 0)
 	for rows.Next() {
 		var pk int64
 		var record ParticipationRecord
@@ -773,7 +780,7 @@ func scanRecords(rows *sql.Rows) ([]ParticipationRecord, []int64, error) {
 			&rawVoting,
 		)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		copy(record.ParticipationID[:], rawParticipation)
@@ -783,7 +790,7 @@ func scanRecords(rows *sql.Rows) ([]ParticipationRecord, []int64, error) {
 			record.VRF = &crypto.VRFSecrets{}
 			err = protocol.Decode(rawVRF, record.VRF)
 			if err != nil {
-				return nil, nil, fmt.Errorf("unable to decode VRF: %w", err)
+				return nil, nil, nil, fmt.Errorf("unable to decode VRF: %w", err)
 			}
 		}
 
@@ -791,20 +798,12 @@ func scanRecords(rows *sql.Rows) ([]ParticipationRecord, []int64, error) {
 			stateProof := merklesignature.Signer{}
 			err = protocol.Decode(rawStateProof, &stateProof.SignerContext)
 			if err != nil {
-				return nil, nil, fmt.Errorf("unable to decode stateproof: %w", err)
+				return nil, nil, nil, fmt.Errorf("unable to decode stateproof: %w", err)
 			}
 			var stateProofVerifer merklesignature.Verifier
 			copy(stateProofVerifer.Commitment[:], stateProof.GetVerifier().Commitment[:])
 			stateProofVerifer.KeyLifetime = stateProof.GetVerifier().KeyLifetime
 			record.StateProof = &stateProofVerifer
-		}
-
-		if len(rawVoting) > 0 {
-			record.Voting = &crypto.OneTimeSignatureSecrets{}
-			err = protocol.Decode(rawVoting, record.Voting)
-			if err != nil {
-				return nil, nil, fmt.Errorf("unable to decode Voting: %w", err)
-			}
 		}
 
 		// Check optional values.
@@ -830,15 +829,16 @@ func scanRecords(rows *sql.Rows) ([]ParticipationRecord, []int64, error) {
 
 		results = append(results, record)
 		pks = append(pks, pk)
+		rawVotings = append(rawVotings, rawVoting)
 	}
 
 	// an iteration error ends the loop the same way exhaustion does; without
 	// this check it would silently truncate the result set
 	if err := rows.Err(); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return results, pks, nil
+	return results, pks, rawVotings, nil
 }
 
 func (db *participationDB) getAllFromDB() (records []ParticipationRecord, err error) {
@@ -849,10 +849,8 @@ func (db *participationDB) getAllFromDB() (records []ParticipationRecord, err er
 		}
 		defer rows.Close()
 
-		var pks []int64
-		records, pks, err = scanRecords(rows)
+		scanned, pks, rawVotings, err := scanRecords(rows)
 		if err != nil {
-			records = nil
 			return fmt.Errorf("problem scanning records: %w", err)
 		}
 		// release the cursor before issuing the subkey queries below
@@ -861,44 +859,33 @@ func (db *participationDB) getAllFromDB() (records []ParticipationRecord, err er
 		// load every subkey row in two queries and group by pk
 		batchesByPK, err := readGroupedSubkeys(tx, selectAllVotingBatches, false)
 		if err != nil {
-			records = nil
 			return fmt.Errorf("unable to read voting batch subkeys: %w", err)
 		}
 		offsetsByPK, err := readGroupedSubkeys(tx, selectAllVotingOffsets, true)
 		if err != nil {
-			records = nil
 			return fmt.Errorf("unable to read voting offset subkeys: %w", err)
 		}
 
-		// reattach the per-subkey voting rows; a blob that itself carries
-		// subkeys is a legacy whole-secrets encoding and is used as-is
-		for i := range records {
-			voting := records[i].Voting
-			if voting == nil || len(voting.Batches) != 0 || len(voting.Offsets) != 0 {
-				continue
+		// decode and reattach the voting secrets; a record whose voting data
+		// is corrupt is excluded with a warning rather than blocking the
+		// whole registry (and with it the node) from loading
+		records = make([]ParticipationRecord, 0, len(scanned))
+		for i := range scanned {
+			if len(rawVotings[i]) > 0 {
+				batches := batchesByPK[pks[i]]
+				offsets := offsetsByPK[pks[i]]
+				voting, rowBased, verr := decodeRowOrientedVoting(rawVotings[i], batches.subkeys, offsets.subkeys, offsets.batches)
+				if verr == nil && rowBased {
+					verr = validateVotingRowCounts(&voting.OneTimeSignatureSecretsPersistent, scanned[i].LastValid, scanned[i].KeyDilution, len(batches.subkeys), len(offsets.subkeys))
+				}
+				if verr != nil {
+					db.log.Warnf("participationDB: excluding key %s (pk %d) from the registry, its voting data is corrupt: %v; delete %s and restart to rebuild the registry",
+						scanned[i].ParticipationID, pks[i], verr, config.ParticipationRegistryFilename)
+					continue
+				}
+				scanned[i].Voting = voting
 			}
-			batches := batchesByPK[pks[i]]
-			offsets := offsetsByPK[pks[i]]
-
-			scalars := &voting.OneTimeSignatureSecretsPersistent
-			if err = validateOffsetRowBatches(scalars, offsets.batches); err != nil {
-				err = fmt.Errorf("voting rows for key %s (pk %d) are corrupt: %w", records[i].ParticipationID, pks[i], err)
-				records = nil
-				return err
-			}
-			if err = validateVotingRowCounts(scalars, records[i].LastValid, records[i].KeyDilution, len(batches.subkeys), len(offsets.subkeys)); err != nil {
-				err = fmt.Errorf("voting rows for key %s (pk %d) are corrupt: %w", records[i].ParticipationID, pks[i], err)
-				records = nil
-				return err
-			}
-			if len(batches.subkeys) == 0 && len(offsets.subkeys) == 0 {
-				continue
-			}
-			records[i].Voting, err = crypto.OneTimeSignatureSecretsFromParts(voting.OneTimeSignatureSecretsPersistent, batches.subkeys, offsets.subkeys)
-			if err != nil {
-				records = nil
-				return fmt.Errorf("unable to reassemble voting secrets for pk %d: %w", pks[i], err)
-			}
+			records = append(records, scanned[i])
 		}
 
 		return nil
@@ -1082,7 +1069,7 @@ func updateRollingFields(ctx context.Context, tx *sql.Tx, record ParticipationRe
 	if err != nil {
 		return err
 	}
-	return applyVotingDeltaToRegistry(tx, pk, delta)
+	return applyVotingDeltaToRegistry(tx, pk, delta, record.Voting)
 }
 
 func recordActive(record ParticipationRecord, on basics.Round) bool {

--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -17,6 +17,7 @@
 package account
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/base32"
@@ -359,10 +360,11 @@ const (
 			PRIMARY KEY (pk, batch)
 		)`
 	createVotingOffsets = `CREATE TABLE VotingOffsets (
-			pk   INTEGER NOT NULL,
-			off  INTEGER NOT NULL, --* absolute offset within batch FirstBatch-1
-			data BLOB    NOT NULL, --* msgpack encoding of the offset subkey
-			PRIMARY KEY (pk, off)
+			pk    INTEGER NOT NULL,
+			batch INTEGER NOT NULL, --* the batch these offsets belong to (FirstBatch-1)
+			off   INTEGER NOT NULL, --* absolute offset within batch
+			data  BLOB    NOT NULL, --* msgpack encoding of the offset subkey
+			PRIMARY KEY (pk, batch, off)
 		)`
 	insertKeysetQuery         = `INSERT INTO Keysets (participationID, account, firstValidRound, lastValidRound, keyDilution, vrf, stateProof) VALUES (?, ?, ?, ?, ?, ?, ?)`
 	insertRollingQuery        = `INSERT INTO Rolling (pk, voting) VALUES (?, ?)`
@@ -389,7 +391,9 @@ const (
 		FROM Rolling r
 		WHERE r.pk IN (SELECT pk FROM Keysets WHERE participationID=?)`
 	selectVotingBatches    = `SELECT batch, data FROM VotingBatches WHERE pk=? ORDER BY batch`
-	selectVotingOffsets    = `SELECT off, data FROM VotingOffsets WHERE pk=? ORDER BY off`
+	selectVotingOffsets    = `SELECT batch, off, data FROM VotingOffsets WHERE pk=? ORDER BY off`
+	selectAllVotingBatches = `SELECT pk, batch, data FROM VotingBatches ORDER BY pk, batch`
+	selectAllVotingOffsets = `SELECT pk, batch, off, data FROM VotingOffsets ORDER BY pk, off`
 	deleteKeysets          = `DELETE FROM Keysets WHERE pk=?`
 	deleteRolling          = `DELETE FROM Rolling WHERE pk=?`
 	deleteStateProofByPK   = `DELETE FROM StateProofKeys WHERE pk=?`
@@ -479,8 +483,36 @@ func dbSchemaUpgrade1(ctx context.Context, tx *sql.Tx, newDatabase bool) error {
 			// converted lazily by the next flush.
 			continue
 		}
-		if err := applyVotingDeltaToRegistry(tx, entry.pk, computeVotingDelta(nil, voting)); err != nil {
+		delta, err := computeVotingDelta(nil, voting)
+		if err != nil {
+			return fmt.Errorf("dbSchemaUpgrade1: failed to compute conversion for pk %d: %w", entry.pk, err)
+		}
+		if err := applyVotingDeltaToRegistry(tx, entry.pk, delta); err != nil {
 			return fmt.Errorf("dbSchemaUpgrade1: failed to convert voting blob for pk %d: %w", entry.pk, err)
+		}
+
+		// validate inside the transaction: reconstruct from what was written
+		// and compare the complete key material against the original blob
+		var storedScalars []byte
+		if err := tx.QueryRow("SELECT voting FROM Rolling WHERE pk=?", entry.pk).Scan(&storedScalars); err != nil {
+			return fmt.Errorf("dbSchemaUpgrade1: failed to read back scalars for pk %d: %w", entry.pk, err)
+		}
+		batches, err := readKeyedSubkeys(tx, selectVotingBatches, entry.pk)
+		if err != nil {
+			return fmt.Errorf("dbSchemaUpgrade1: failed to read back batch subkeys for pk %d: %w", entry.pk, err)
+		}
+		offsets, offsetBatches, err := readOffsetSubkeys(tx, selectVotingOffsets, entry.pk)
+		if err != nil {
+			return fmt.Errorf("dbSchemaUpgrade1: failed to read back offset subkeys for pk %d: %w", entry.pk, err)
+		}
+		reconstructed, rowBased, err := decodeRowOrientedVoting(storedScalars, batches, offsets, offsetBatches)
+		if err != nil || !rowBased {
+			return fmt.Errorf("dbSchemaUpgrade1: reconstruction of converted state for pk %d failed: %v", entry.pk, err)
+		}
+		origSnap := voting.Snapshot()
+		newSnap := reconstructed.Snapshot()
+		if !bytes.Equal(protocol.Encode(&origSnap), protocol.Encode(&newSnap)) {
+			return fmt.Errorf("dbSchemaUpgrade1: converted state for pk %d does not match the original key material", entry.pk)
 		}
 	}
 
@@ -823,8 +855,20 @@ func (db *participationDB) getAllFromDB() (records []ParticipationRecord, err er
 			records = nil
 			return fmt.Errorf("problem scanning records: %w", err)
 		}
-		// release the cursor before issuing the per-subkey queries below
+		// release the cursor before issuing the subkey queries below
 		rows.Close()
+
+		// load every subkey row in two queries and group by pk
+		batchesByPK, err := readGroupedSubkeys(tx, selectAllVotingBatches, false)
+		if err != nil {
+			records = nil
+			return fmt.Errorf("unable to read voting batch subkeys: %w", err)
+		}
+		offsetsByPK, err := readGroupedSubkeys(tx, selectAllVotingOffsets, true)
+		if err != nil {
+			records = nil
+			return fmt.Errorf("unable to read voting offset subkeys: %w", err)
+		}
 
 		// reattach the per-subkey voting rows; a blob that itself carries
 		// subkeys is a legacy whole-secrets encoding and is used as-is
@@ -833,27 +877,24 @@ func (db *participationDB) getAllFromDB() (records []ParticipationRecord, err er
 			if voting == nil || len(voting.Batches) != 0 || len(voting.Offsets) != 0 {
 				continue
 			}
-			batches, err := readKeyedSubkeys(tx, selectVotingBatches, pks[i])
-			if err != nil {
+			batches := batchesByPK[pks[i]]
+			offsets := offsetsByPK[pks[i]]
+
+			scalars := &voting.OneTimeSignatureSecretsPersistent
+			if err := validateOffsetRowBatches(scalars, offsets.batches); err != nil {
+				err = fmt.Errorf("voting rows for key %s (pk %d) are corrupt: %w", records[i].ParticipationID, pks[i], err)
 				records = nil
-				return fmt.Errorf("unable to read voting batch subkeys for pk %d: %w", pks[i], err)
+				return err
 			}
-			offsets, err := readKeyedSubkeys(tx, selectVotingOffsets, pks[i])
-			if err != nil {
+			if err := validateVotingRowCounts(scalars, records[i].LastValid, records[i].KeyDilution, len(batches.subkeys), len(offsets.subkeys)); err != nil {
+				err = fmt.Errorf("voting rows for key %s (pk %d) are corrupt: %w", records[i].ParticipationID, pks[i], err)
 				records = nil
-				return fmt.Errorf("unable to read voting offset subkeys for pk %d: %w", pks[i], err)
+				return err
 			}
-			if len(batches) == 0 && len(offsets) == 0 {
-				// a key that should still hold subkeys but has no rows would
-				// look valid yet be unable to vote; make that loud
-				if dilution := records[i].KeyDilution; dilution > 0 &&
-					voting.FirstBatch <= basics.OneTimeIDForRound(records[i].LastValid, dilution).Batch {
-					db.log.Warnf("participationDB: key %s has no voting subkey rows but is valid through round %d; it will not be able to vote",
-						records[i].ParticipationID, records[i].LastValid)
-				}
+			if len(batches.subkeys) == 0 && len(offsets.subkeys) == 0 {
 				continue
 			}
-			records[i].Voting, err = crypto.OneTimeSignatureSecretsFromParts(voting.OneTimeSignatureSecretsPersistent, batches, offsets)
+			records[i].Voting, err = crypto.OneTimeSignatureSecretsFromParts(voting.OneTimeSignatureSecretsPersistent, batches.subkeys, offsets.subkeys)
 			if err != nil {
 				records = nil
 				return fmt.Errorf("unable to reassemble voting secrets for pk %d: %w", pks[i], err)
@@ -1037,7 +1078,11 @@ func updateRollingFields(ctx context.Context, tx *sql.Tx, record ParticipationRe
 			old = &decoded.OneTimeSignatureSecretsPersistent
 		}
 	}
-	return applyVotingDeltaToRegistry(tx, pk, computeVotingDelta(old, record.Voting))
+	delta, err := computeVotingDelta(old, record.Voting)
+	if err != nil {
+		return err
+	}
+	return applyVotingDeltaToRegistry(tx, pk, delta)
 }
 
 func recordActive(record ParticipationRecord, on basics.Round) bool {

--- a/data/account/participationRegistry.go
+++ b/data/account/participationRegistry.go
@@ -472,7 +472,12 @@ func dbSchemaUpgrade1(ctx context.Context, tx *sql.Tx, newDatabase bool) error {
 		}
 		voting := &crypto.OneTimeSignatureSecrets{}
 		if err := protocol.Decode(entry.rawVoting, voting); err != nil {
-			return fmt.Errorf("dbSchemaUpgrade1: failed to decode voting blob for pk %d: %w", entry.pk, err)
+			// Leave an undecodable blob in place rather than failing the
+			// whole migration (db.Initialize would mask this error as a
+			// generic upgrade failure with no quarantine path).  The record
+			// stays readable through the legacy whole-blob tolerance and is
+			// converted lazily by the next flush.
+			continue
 		}
 		if err := applyVotingDeltaToRegistry(tx, entry.pk, computeVotingDelta(nil, voting)); err != nil {
 			return fmt.Errorf("dbSchemaUpgrade1: failed to convert voting blob for pk %d: %w", entry.pk, err)
@@ -795,6 +800,12 @@ func scanRecords(rows *sql.Rows) ([]ParticipationRecord, []int64, error) {
 		pks = append(pks, pk)
 	}
 
+	// an iteration error ends the loop the same way exhaustion does; without
+	// this check it would silently truncate the result set
+	if err := rows.Err(); err != nil {
+		return nil, nil, err
+	}
+
 	return results, pks, nil
 }
 
@@ -804,6 +815,7 @@ func (db *participationDB) getAllFromDB() (records []ParticipationRecord, err er
 		if err != nil {
 			return fmt.Errorf("unable to query records: %w", err)
 		}
+		defer rows.Close()
 
 		var pks []int64
 		records, pks, err = scanRecords(rows)
@@ -811,6 +823,7 @@ func (db *participationDB) getAllFromDB() (records []ParticipationRecord, err er
 			records = nil
 			return fmt.Errorf("problem scanning records: %w", err)
 		}
+		// release the cursor before issuing the per-subkey queries below
 		rows.Close()
 
 		// reattach the per-subkey voting rows; a blob that itself carries
@@ -831,6 +844,13 @@ func (db *participationDB) getAllFromDB() (records []ParticipationRecord, err er
 				return fmt.Errorf("unable to read voting offset subkeys for pk %d: %w", pks[i], err)
 			}
 			if len(batches) == 0 && len(offsets) == 0 {
+				// a key that should still hold subkeys but has no rows would
+				// look valid yet be unable to vote; make that loud
+				if dilution := records[i].KeyDilution; dilution > 0 &&
+					voting.FirstBatch <= basics.OneTimeIDForRound(records[i].LastValid, dilution).Batch {
+					db.log.Warnf("participationDB: key %s has no voting subkey rows but is valid through round %d; it will not be able to vote",
+						records[i].ParticipationID, records[i].LastValid)
+				}
 				continue
 			}
 			records[i].Voting, err = crypto.OneTimeSignatureSecretsFromParts(voting.OneTimeSignatureSecretsPersistent, batches, offsets)
@@ -1002,9 +1022,6 @@ func updateRollingFields(ctx context.Context, tx *sql.Tx, record ParticipationRe
 		record.EffectiveFirst,
 		record.EffectiveLast,
 		pk)
-	if err != nil {
-		return err
-	}
 	if err = verifyExecWithOneRowEffected(err, result, "update rolling fields"); err != nil {
 		return err
 	}

--- a/data/account/participationRegistry_test.go
+++ b/data/account/participationRegistry_test.go
@@ -342,41 +342,20 @@ func TestParticipation_CleanupTablesAfterDeleteExpired(t *testing.T) {
 	a.NoError(err)
 
 	a.NoError(registry.Flush(defaultTimeout))
-	var numOfRecords int
 	// make sure tables are clean
-	err = registry.store.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		row := tx.QueryRow(`select count(*) from Keysets`)
-		err = row.Scan(&numOfRecords)
-		if err != nil {
-			return fmt.Errorf("unable to scan pk: %w", err)
-		}
-		return nil
-	})
-
-	a.NoError(err)
-	a.Equal(0, numOfRecords)
-
-	err = registry.store.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		row := tx.QueryRow(`select count(*) from Rolling`)
-		err = row.Scan(&numOfRecords)
-		if err != nil {
-			return fmt.Errorf("unable to scan pk: %w", err)
-		}
-		return nil
-	})
-	a.NoError(err)
-	a.Equal(0, numOfRecords)
-
-	err = registry.store.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		row := tx.QueryRow(`select count(*) from stateproofkeys`)
-		err = row.Scan(&numOfRecords)
-		if err != nil {
-			return fmt.Errorf("unable to scan pk: %w", err)
-		}
-		return nil
-	})
-	a.NoError(err)
-	a.Equal(0, numOfRecords)
+	for _, table := range []string{"Keysets", "Rolling", "stateproofkeys", "VotingBatches", "VotingOffsets"} {
+		var numOfRecords int
+		err = registry.store.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+			row := tx.QueryRow(`select count(*) from ` + table)
+			err = row.Scan(&numOfRecords)
+			if err != nil {
+				return fmt.Errorf("unable to scan count: %w", err)
+			}
+			return nil
+		})
+		a.NoError(err)
+		a.Equal(0, numOfRecords, "table %s not cleaned up", table)
+	}
 }
 
 // Make sure the register function properly sets effective first/last for all effected records.

--- a/data/account/participation_test.go
+++ b/data/account/participation_test.go
@@ -203,55 +203,43 @@ func TestRetrieveFromDB(t *testing.T) {
 
 }
 
-func TestRetrieveFromDBAtVersion1(t *testing.T) {
+// TestRetrieveFromDBAtUnsupportedVersions verifies pre-state-proof schema
+// versions (1 and 2) are rejected rather than migrated: any key stored in
+// such a file expired years ago.
+func TestRetrieveFromDBAtUnsupportedVersions(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
 	a := require.New(t)
 	ppart := setupkeyWithNoDBS(t, a)
-	_, rootDB, partDB := createTestDBs(a, t.Name())
-	defer closeDBS(rootDB, partDB)
-
 	part := ppart.Participation
-	a.NoError(setupTestDBAtVer1(partDB, part))
 
-	retrivedPart, err := RestoreParticipation(partDB)
-	a.NoError(err)
-	assertionForRestoringFromDBAtLowVersion(a, retrivedPart)
-	assertStateProofTablesExists(a, partDB)
+	setups := map[string]func(db.Accessor, Participation) error{
+		"v1": setupTestDBAtVer1,
+		"v2": setupTestDBAtVer2,
+	}
+	for name, setup := range setups {
+		_, rootDB, partDB := createTestDBs(a, t.Name()+name)
 
-	retrivedPart, err = RestoreParticipationWithSecrets(partDB)
-	a.NoError(err)
-	assertionForRestoringFromDBAtLowVersion(a, retrivedPart)
-	assertStateProofTablesExists(a, partDB)
-}
+		a.NoError(setup(partDB, part))
 
-func TestRetrieveFromDBAtVersion2(t *testing.T) {
-	partitiontest.PartitionTest(t)
+		_, err := RestoreParticipation(partDB)
+		a.ErrorIs(err, ErrUnsupportedSchema, name)
+		_, err = RestoreParticipationWithSecrets(partDB)
+		a.ErrorIs(err, ErrUnsupportedSchema, name)
+		_, err = RestoreParticipationUnmigrated(partDB)
+		a.ErrorIs(err, ErrUnsupportedSchema, name)
 
-	a := require.New(t)
+		// the rejected file was not modified
+		versions, err := getSchemaVersions(partDB)
+		a.NoError(err)
+		expectedVersion := 1
+		if name == "v2" {
+			expectedVersion = 2
+		}
+		a.Equal(expectedVersion, versions[PartTableSchemaName], name)
 
-	ppart := setupkeyWithNoDBS(t, a)
-	_, rootDB, partDB := createTestDBs(a, t.Name())
-	defer closeDBS(rootDB, partDB)
-
-	part := ppart.Participation
-	a.NoError(setupTestDBAtVer2(partDB, part))
-
-	retrivedPart, err := RestoreParticipation(partDB)
-	a.NoError(err)
-	assertionForRestoringFromDBAtLowVersion(a, retrivedPart)
-	assertStateProofTablesExists(a, partDB)
-	versions, err := getSchemaVersions(partDB)
-	a.NoError(err)
-	a.Equal(versions[PartTableSchemaName], PartTableSchemaVersion)
-
-	retrivedPart, err = RestoreParticipationWithSecrets(partDB)
-	a.NoError(err)
-	assertionForRestoringFromDBAtLowVersion(a, retrivedPart)
-	assertStateProofTablesExists(a, partDB)
-	versions, err = getSchemaVersions(partDB)
-	a.NoError(err)
-	a.Equal(versions[PartTableSchemaName], PartTableSchemaVersion)
+		closeDBS(rootDB, partDB)
+	}
 }
 
 func TestKeyRegCreation(t *testing.T) {
@@ -272,49 +260,6 @@ func closeDBS(dbAccessor ...db.Accessor) {
 	for _, accessor := range dbAccessor {
 		accessor.Close()
 	}
-}
-
-func assertStateProofTablesExists(a *require.Assertions, store db.Accessor) {
-	err := store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.Exec("select count(*) From StateProofKeys;")
-		return err
-	})
-	a.NoError(err)
-
-}
-func assertionForRestoringFromDBAtLowVersion(a *require.Assertions, retrivedPart PersistedParticipation) {
-	a.NotNil(retrivedPart)
-	a.Nil(retrivedPart.StateProofSecrets)
-}
-
-func TestMigrateFromVersion1(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	a := require.New(t)
-	part := setupkeyWithNoDBS(t, a).Participation
-
-	_, rootDB, partDB := createTestDBs(a, t.Name())
-	defer closeDBS(rootDB, partDB)
-
-	a.NoError(setupTestDBAtVer1(partDB, part))
-	a.NoError(Migrate(partDB))
-
-	a.NoError(testDBContainsAllColumns(partDB))
-}
-
-func TestMigrationFromVersion2(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	a := require.New(t)
-	part := setupkeyWithNoDBS(t, a).Participation
-
-	_, rootDB, partDB := createTestDBs(a, t.Name())
-	defer closeDBS(rootDB, partDB)
-
-	a.NoError(setupTestDBAtVer2(partDB, part))
-	a.NoError(Migrate(partDB))
-
-	a.NoError(testDBContainsAllColumns(partDB))
 }
 
 func testDBContainsAllColumns(partDB db.Accessor) error {

--- a/data/account/registeryDbOps.go
+++ b/data/account/registeryDbOps.go
@@ -106,7 +106,7 @@ func (r *registerOp) apply(db *participationDB) error {
 	err := db.store.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
 		// Disable active key if there is one
 		for id, record := range r.updated {
-			err := updateRollingFields(ctx, tx, record.ParticipationRecord)
+			err := updateRegistrationFields(ctx, tx, record.ParticipationRecord)
 			// Repair the case when no keys were updated
 			if err == ErrNoKeyForID {
 				db.log.Warn("participationDB unable to update key in cache. Removing from cache.")

--- a/data/account/registeryDbOps.go
+++ b/data/account/registeryDbOps.go
@@ -24,6 +24,7 @@ import (
 	"maps"
 	"strings"
 
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/logging"
@@ -157,10 +158,11 @@ func fastForwardToStoredCursor(tx *sql.Tx, log logging.Logger, id ParticipationI
 			continue
 		}
 		var decoded crypto.OneTimeSignatureSecrets
-		// an undecodable stored state cannot be compared; consistent with
-		// the delta computation, it degrades to replacement
-		if protocol.Decode(rawVoting, &decoded) != nil {
-			continue
+		// Fail closed: an undecodable stored cursor cannot be compared, and
+		// replacing it from the inserted copy could resurrect retired keys.
+		if err := protocol.Decode(rawVoting, &decoded); err != nil {
+			return fmt.Errorf("stored voting scalars for key %s are undecodable; refusing to replace them from the inserted copy (delete %s and restart to rebuild the registry): %v",
+				id, config.ParticipationRegistryFilename, err)
 		}
 		if stored == nil || cursorAhead(&decoded.OneTimeSignatureSecretsPersistent, stored) {
 			s := decoded.OneTimeSignatureSecretsPersistent
@@ -170,9 +172,30 @@ func fastForwardToStoredCursor(tx *sql.Tx, log logging.Logger, id ParticipationI
 	if err := rows.Err(); err != nil {
 		return err
 	}
+	rows.Close()
+
+	if stored == nil {
+		return nil // known-new: nothing stored for this key
+	}
+	// Exhaustion written by older code left FirstOffset behind while every
+	// row was erased, so (FirstBatch, FirstOffset) alone cannot tell an
+	// exhausted key from a live, partially used final batch.  With no rows
+	// at all the stored key holds nothing, so treat its cursor as the end of
+	// the batch — erring towards fewer keys.
+	if stored.OffsetsExpanded() && dilution > 0 && stored.FirstOffset < dilution {
+		var storedRows int
+		err := tx.QueryRow(`SELECT (SELECT count(*) FROM VotingBatches WHERE pk IN (SELECT pk FROM Keysets WHERE participationID=?))
+			+ (SELECT count(*) FROM VotingOffsets WHERE pk IN (SELECT pk FROM Keysets WHERE participationID=?))`, id[:], id[:]).Scan(&storedRows)
+		if err != nil {
+			return fmt.Errorf("unable to count stored voting rows for %s: %w", id, err)
+		}
+		if storedRows == 0 {
+			stored.FirstOffset = dilution
+		}
+	}
 
 	current, _, _ := secrets.PersistentState()
-	if stored == nil || !cursorAhead(stored, &current) {
+	if !cursorAhead(stored, &current) {
 		return nil
 	}
 	// a cursor can only be ahead after a batch expansion, so FirstBatch >= 1
@@ -362,32 +385,55 @@ func (f *flushOp) apply(db *participationDB) error {
 		return nil
 	}
 
+	// Each record is written under its own savepoint so one record that
+	// cannot be persisted (e.g. undecodable stored scalars, which fail
+	// closed) does not roll back the others and stall on-disk key deletion
+	// for every key; only the failed records are retried at the next flush.
+	var failed []ParticipationID
+	var errorStr strings.Builder
 	err := db.store.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		var errorStr strings.Builder
+		failed = failed[:0]
+		errorStr.Reset()
 		for _, record := range needsUpdate {
+			if _, serr := tx.ExecContext(ctx, "SAVEPOINT flush_record"); serr != nil {
+				return serr
+			}
 			err := updateRollingFields(ctx, tx, record)
 			// This should only be updating key usage so ignoring missing keys is not a problem.
 			if err != nil && err != ErrNoKeyForID {
+				if _, rerr := tx.ExecContext(ctx, "ROLLBACK TO SAVEPOINT flush_record"); rerr != nil {
+					return rerr
+				}
+				failed = append(failed, record.ParticipationID)
 				if errorStr.Len() > 0 {
 					errorStr.WriteString(", ")
 				}
 				errorStr.WriteString(err.Error())
 			}
-		}
-		if errorStr.Len() > 0 {
-			return errors.New(errorStr.String())
+			if _, serr := tx.ExecContext(ctx, "RELEASE SAVEPOINT flush_record"); serr != nil {
+				return serr
+			}
 		}
 		return nil
 	})
 
 	if err != nil {
-		// put back what we didn't finish with
+		// the whole transaction failed: put back everything
 		db.mutex.Lock()
 		maps.Copy(db.dirty, dirty)
 		db.mutex.Unlock()
+		return err
 	}
-
-	return err
+	if len(failed) != 0 {
+		// the others committed; retry only the failed records
+		db.mutex.Lock()
+		for _, id := range failed {
+			db.dirty[id] = struct{}{}
+		}
+		db.mutex.Unlock()
+		return errors.New(errorStr.String())
+	}
+	return nil
 }
 
 func (a *appendKeysOp) apply(db *participationDB) error {

--- a/data/account/registeryDbOps.go
+++ b/data/account/registeryDbOps.go
@@ -24,6 +24,7 @@ import (
 	"maps"
 	"strings"
 
+	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/protocol"
 )
@@ -135,14 +136,16 @@ func (r *registerOp) apply(db *participationDB) error {
 func (i *insertOp) apply(db *participationDB) (err error) {
 	var rawVRF []byte
 	var rawVoting []byte
+	var votingBatches, votingOffsets []crypto.KeyedSubkey
 	var rawStateProofContext []byte
 
 	if i.record.VRF != nil {
 		rawVRF = protocol.Encode(i.record.VRF)
 	}
 	if i.record.Voting != nil {
-		voting := i.record.Voting.Snapshot()
-		rawVoting = protocol.Encode(&voting)
+		var scalars crypto.OneTimeSignatureSecretsPersistent
+		scalars, votingBatches, votingOffsets = i.record.Voting.PersistentParts()
+		rawVoting = protocol.Encode(&scalars)
 	}
 
 	// This contains all the state proof data except for the actual secret keys (stored in a different table)
@@ -170,7 +173,20 @@ func (i *insertOp) apply(db *participationDB) (err error) {
 
 		// Create Rolling entry
 		result, err2 = tx.Exec(insertRollingQuery, pk, rawVoting)
-		return verifyExecWithOneRowEffected(err2, result, "insert rolling")
+		if err2 = verifyExecWithOneRowEffected(err2, result, "insert rolling"); err2 != nil {
+			return err2
+		}
+
+		// Per-subkey voting rows (a mid-life key carries offsets too)
+		err2 = insertKeyedSubkeys(tx, "INSERT INTO VotingBatches (pk, batch, data) VALUES (?, ?, ?)", []interface{}{pk}, votingBatches)
+		if err2 != nil {
+			return fmt.Errorf("unable to insert voting batch subkeys: %w", err2)
+		}
+		err2 = insertKeyedSubkeys(tx, "INSERT INTO VotingOffsets (pk, off, data) VALUES (?, ?, ?)", []interface{}{pk}, votingOffsets)
+		if err2 != nil {
+			return fmt.Errorf("unable to insert voting offset subkeys: %w", err2)
+		}
+		return nil
 	})
 	return err
 }
@@ -201,6 +217,16 @@ func (d *deleteOp) apply(db *participationDB) error {
 		}
 
 		_, err = tx.Exec(deleteStateProofByPK, pk)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.Exec(deleteVotingBatchesPK, pk)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.Exec(deleteVotingOffsetsPK, pk)
 		if err != nil {
 			return err
 		}

--- a/data/account/registeryDbOps.go
+++ b/data/account/registeryDbOps.go
@@ -142,10 +142,15 @@ func (i *insertOp) apply(db *participationDB) (err error) {
 	if i.record.VRF != nil {
 		rawVRF = protocol.Encode(i.record.VRF)
 	}
+	var votingOffsetsBatch uint64
 	if i.record.Voting != nil {
 		var scalars crypto.OneTimeSignatureSecretsPersistent
 		scalars, votingBatches, votingOffsets = i.record.Voting.PersistentParts()
 		rawVoting = protocol.Encode(&scalars)
+		if len(votingOffsets) > 0 {
+			// offset subkeys belong to the batch preceding FirstBatch
+			votingOffsetsBatch = scalars.FirstBatch - 1
+		}
 	}
 
 	// This contains all the state proof data except for the actual secret keys (stored in a different table)
@@ -182,7 +187,7 @@ func (i *insertOp) apply(db *participationDB) (err error) {
 		if err2 != nil {
 			return fmt.Errorf("unable to insert voting batch subkeys: %w", err2)
 		}
-		err2 = insertKeyedSubkeys(tx, "INSERT INTO VotingOffsets (pk, off, data) VALUES (?, ?, ?)", []any{pk}, votingOffsets)
+		err2 = insertKeyedSubkeys(tx, "INSERT INTO VotingOffsets (pk, batch, off, data) VALUES (?, ?, ?, ?)", []any{pk, votingOffsetsBatch}, votingOffsets)
 		if err2 != nil {
 			return fmt.Errorf("unable to insert voting offset subkeys: %w", err2)
 		}

--- a/data/account/registeryDbOps.go
+++ b/data/account/registeryDbOps.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -133,32 +134,125 @@ func (r *registerOp) apply(db *participationDB) error {
 	return err
 }
 
+// fastForwardToStoredCursor advances secrets to the most advanced deletion
+// cursor already persisted for id, so an insert can never rewind the cursor
+// and resurrect retired keys on disk.  Fast-forwarding is exact because the
+// participation ID commits to the key material: a stored cursor ahead of the
+// inserted copy means those rounds were already voted and retired.
+func fastForwardToStoredCursor(tx *sql.Tx, log logging.Logger, id ParticipationID, secrets *crypto.OneTimeSignatureSecrets, dilution uint64) error {
+	rows, err := tx.Query(selectRollingVotingByID, id[:])
+	if err != nil {
+		return fmt.Errorf("unable to read stored voting scalars for %s: %w", id, err)
+	}
+	defer rows.Close()
+
+	var stored *crypto.OneTimeSignatureSecretsPersistent
+	for rows.Next() {
+		var pk int64
+		var rawVoting []byte
+		if err := rows.Scan(&pk, &rawVoting); err != nil {
+			return err
+		}
+		if len(rawVoting) == 0 {
+			continue
+		}
+		var decoded crypto.OneTimeSignatureSecrets
+		// an undecodable stored state cannot be compared; consistent with
+		// the delta computation, it degrades to replacement
+		if protocol.Decode(rawVoting, &decoded) != nil {
+			continue
+		}
+		if stored == nil || cursorAhead(&decoded.OneTimeSignatureSecretsPersistent, stored) {
+			s := decoded.OneTimeSignatureSecretsPersistent
+			stored = &s
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	current, _, _ := secrets.PersistentState()
+	if stored == nil || !cursorAhead(stored, &current) {
+		return nil
+	}
+	// a cursor can only be ahead after a batch expansion, so FirstBatch >= 1
+	if stored.FirstBatch == 0 {
+		return nil
+	}
+	if dilution == 0 {
+		return fmt.Errorf("stored voting state for %s (batch %d, offset %d) is ahead of the inserted copy (batch %d, offset %d) and its key dilution is unknown; refusing to rewind the deletion cursor",
+			id, stored.FirstBatch, stored.FirstOffset, current.FirstBatch, current.FirstOffset)
+	}
+	log.Warnf("participationDB: inserted copy of key %s lags the stored deletion cursor; fast-forwarding from (batch %d, offset %d) to (batch %d, offset %d)",
+		id, current.FirstBatch, current.FirstOffset, stored.FirstBatch, stored.FirstOffset)
+	secrets.DeleteBeforeFineGrained(crypto.OneTimeSignatureIdentifier{Batch: stored.FirstBatch - 1, Offset: stored.FirstOffset}, dilution)
+	return nil
+}
+
 func (i *insertOp) apply(db *participationDB) (err error) {
 	var rawVRF []byte
-	var rawVoting []byte
-	var votingBatches, votingOffsets []crypto.KeyedSubkey
 	var rawStateProofContext []byte
 
 	if i.record.VRF != nil {
 		rawVRF = protocol.Encode(i.record.VRF)
 	}
-	var votingOffsetsBatch uint64
-	if i.record.Voting != nil {
-		var scalars crypto.OneTimeSignatureSecretsPersistent
-		scalars, votingBatches, votingOffsets = i.record.Voting.PersistentParts()
-		rawVoting = protocol.Encode(&scalars)
-		if len(votingOffsets) > 0 {
-			// offset subkeys belong to the batch preceding FirstBatch
-			votingOffsetsBatch = scalars.FirstBatch - 1
-		}
-	}
-
 	// This contains all the state proof data except for the actual secret keys (stored in a different table)
 	if i.record.StateProofSecrets != nil {
 		rawStateProofContext = protocol.Encode(&i.record.StateProofSecrets.SignerContext)
 	}
 
 	err = db.store.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		// Replacing pre-existing rows must never rewind the persisted
+		// deletion cursor: the .partkey file and the registry are
+		// independent stores, so an inserted copy can lag what the registry
+		// already retired (e.g. a key file restored from a backup).  The
+		// participation ID commits to the key material, so the stored and
+		// inserted secrets are the same key — fast-forward the inserted copy
+		// to the most advanced stored cursor before persisting it.
+		if i.record.Voting != nil {
+			if err2 := fastForwardToStoredCursor(tx, db.log, i.id, i.record.Voting, i.record.KeyDilution); err2 != nil {
+				return err2
+			}
+		}
+
+		// capture the voting parts only after the potential fast-forward
+		var rawVoting []byte
+		var votingBatches, votingOffsets []crypto.KeyedSubkey
+		var votingOffsetsBatch uint64
+		if i.record.Voting != nil {
+			var scalars crypto.OneTimeSignatureSecretsPersistent
+			scalars, votingBatches, votingOffsets = i.record.Voting.PersistentParts()
+			rawVoting = protocol.Encode(&scalars)
+			if len(votingOffsets) > 0 {
+				// offset subkeys belong to the batch preceding FirstBatch
+				var err2 error
+				votingOffsetsBatch, err2 = offsetsOwningBatch(scalars.FirstBatch)
+				if err2 != nil {
+					return err2
+				}
+			}
+		}
+
+		// Clear any pre-existing rows for this participation ID.  A corrupt
+		// record excluded from the cache at load leaves its rows behind, and
+		// the caller (e.g. loadParticipationKeys in the same startup) then
+		// legitimately re-inserts the key: dedup happens against the cache
+		// only, and a duplicate Keysets row would make every subsequent
+		// flush fail with ErrMultipleKeysForID.
+		var cleared int64
+		for _, query := range []string{clearRollingByID, clearStateProofByID, clearVotingBatchesByID, clearVotingOffsetsByID, clearKeysetsByID} {
+			result, err2 := tx.Exec(query, i.id[:])
+			if err2 != nil {
+				return fmt.Errorf("unable to clear pre-existing rows for %s: %w", i.id, err2)
+			}
+			if n, err2 := result.RowsAffected(); err2 == nil {
+				cleared += n
+			}
+		}
+		if cleared > 0 {
+			db.log.Warnf("participationDB: insert of key %s replaced %d pre-existing rows", i.id, cleared)
+		}
+
 		result, err2 := tx.Exec(
 			insertKeysetQuery,
 			i.id[:],

--- a/data/account/registeryDbOps.go
+++ b/data/account/registeryDbOps.go
@@ -178,11 +178,11 @@ func (i *insertOp) apply(db *participationDB) (err error) {
 		}
 
 		// Per-subkey voting rows (a mid-life key carries offsets too)
-		err2 = insertKeyedSubkeys(tx, "INSERT INTO VotingBatches (pk, batch, data) VALUES (?, ?, ?)", []interface{}{pk}, votingBatches)
+		err2 = insertKeyedSubkeys(tx, "INSERT INTO VotingBatches (pk, batch, data) VALUES (?, ?, ?)", []any{pk}, votingBatches)
 		if err2 != nil {
 			return fmt.Errorf("unable to insert voting batch subkeys: %w", err2)
 		}
-		err2 = insertKeyedSubkeys(tx, "INSERT INTO VotingOffsets (pk, off, data) VALUES (?, ?, ?)", []interface{}{pk}, votingOffsets)
+		err2 = insertKeyedSubkeys(tx, "INSERT INTO VotingOffsets (pk, off, data) VALUES (?, ?, ?)", []any{pk}, votingOffsets)
 		if err2 != nil {
 			return fmt.Errorf("unable to insert voting offset subkeys: %w", err2)
 		}

--- a/data/account/registryVotingRows_test.go
+++ b/data/account/registryVotingRows_test.go
@@ -241,6 +241,89 @@ func TestRegistryExcludesCorruptRecord(t *testing.T) {
 	a.NoError(registry.initializeCache())
 	a.True(registry.Get(corruptID).IsZero(), "corrupt record not excluded")
 	a.False(registry.Get(healthyID).IsZero(), "healthy record lost")
+
+	// re-inserting the excluded key (as loadParticipationKeys does from the
+	// .partkey file in the same startup) must replace the orphaned rows, not
+	// create a duplicate Keysets row that would fail every flush with
+	// ErrMultipleKeysForID
+	reinsertedID, err := registry.Insert(pCorrupt)
+	a.NoError(err)
+	a.Equal(corruptID, reinsertedID)
+	a.NoError(registry.Flush(defaultTimeout))
+
+	var keysetRows int
+	err = registry.store.Rdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRow("SELECT count(*) FROM Keysets WHERE participationID=?", corruptID[:]).Scan(&keysetRows)
+	})
+	a.NoError(err)
+	a.Equal(1, keysetRows, "duplicate Keysets row after re-insert")
+
+	// the next round's deletion flush works for every key
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	a.NoError(registry.DeleteExpired(1, proto))
+	a.NoError(registry.Flush(defaultTimeout))
+
+	a.NoError(registry.initializeCache())
+	a.False(registry.Get(corruptID).IsZero(), "re-inserted record not restored")
+	a.False(registry.Get(healthyID).IsZero(), "healthy record lost after re-insert")
+}
+
+// TestInsertNeverRewindsCursor verifies re-inserting a lagging copy of a key
+// (the .partkey file and the registry are independent stores) cannot rewind
+// the persisted deletion cursor and resurrect retired rounds: the inserted
+// copy is fast-forwarded to the stored cursor instead.
+func TestInsertNeverRewindsCursor(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	registry, dbfile := getRegistry(t)
+	defer registryCloseTest(t, registry, dbfile)
+
+	const dilution = 10
+	p := makeTestParticipation(a, 1, 1, 3000, dilution)
+	// an independent copy of the same key, which will lag behind
+	behind := p
+	behindVoting := p.Voting.Snapshot()
+	behind.Voting = &behindVoting
+
+	id, err := registry.Insert(p)
+	a.NoError(err)
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+
+	// vote through round 999: the stored cursor advances to batch 101
+	a.NoError(registry.DeleteExpired(999, proto))
+	a.NoError(registry.Flush(defaultTimeout))
+
+	// evict the key from the cache the way the corrupt-record exclusion does
+	registry.mutex.Lock()
+	delete(registry.cache, id)
+	delete(registry.dirty, id)
+	registry.mutex.Unlock()
+
+	// the lagging copy only reached round 500; re-insert it
+	behind.Voting.DeleteBeforeFineGrained(basics.OneTimeIDForRound(500, dilution), dilution)
+	reinsertedID, err := registry.Insert(behind)
+	a.NoError(err)
+	a.Equal(id, reinsertedID)
+	a.NoError(registry.Flush(defaultTimeout))
+
+	// the persisted cursor did not rewind
+	var storedScalars crypto.OneTimeSignatureSecrets
+	a.NoError(protocol.Decode(registryReadVotingBlob(a, registry, id), &storedScalars))
+	a.GreaterOrEqual(storedScalars.FirstBatch, uint64(101), "persisted deletion cursor rewound")
+
+	// after a reload, retired rounds cannot produce valid signatures while
+	// live rounds still can
+	a.NoError(registry.initializeCache())
+	record := registry.Get(id)
+	a.False(record.IsZero())
+	msg := crypto.OneTimeSignatureSubkeyBatchID{Batch: 1}
+	retired := basics.OneTimeIDForRound(500, dilution)
+	sig := record.Voting.Sign(retired, msg)
+	a.False(p.Voting.OneTimeSignatureVerifier.Verify(retired, msg, sig), "retired round signed after re-inserting a lagging copy")
+	live := basics.OneTimeIDForRound(1500, dilution)
+	sig = record.Voting.Sign(live, msg)
+	a.True(p.Voting.OneTimeSignatureVerifier.Verify(live, msg, sig), "live round unusable after fast-forward")
 }
 
 // TestFlushSelfHealsInconsistentRows verifies one key with rows inconsistent

--- a/data/account/registryVotingRows_test.go
+++ b/data/account/registryVotingRows_test.go
@@ -1,0 +1,228 @@
+// Copyright (C) 2019-2026 Algorand Foundation Ltd.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package account
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/algorand/go-algorand/util/db"
+)
+
+func registryCountRows(a *require.Assertions, registry *participationDB, table string) (n int) {
+	err := registry.store.Rdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRow("SELECT count(*) FROM " + table).Scan(&n)
+	})
+	a.NoError(err)
+	return n
+}
+
+func registryReadVotingBlob(a *require.Assertions, registry *participationDB, id ParticipationID) (raw []byte) {
+	err := registry.store.Rdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRow(selectRollingVotingByID, id[:]).Scan(new(int64), &raw)
+	})
+	a.NoError(err)
+	return raw
+}
+
+// TestRegistryMigrationV1ToV2 hand-builds a version-1 registry (whole voting
+// blob in Rolling.voting) and verifies opening it converts to per-subkey rows
+// with identical restored secrets.
+func TestRegistryMigrationV1ToV2(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	// mid-life key so both batch and offset rows exist
+	p := makeTestParticipation(a, 1, 1, 200, 10)
+	p.Voting.DeleteBeforeFineGrained(basics.OneTimeIDForRound(55, 10), 10)
+	a.NotEmpty(p.Voting.Offsets)
+	votingBlob := protocol.Encode(p.Voting)
+
+	rootDB, err := db.OpenPair(t.Name(), true)
+	a.NoError(err)
+
+	// build the version-1 schema by hand and insert a record with the legacy blob
+	err = rootDB.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		if err := dbSchemaUpgrade0(ctx, tx, true); err != nil {
+			return err
+		}
+		if _, err := db.SetUserVersion(ctx, tx, 1); err != nil {
+			return err
+		}
+		id := p.ID()
+		result, err := tx.Exec(insertKeysetQuery, id[:], p.Parent[:], p.FirstValid, p.LastValid, p.KeyDilution,
+			protocol.Encode(p.VRF), protocol.Encode(&p.StateProofSecrets.SignerContext))
+		if err != nil {
+			return err
+		}
+		pk, err := result.LastInsertId()
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(insertRollingQuery, pk, votingBlob)
+		return err
+	})
+	a.NoError(err)
+
+	// opening the registry runs dbSchemaUpgrade1
+	registry, err := makeParticipationRegistry(rootDB, logging.TestingLog(t))
+	a.NoError(err)
+	defer registryCloseTest(t, registry, "")
+
+	err = rootDB.Rdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		version, err := db.GetUserVersion(ctx, tx)
+		a.Equal(int32(2), version)
+		return err
+	})
+	a.NoError(err)
+
+	a.Equal(len(p.Voting.Batches), registryCountRows(a, registry, "VotingBatches"))
+	a.Equal(len(p.Voting.Offsets), registryCountRows(a, registry, "VotingOffsets"))
+
+	// blob now holds scalars only
+	var scalars crypto.OneTimeSignatureSecrets
+	a.NoError(protocol.Decode(registryReadVotingBlob(a, registry, p.ID()), &scalars))
+	a.Empty(scalars.Batches)
+	a.Empty(scalars.Offsets)
+
+	// cache built from the converted store equals the original secrets
+	record := registry.Get(p.ID())
+	a.False(record.IsZero())
+	a.Equal(encodedVotingSnapshot(p.Voting), encodedVotingSnapshot(record.Voting))
+}
+
+// TestRegistryMigrationFreshDB verifies the newDatabase path skips conversion
+// but still creates the tables.
+func TestRegistryMigrationFreshDB(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	registry, dbfile := getRegistry(t)
+	defer registryCloseTest(t, registry, dbfile)
+
+	a.Zero(registryCountRows(a, registry, "VotingBatches"))
+	a.Zero(registryCountRows(a, registry, "VotingOffsets"))
+
+	err := registry.store.Rdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		version, err := db.GetUserVersion(ctx, tx)
+		a.Equal(int32(2), version)
+		return err
+	})
+	a.NoError(err)
+}
+
+// TestRegistryInsertMidLifeKey verifies inserting a key that already has
+// expanded offsets stores and restores them.
+func TestRegistryInsertMidLifeKey(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	registry, dbfile := getRegistry(t)
+	defer registryCloseTest(t, registry, dbfile)
+
+	p := makeTestParticipation(a, 1, 1, 200, 10)
+	p.Voting.DeleteBeforeFineGrained(basics.OneTimeIDForRound(37, 10), 10)
+	a.NotEmpty(p.Voting.Offsets)
+
+	id, err := registry.Insert(p)
+	a.NoError(err)
+	a.NoError(registry.Flush(defaultTimeout))
+
+	a.Equal(len(p.Voting.Batches), registryCountRows(a, registry, "VotingBatches"))
+	a.Equal(len(p.Voting.Offsets), registryCountRows(a, registry, "VotingOffsets"))
+
+	// reload from disk and compare
+	a.NoError(registry.initializeCache())
+	record := registry.Get(id)
+	a.False(record.IsZero())
+	a.Equal(encodedVotingSnapshot(p.Voting), encodedVotingSnapshot(record.Voting))
+}
+
+// TestRegistryDeleteExpiredPersistsReassembly walks rounds through
+// DeleteExpired+Flush and verifies the store reassembles to exactly the
+// cached secrets each round, including across batch rollovers.
+func TestRegistryDeleteExpiredPersistsReassembly(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	registry, dbfile := getRegistry(t)
+	defer registryCloseTest(t, registry, dbfile)
+
+	p := makeTestParticipation(a, 1, 1, 200, 10)
+	id, err := registry.Insert(p)
+	a.NoError(err)
+	a.NoError(registry.Register(id, 1))
+	a.NoError(registry.Flush(defaultTimeout))
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	for round := basics.Round(2); round <= 60; round += 7 {
+		a.NoError(registry.DeleteExpired(round, proto))
+		a.NoError(registry.Flush(defaultTimeout))
+
+		cached := registry.Get(id)
+		a.False(cached.IsZero())
+
+		a.NoError(registry.initializeCache())
+		reloaded := registry.Get(id)
+		a.False(reloaded.IsZero())
+		a.Equal(encodedVotingSnapshot(cached.Voting), encodedVotingSnapshot(reloaded.Voting), "round %d", round)
+	}
+}
+
+// TestFlushWritesDeltaOnly verifies a flush with no voting-key progress
+// leaves the voting blob and subkey rows untouched.
+func TestFlushWritesDeltaOnly(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	registry, dbfile := getRegistry(t)
+	defer registryCloseTest(t, registry, dbfile)
+
+	p := makeTestParticipation(a, 1, 1, 200, 10)
+	id, err := registry.Insert(p)
+	a.NoError(err)
+	a.NoError(registry.Register(id, 1))
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	a.NoError(registry.DeleteExpired(10, proto))
+	a.NoError(registry.Flush(defaultTimeout))
+
+	blobBefore := registryReadVotingBlob(a, registry, id)
+	batchesBefore := registryCountRows(a, registry, "VotingBatches")
+	offsetsBefore := registryCountRows(a, registry, "VotingOffsets")
+
+	// dirty the record without advancing the voting keys
+	a.NoError(registry.Record(p.Parent, 10, Vote))
+	a.NoError(registry.Flush(defaultTimeout))
+
+	a.Equal(blobBefore, registryReadVotingBlob(a, registry, id))
+	a.Equal(batchesBefore, registryCountRows(a, registry, "VotingBatches"))
+	a.Equal(offsetsBefore, registryCountRows(a, registry, "VotingOffsets"))
+
+	// and the rolling fields did land
+	record := registry.Get(id)
+	a.Equal(basics.Round(10), record.LastVote)
+}

--- a/data/account/registryVotingRows_test.go
+++ b/data/account/registryVotingRows_test.go
@@ -399,3 +399,65 @@ func TestFlushWritesDeltaOnly(t *testing.T) {
 	record := registry.Get(id)
 	a.Equal(basics.Round(10), record.LastVote)
 }
+
+// TestRegisterStaleSnapshotDoesNotTouchVoting reproduces a registration
+// whose record snapshot predates a flush that already advanced the persisted
+// deletion cursor (a flush lagging a full round).  Registration must persist
+// only the registration window and leave the newer cursor alone, instead of
+// failing with the monotonicity error.
+func TestRegisterStaleSnapshotDoesNotTouchVoting(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	registry, dbfile := getRegistry(t)
+	defer registryCloseTest(t, registry, dbfile)
+
+	const dilution = 10
+	p := makeTestParticipation(a, 1, 1, 200, dilution)
+	id, err := registry.Insert(p)
+	a.NoError(err)
+	a.NoError(registry.Flush(defaultTimeout))
+
+	// snapshot the record as Register would, before the cursor advances
+	stale := registry.Get(id)
+	stale.EffectiveFirst = 1
+	stale.EffectiveLast = stale.LastValid
+	staleOp := &registerOp{updated: map[ParticipationID]updatingParticipationRecord{
+		id: {ParticipationRecord: stale, required: true},
+	}}
+
+	// a full round of deletion is flushed first
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	a.NoError(registry.DeleteExpired(50, proto))
+	a.NoError(registry.Flush(defaultTimeout))
+	advanced := registry.Get(id)
+	a.NotZero(advanced.Voting.FirstBatch)
+
+	// the lagging registration lands afterwards and must succeed
+	registry.writeQueue <- makeOpRequest(staleOp)
+	a.NoError(registry.Flush(defaultTimeout))
+
+	// the persisted cursor is the advanced one and the registration is stored
+	var storedScalars crypto.OneTimeSignatureSecrets
+	a.NoError(protocol.Decode(registryReadVotingBlob(a, registry, id), &storedScalars))
+	a.Equal(advanced.Voting.FirstBatch, storedScalars.FirstBatch)
+	a.Equal(advanced.Voting.FirstOffset, storedScalars.FirstOffset)
+	a.NoError(registry.initializeCache())
+	reloaded := registry.Get(id)
+	a.Equal(basics.Round(1), reloaded.EffectiveFirst)
+	a.Equal(p.LastValid, reloaded.EffectiveLast)
+	a.Equal(encodedVotingSnapshot(advanced.Voting), encodedVotingSnapshot(reloaded.Voting))
+
+	// the public Register path leaves pending changes dirty for the flush
+	a.NoError(registry.DeleteExpired(60, proto))
+	registry.mutex.RLock()
+	_, dirtyBefore := registry.dirty[id]
+	registry.mutex.RUnlock()
+	a.True(dirtyBefore)
+	a.NoError(registry.Register(id, 61))
+	registry.mutex.RLock()
+	_, dirtyAfter := registry.dirty[id]
+	registry.mutex.RUnlock()
+	a.True(dirtyAfter, "Register must not clear a pending flush")
+	a.NoError(registry.Flush(defaultTimeout))
+}

--- a/data/account/registryVotingRows_test.go
+++ b/data/account/registryVotingRows_test.go
@@ -192,6 +192,46 @@ func TestRegistryDeleteExpiredPersistsReassembly(t *testing.T) {
 	}
 }
 
+// TestRegistryEndOfLifeClearsRows verifies the registry erases every voting
+// subkey row when a key on its final batch moves past its end while still
+// within its validity window (the transition where the scalars don't move).
+func TestRegistryEndOfLifeClearsRows(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	registry, dbfile := getRegistry(t)
+	defer registryCloseTest(t, registry, dbfile)
+
+	// LastValid 309 with dilution 10 puts the end of validity at the very end
+	// of the final batch (30), so the end-of-life transition happens while the
+	// record is still in the registry.
+	p := makeTestParticipation(a, 1, 1, 309, 10)
+	id, err := registry.Insert(p)
+	a.NoError(err)
+	a.NoError(registry.Register(id, 1))
+	a.NoError(registry.Flush(defaultTimeout))
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+
+	// expand the final batch
+	a.NoError(registry.DeleteExpired(300, proto))
+	a.NoError(registry.Flush(defaultTimeout))
+	a.NotZero(registryCountRows(a, registry, "VotingOffsets"))
+
+	// move past the end of the key: offsets are cleared without scalar movement
+	a.NoError(registry.DeleteExpired(309, proto))
+	a.NoError(registry.Flush(defaultTimeout))
+	a.Zero(registryCountRows(a, registry, "VotingOffsets"), "retired offset subkeys survived in the registry")
+	a.Zero(registryCountRows(a, registry, "VotingBatches"))
+
+	// a cache rebuild must not resurrect any subkeys
+	a.NoError(registry.initializeCache())
+	record := registry.Get(id)
+	a.False(record.IsZero())
+	a.Empty(record.Voting.Offsets)
+	a.Empty(record.Voting.Batches)
+}
+
 // TestFlushWritesDeltaOnly verifies a flush with no voting-key progress
 // leaves the voting blob and subkey rows untouched.
 func TestFlushWritesDeltaOnly(t *testing.T) {

--- a/data/account/registryVotingRows_test.go
+++ b/data/account/registryVotingRows_test.go
@@ -114,26 +114,6 @@ func TestRegistryMigrationV1ToV2(t *testing.T) {
 	a.Equal(encodedVotingSnapshot(p.Voting), encodedVotingSnapshot(record.Voting))
 }
 
-// TestRegistryMigrationFreshDB verifies the newDatabase path skips conversion
-// but still creates the tables.
-func TestRegistryMigrationFreshDB(t *testing.T) {
-	partitiontest.PartitionTest(t)
-	a := require.New(t)
-
-	registry, dbfile := getRegistry(t)
-	defer registryCloseTest(t, registry, dbfile)
-
-	a.Zero(registryCountRows(a, registry, "VotingBatches"))
-	a.Zero(registryCountRows(a, registry, "VotingOffsets"))
-
-	err := registry.store.Rdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		version, err := db.GetUserVersion(ctx, tx)
-		a.Equal(int32(2), version)
-		return err
-	})
-	a.NoError(err)
-}
-
 // TestRegistryInsertMidLifeKey verifies inserting a key that already has
 // expanded offsets stores and restores them.
 func TestRegistryInsertMidLifeKey(t *testing.T) {

--- a/data/account/registryVotingRows_test.go
+++ b/data/account/registryVotingRows_test.go
@@ -232,6 +232,31 @@ func TestRegistryEndOfLifeClearsRows(t *testing.T) {
 	a.Empty(record.Voting.Batches)
 }
 
+// TestRegistryDetectsMissingRows verifies a registry whose subkey rows were
+// lost fails the cache load as corruption instead of silently producing a
+// key that cannot vote.
+func TestRegistryDetectsMissingRows(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	registry, dbfile := getRegistry(t)
+	defer registryCloseTest(t, registry, dbfile)
+
+	p := makeTestParticipation(a, 1, 1, 200, 10)
+	_, err := registry.Insert(p)
+	a.NoError(err)
+	a.NoError(registry.Flush(defaultTimeout))
+	a.NoError(registry.initializeCache())
+
+	err = registry.store.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.Exec("DELETE FROM VotingBatches WHERE batch=(SELECT MAX(batch) FROM VotingBatches)")
+		return err
+	})
+	a.NoError(err)
+
+	a.ErrorContains(registry.initializeCache(), "missing or extra rows")
+}
+
 // TestFlushWritesDeltaOnly verifies a flush with no voting-key progress
 // leaves the voting blob and subkey rows untouched.
 func TestFlushWritesDeltaOnly(t *testing.T) {

--- a/data/account/registryVotingRows_test.go
+++ b/data/account/registryVotingRows_test.go
@@ -461,3 +461,132 @@ func TestRegisterStaleSnapshotDoesNotTouchVoting(t *testing.T) {
 	a.True(dirtyAfter, "Register must not clear a pending flush")
 	a.NoError(registry.Flush(defaultTimeout))
 }
+
+// TestFlushIsolatesCorruptScalars verifies a key whose stored cursor is
+// undecodable fails closed (nothing rewritten from memory) without taking the
+// other keys' flush down with it.
+func TestFlushIsolatesCorruptScalars(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	registry, dbfile := getRegistry(t)
+	defer registryCloseTest(t, registry, dbfile)
+
+	pA := makeTestParticipation(a, 1, 1, 200, 10)
+	idA, err := registry.Insert(pA)
+	a.NoError(err)
+	pB := makeTestParticipation(a, 2, 1, 200, 10)
+	idB, err := registry.Insert(pB)
+	a.NoError(err)
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	a.NoError(registry.DeleteExpired(20, proto))
+	a.NoError(registry.Flush(defaultTimeout))
+
+	// corrupt B's stored cursor
+	err = registry.store.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.Exec("UPDATE Rolling SET voting=? WHERE pk=(SELECT pk FROM Keysets WHERE participationID=?)", []byte{0xff, 0x00}, idB[:])
+		return err
+	})
+	a.NoError(err)
+	bOffsetRows := func() (n int) {
+		err := registry.store.Rdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+			return tx.QueryRow("SELECT count(*) FROM VotingOffsets WHERE pk=(SELECT pk FROM Keysets WHERE participationID=?)", idB[:]).Scan(&n)
+		})
+		a.NoError(err)
+		return n
+	}
+	bRowsBefore := bOffsetRows()
+
+	// the next round's flush reports B's failure but still persists A
+	a.NoError(registry.DeleteExpired(25, proto))
+	err = registry.Flush(defaultTimeout)
+	a.ErrorContains(err, "undecodable")
+	a.Equal(bRowsBefore, bOffsetRows(), "B's rows were rewritten despite an undecodable cursor")
+
+	var storedA crypto.OneTimeSignatureSecrets
+	a.NoError(protocol.Decode(registryReadVotingBlob(a, registry, idA), &storedA))
+	cachedA := registry.Get(idA)
+	a.Equal(cachedA.Voting.FirstOffset, storedA.FirstOffset, "A's deletion was not persisted")
+
+	// only B stays dirty for retry
+	registry.mutex.RLock()
+	_, aDirty := registry.dirty[idA]
+	_, bDirty := registry.dirty[idB]
+	registry.mutex.RUnlock()
+	a.False(aDirty)
+	a.True(bDirty)
+}
+
+// TestInsertPreservesExhaustedState verifies re-inserting a lagging copy of
+// an exhausted key cannot regenerate offset subkeys the store already
+// retired — for exhaustion recorded with the cursor at the batch end, and
+// for the older encoding where erasing the rows left the cursor in place.
+func TestInsertPreservesExhaustedState(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	registry, dbfile := getRegistry(t)
+	defer registryCloseTest(t, registry, dbfile)
+
+	const dilution = 10
+	// LastValid 209 keeps the record registered through the end of its final
+	// batch (20), so exhaustion happens while it is still in the registry
+	p := makeTestParticipation(a, 1, 1, 209, dilution)
+	laggingCopy := func() Participation {
+		behind := p
+		snap := p.Voting.Snapshot()
+		behind.Voting = &snap
+		behind.Voting.DeleteBeforeFineGrained(basics.OneTimeIDForRound(100, dilution), dilution)
+		return behind
+	}
+	msg := crypto.OneTimeSignatureSubkeyBatchID{Batch: 1}
+	retired := basics.OneTimeIDForRound(205, dilution) // offset 5 of the final batch
+	assertExhausted := func(id ParticipationID, what string) {
+		a.Zero(registryCountRows(a, registry, "VotingOffsets"), "%s: retired offsets regenerated", what)
+		a.Zero(registryCountRows(a, registry, "VotingBatches"), what)
+		a.NoError(registry.initializeCache())
+		record := registry.Get(id)
+		a.False(record.IsZero(), what)
+		sig := record.Voting.Sign(retired, msg)
+		a.False(p.Voting.OneTimeSignatureVerifier.Verify(retired, msg, sig), "%s: retired identifier signed", what)
+	}
+	evict := func(id ParticipationID) {
+		registry.mutex.Lock()
+		delete(registry.cache, id)
+		delete(registry.dirty, id)
+		registry.mutex.Unlock()
+	}
+
+	id, err := registry.Insert(p)
+	a.NoError(err)
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	a.NoError(registry.DeleteExpired(200, proto)) // final batch expanded
+	a.NoError(registry.DeleteExpired(209, proto)) // and exhausted
+	a.NoError(registry.Flush(defaultTimeout))
+	var stored crypto.OneTimeSignatureSecrets
+	a.NoError(protocol.Decode(registryReadVotingBlob(a, registry, id), &stored))
+	a.Equal(uint64(dilution), stored.FirstOffset, "exhaustion did not advance the cursor to the batch end")
+	a.Zero(registryCountRows(a, registry, "VotingOffsets"))
+
+	// (1) exhaustion recorded with the cursor at the batch end
+	evict(id)
+	_, err = registry.Insert(laggingCopy())
+	a.NoError(err)
+	a.NoError(registry.Flush(defaultTimeout))
+	assertExhausted(id, "cursor at batch end")
+
+	// (2) older encoding: rows erased but the cursor left mid-batch
+	legacyScalars := stored.OneTimeSignatureSecretsPersistent
+	legacyScalars.FirstOffset = 2
+	err = registry.store.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.Exec("UPDATE Rolling SET voting=? WHERE pk=(SELECT pk FROM Keysets WHERE participationID=?)", protocol.Encode(&legacyScalars), id[:])
+		return err
+	})
+	a.NoError(err)
+	evict(id)
+	_, err = registry.Insert(laggingCopy())
+	a.NoError(err)
+	a.NoError(registry.Flush(defaultTimeout))
+	assertExhausted(id, "legacy cursor")
+}

--- a/data/account/registryVotingRows_test.go
+++ b/data/account/registryVotingRows_test.go
@@ -212,29 +212,74 @@ func TestRegistryEndOfLifeClearsRows(t *testing.T) {
 	a.Empty(record.Voting.Batches)
 }
 
-// TestRegistryDetectsMissingRows verifies a registry whose subkey rows were
-// lost fails the cache load as corruption instead of silently producing a
-// key that cannot vote.
-func TestRegistryDetectsMissingRows(t *testing.T) {
+// TestRegistryExcludesCorruptRecord verifies a record whose subkey rows were
+// lost is excluded from the cache with a warning instead of blocking the
+// whole registry (and the node) from loading, while healthy records survive.
+func TestRegistryExcludesCorruptRecord(t *testing.T) {
 	partitiontest.PartitionTest(t)
 	a := require.New(t)
 
 	registry, dbfile := getRegistry(t)
 	defer registryCloseTest(t, registry, dbfile)
 
-	p := makeTestParticipation(a, 1, 1, 200, 10)
-	_, err := registry.Insert(p)
+	pHealthy := makeTestParticipation(a, 1, 1, 200, 10)
+	healthyID, err := registry.Insert(pHealthy)
+	a.NoError(err)
+	pCorrupt := makeTestParticipation(a, 2, 1, 200, 10)
+	corruptID, err := registry.Insert(pCorrupt)
 	a.NoError(err)
 	a.NoError(registry.Flush(defaultTimeout))
 	a.NoError(registry.initializeCache())
 
+	// damage the second key's rows
 	err = registry.store.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.Exec("DELETE FROM VotingBatches WHERE batch=(SELECT MAX(batch) FROM VotingBatches)")
+		_, err := tx.Exec("DELETE FROM VotingBatches WHERE batch=(SELECT MAX(batch) FROM VotingBatches) AND pk=(SELECT pk FROM Keysets WHERE participationID=?)", corruptID[:])
 		return err
 	})
 	a.NoError(err)
 
-	a.ErrorContains(registry.initializeCache(), "missing or extra rows")
+	a.NoError(registry.initializeCache())
+	a.True(registry.Get(corruptID).IsZero(), "corrupt record not excluded")
+	a.False(registry.Get(healthyID).IsZero(), "healthy record lost")
+}
+
+// TestFlushSelfHealsInconsistentRows verifies one key with rows inconsistent
+// with its scalars does not block the flush for every key: the applier
+// rebuilds the damaged key's rows from memory and the flush succeeds.
+func TestFlushSelfHealsInconsistentRows(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	a := require.New(t)
+
+	registry, dbfile := getRegistry(t)
+	defer registryCloseTest(t, registry, dbfile)
+
+	pA := makeTestParticipation(a, 1, 1, 200, 10)
+	idA, err := registry.Insert(pA)
+	a.NoError(err)
+	pB := makeTestParticipation(a, 2, 1, 200, 10)
+	idB, err := registry.Insert(pB)
+	a.NoError(err)
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	a.NoError(registry.DeleteExpired(20, proto))
+	a.NoError(registry.Flush(defaultTimeout))
+
+	// lose one of B's offset rows behind the registry's back
+	err = registry.store.Wdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.Exec("DELETE FROM VotingOffsets WHERE off=(SELECT MIN(off) FROM VotingOffsets) AND pk=(SELECT pk FROM Keysets WHERE participationID=?)", idB[:])
+		return err
+	})
+	a.NoError(err)
+
+	// the next flush trims offsets, detects the inconsistency, and rebuilds
+	a.NoError(registry.DeleteExpired(23, proto))
+	a.NoError(registry.Flush(defaultTimeout))
+
+	// both keys reload consistent with the cache
+	cachedA, cachedB := registry.Get(idA), registry.Get(idB)
+	a.NoError(registry.initializeCache())
+	a.Equal(encodedVotingSnapshot(cachedA.Voting), encodedVotingSnapshot(registry.Get(idA).Voting))
+	a.Equal(encodedVotingSnapshot(cachedB.Voting), encodedVotingSnapshot(registry.Get(idB).Voting))
 }
 
 // TestFlushWritesDeltaOnly verifies a flush with no voting-key progress

--- a/data/account/votingRows.go
+++ b/data/account/votingRows.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -34,7 +35,7 @@ type votingDelta struct {
 	// noop means the persisted state already matches; skip all writes.
 	noop bool
 
-	// fullRewrite means the persisted state is unusable (ahead of memory,
+	// fullRewrite means the persisted state cannot be diffed (missing,
 	// undecodable, or a legacy whole-blob): delete every row and re-insert
 	// insertBatches+insertOffsets.
 	fullRewrite bool
@@ -49,9 +50,18 @@ type votingDelta struct {
 	// (rollover path; 0 means no batch deletion).
 	deleteBatchesBelow uint64
 
+	// expectedBatchDeletes is the exact number of rows deleteBatchesBelow
+	// must remove; a mismatch means the stored rows are inconsistent with
+	// the stored scalars.  -1 skips the check.
+	expectedBatchDeletes int64
+
 	// deleteOffsetsBelow deletes offset rows with index < this value
 	// (same-batch path; 0 means no offset range-deletion).
 	deleteOffsetsBelow uint64
+
+	// expectedOffsetDeletes is the exact number of rows deleteOffsetsBelow
+	// must remove.  -1 skips the check.
+	expectedOffsetDeletes int64
 
 	// replaceAllOffsets clears the offsets table before inserting
 	// insertOffsets.  Offsets restart at 0 in every batch, so a rollover must
@@ -61,6 +71,11 @@ type votingDelta struct {
 	insertBatches []crypto.KeyedSubkey
 	insertOffsets []crypto.KeyedSubkey
 
+	// offsetsBatch is the batch the insertOffsets subkeys belong to
+	// (FirstBatch-1 of the scalars they were captured with); meaningful only
+	// when insertOffsets is non-empty.
+	offsetsBatch uint64
+
 	// newScalars is the encoded scalar state to store; nil when the stored
 	// scalars need no update (noop and clearAllRows).
 	newScalars []byte
@@ -68,25 +83,48 @@ type votingDelta struct {
 
 // computeVotingDelta compares the last-persisted scalars against the current
 // in-memory secrets and returns the row operations to persist the difference.
-// old == nil requests an unconditional full rewrite (undecodable or missing
-// persisted state).
-func computeVotingDelta(old *crypto.OneTimeSignatureSecretsPersistent, secrets *crypto.OneTimeSignatureSecrets) votingDelta {
+// old == nil requests an unconditional full rewrite (missing persisted
+// state, e.g. during format migration).
+//
+// Forward security requires the persisted deletion cursor to be monotonic:
+// if storage is ahead of memory, rewriting from memory would resurrect keys
+// that were already deleted on disk, so that state is an error rather than a
+// self-heal.
+func computeVotingDelta(old *crypto.OneTimeSignatureSecretsPersistent, secrets *crypto.OneTimeSignatureSecrets) (votingDelta, error) {
 	fullRewrite := func() votingDelta {
 		scalars, batches, offsets := secrets.PersistentParts()
-		return votingDelta{
-			fullRewrite:   true,
-			insertBatches: batches,
-			insertOffsets: offsets,
-			newScalars:    protocol.Encode(&scalars),
+		d := votingDelta{
+			fullRewrite:           true,
+			expectedBatchDeletes:  -1,
+			expectedOffsetDeletes: -1,
+			insertBatches:         batches,
+			insertOffsets:         offsets,
+			newScalars:            protocol.Encode(&scalars),
 		}
+		if len(offsets) > 0 {
+			d.offsetsBatch = scalars.FirstBatch - 1
+		}
+		return d
 	}
 
-	// Legacy whole-blob or unusable persisted state: convert in place.
-	if old == nil || len(old.Batches) != 0 || len(old.Offsets) != 0 {
-		return fullRewrite()
+	if old == nil {
+		return fullRewrite(), nil
 	}
 
 	scalars, numBatches, numOffsets := secrets.PersistentState()
+
+	if old.FirstBatch > scalars.FirstBatch ||
+		(old.FirstBatch == scalars.FirstBatch && old.FirstOffset > scalars.FirstOffset) {
+		return votingDelta{}, fmt.Errorf("computeVotingDelta: persisted voting state (batch %d, offset %d) is ahead of memory (batch %d, offset %d): stale or corrupt store; refusing to resurrect deleted keys",
+			old.FirstBatch, old.FirstOffset, scalars.FirstBatch, scalars.FirstOffset)
+	}
+
+	// Legacy whole-blob persisted state: convert in place.  The cursor check
+	// above guarantees memory holds no more keys than the blob did.
+	if len(old.Batches) != 0 || len(old.Offsets) != 0 {
+		return fullRewrite(), nil
+	}
+
 	switch {
 	case scalars.FirstBatch == old.FirstBatch && scalars.FirstOffset == old.FirstOffset:
 		if numBatches == 0 && numOffsets == 0 {
@@ -96,46 +134,57 @@ func computeVotingDelta(old *crypto.OneTimeSignatureSecretsPersistent, secrets *
 			// does not imply the stored rows are current.  A key with no
 			// subkeys in memory must have no rows on disk (forward
 			// security).
-			return votingDelta{clearAllRows: true}
+			return votingDelta{clearAllRows: true, expectedBatchDeletes: -1, expectedOffsetDeletes: -1}, nil
 		}
-		return votingDelta{noop: true}
+		return votingDelta{noop: true}, nil
 
-	case scalars.FirstBatch == old.FirstBatch && scalars.FirstOffset > old.FirstOffset:
-		// Common per-round path: offsets consumed from the front.
+	case scalars.FirstBatch == old.FirstBatch:
+		// Common per-round path: offsets consumed from the front.  Storage
+		// held rows from old.FirstOffset, so the trim size is exact.
 		return votingDelta{
-			deleteOffsetsBelow: scalars.FirstOffset,
-			newScalars:         protocol.Encode(&scalars),
-		}
+			deleteOffsetsBelow:    scalars.FirstOffset,
+			expectedOffsetDeletes: int64(scalars.FirstOffset - old.FirstOffset),
+			expectedBatchDeletes:  -1,
+			newScalars:            protocol.Encode(&scalars),
+		}, nil
 
-	case scalars.FirstBatch > old.FirstBatch:
+	default:
 		// Batch rollover: batch rows consumed, offset rows regenerated.
 		// Re-capture scalars and offset rows in one consistent snapshot;
 		// batch rows are already present in storage and never re-inserted.
 		partScalars, offsets := secrets.PersistentScalarsAndOffsets()
-		return votingDelta{
-			deleteBatchesBelow: partScalars.FirstBatch,
-			replaceAllOffsets:  true,
-			insertOffsets:      offsets,
-			newScalars:         protocol.Encode(&partScalars),
+		d := votingDelta{
+			deleteBatchesBelow:    partScalars.FirstBatch,
+			expectedBatchDeletes:  -1,
+			expectedOffsetDeletes: -1,
+			replaceAllOffsets:     true,
+			insertOffsets:         offsets,
+			newScalars:            protocol.Encode(&partScalars),
 		}
-
-	default:
-		// Persisted state is ahead of memory; self-heal.
-		return fullRewrite()
+		if len(offsets) > 0 {
+			d.offsetsBatch = partScalars.FirstBatch - 1
+			// memory still holds the tail of the batch sequence, so storage
+			// must have carried exactly the same tail and the trim size is
+			// exact; when memory ran out of batches entirely the tail length
+			// is unknown here, so the check is skipped
+			d.expectedBatchDeletes = int64(partScalars.FirstBatch - old.FirstBatch)
+		}
+		return d, nil
 	}
 }
 
 // votingDeltaTarget names the SQL statements for one of the two row-oriented
 // voting key stores: the .partkey file tables, or the registry tables scoped
 // by pk.  Statements taking a threshold or row values receive prefixArgs
-// first.
+// first; insertOffset additionally receives the owning batch number between
+// the prefix and the row values.
 type votingDeltaTarget struct {
 	deleteAllBatches   string
 	deleteBatchesBelow string // args: (prefixArgs..., threshold)
 	deleteAllOffsets   string
 	deleteOffsetsBelow string // args: (prefixArgs..., threshold)
 	insertBatch        string // args: (prefixArgs..., index, data)
-	insertOffset       string // args: (prefixArgs..., index, data)
+	insertOffset       string // args: (prefixArgs..., batch, index, data)
 	updateScalars      string // args: (scalars, prefixArgs...)
 	prefixArgs         []any
 }
@@ -146,7 +195,7 @@ var partkeyFileVotingTarget = votingDeltaTarget{
 	deleteAllOffsets:   "DELETE FROM OtsOffsets",
 	deleteOffsetsBelow: "DELETE FROM OtsOffsets WHERE off<?",
 	insertBatch:        "INSERT INTO OtsBatches (batch, data) VALUES (?, ?)",
-	insertOffset:       "INSERT INTO OtsOffsets (off, data) VALUES (?, ?)",
+	insertOffset:       "INSERT INTO OtsOffsets (batch, off, data) VALUES (?, ?, ?)",
 	updateScalars:      "UPDATE ParticipationAccount SET voting=?",
 }
 
@@ -157,7 +206,7 @@ func registryVotingTarget(pk int64) votingDeltaTarget {
 		deleteAllOffsets:   deleteVotingOffsetsPK,
 		deleteOffsetsBelow: "DELETE FROM VotingOffsets WHERE pk=? AND off<?",
 		insertBatch:        "INSERT INTO VotingBatches (pk, batch, data) VALUES (?, ?, ?)",
-		insertOffset:       "INSERT INTO VotingOffsets (pk, off, data) VALUES (?, ?, ?)",
+		insertOffset:       "INSERT INTO VotingOffsets (pk, batch, off, data) VALUES (?, ?, ?, ?)",
 		updateScalars:      "UPDATE Rolling SET voting=? WHERE pk=?",
 		prefixArgs:         []any{pk},
 	}
@@ -184,8 +233,12 @@ func applyVotingDelta(tx *sql.Tx, target votingDeltaTarget, d votingDelta) error
 			return fmt.Errorf("applyVotingDelta: failed to clear batches: %w", err)
 		}
 	} else if d.deleteBatchesBelow > 0 {
-		if _, err := tx.Exec(target.deleteBatchesBelow, append(append([]any{}, target.prefixArgs...), d.deleteBatchesBelow)...); err != nil {
+		result, err := tx.Exec(target.deleteBatchesBelow, append(append([]any{}, target.prefixArgs...), d.deleteBatchesBelow)...)
+		if err != nil {
 			return fmt.Errorf("applyVotingDelta: failed to trim batches: %w", err)
+		}
+		if err := verifyRowsAffected(result, d.expectedBatchDeletes, "batch subkey trim"); err != nil {
+			return fmt.Errorf("applyVotingDelta: %w", err)
 		}
 	}
 
@@ -194,21 +247,111 @@ func applyVotingDelta(tx *sql.Tx, target votingDeltaTarget, d votingDelta) error
 			return fmt.Errorf("applyVotingDelta: failed to clear offsets: %w", err)
 		}
 	} else if d.deleteOffsetsBelow > 0 {
-		if _, err := tx.Exec(target.deleteOffsetsBelow, append(append([]any{}, target.prefixArgs...), d.deleteOffsetsBelow)...); err != nil {
+		result, err := tx.Exec(target.deleteOffsetsBelow, append(append([]any{}, target.prefixArgs...), d.deleteOffsetsBelow)...)
+		if err != nil {
 			return fmt.Errorf("applyVotingDelta: failed to trim offsets: %w", err)
+		}
+		if err := verifyRowsAffected(result, d.expectedOffsetDeletes, "offset subkey trim"); err != nil {
+			return fmt.Errorf("applyVotingDelta: %w", err)
 		}
 	}
 
 	if err := insertKeyedSubkeys(tx, target.insertBatch, target.prefixArgs, d.insertBatches); err != nil {
 		return fmt.Errorf("applyVotingDelta: failed to insert batches: %w", err)
 	}
-	if err := insertKeyedSubkeys(tx, target.insertOffset, target.prefixArgs, d.insertOffsets); err != nil {
-		return fmt.Errorf("applyVotingDelta: failed to insert offsets: %w", err)
+	if len(d.insertOffsets) > 0 {
+		offsetPrefix := append(append([]any{}, target.prefixArgs...), d.offsetsBatch)
+		if err := insertKeyedSubkeys(tx, target.insertOffset, offsetPrefix, d.insertOffsets); err != nil {
+			return fmt.Errorf("applyVotingDelta: failed to insert offsets: %w", err)
+		}
 	}
 
 	if d.newScalars != nil {
-		if _, err := tx.Exec(target.updateScalars, append([]any{d.newScalars}, target.prefixArgs...)...); err != nil {
+		result, err := tx.Exec(target.updateScalars, append([]any{d.newScalars}, target.prefixArgs...)...)
+		if err != nil {
 			return fmt.Errorf("applyVotingDelta: failed to update scalars: %w", err)
+		}
+		if err := verifyRowsAffected(result, 1, "scalar update"); err != nil {
+			return fmt.Errorf("applyVotingDelta: %w", err)
+		}
+	}
+	return nil
+}
+
+// verifyRowsAffected checks a statement changed exactly the expected number
+// of rows; expected < 0 skips the check.
+func verifyRowsAffected(result sql.Result, expected int64, what string) error {
+	if expected < 0 {
+		return nil
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n != expected {
+		return fmt.Errorf("%s affected %d rows, expected %d: stored voting rows are inconsistent", what, n, expected)
+	}
+	return nil
+}
+
+// validateVotingRowCounts verifies the number of stored subkey rows matches
+// what the scalars imply.  Batch rows are only ever trimmed from the front,
+// so a key valid through lastValid must hold exactly the batches from
+// FirstBatch through the last batch of its validity window.  Offset rows for
+// the current batch (FirstBatch-1) must cover FirstOffset through
+// dilution-1, except while the key is past its final batch where zero rows
+// (erased at end of key life) are also legitimate.  dilution 0 (ancient keys
+// deferring to consensus parameters) skips the checks.
+func validateVotingRowCounts(scalars *crypto.OneTimeSignatureSecretsPersistent, lastValid basics.Round, dilution uint64, numBatchRows, numOffsetRows int) error {
+	if dilution == 0 {
+		return nil
+	}
+	lastBatch := basics.OneTimeIDForRound(lastValid, dilution).Batch
+
+	expectedBatches := 0
+	if scalars.FirstBatch <= lastBatch {
+		expectedBatches = int(lastBatch - scalars.FirstBatch + 1)
+	}
+	if numBatchRows != expectedBatches {
+		return fmt.Errorf("voting key has %d batch subkey rows, expected %d (first batch %d, last batch %d): missing or extra rows", numBatchRows, expectedBatches, scalars.FirstBatch, lastBatch)
+	}
+
+	expectedOffsets := 0
+	if dilution > scalars.FirstOffset {
+		expectedOffsets = int(dilution - scalars.FirstOffset)
+	}
+	switch {
+	case !scalars.OffsetsExpanded():
+		expectedOffsets = 0
+	case scalars.FirstBatch == lastBatch+1:
+		// final-batch phase: the rows are either still live or already
+		// erased at the end of the key's life — both are legitimate
+		if numOffsetRows == 0 {
+			return nil
+		}
+	case scalars.FirstBatch > lastBatch+1:
+		expectedOffsets = 0
+	}
+	if numOffsetRows != expectedOffsets {
+		return fmt.Errorf("voting key has %d offset subkey rows, expected %d (first offset %d, dilution %d): missing or extra rows", numOffsetRows, expectedOffsets, scalars.FirstOffset, dilution)
+	}
+	return nil
+}
+
+// validateOffsetRowBatches verifies every stored offset row belongs to the
+// batch the scalars say is expanded (FirstBatch-1), so a scalar/row mismatch
+// cannot silently associate offsets with the wrong batch.
+func validateOffsetRowBatches(scalars *crypto.OneTimeSignatureSecretsPersistent, offsetBatches []uint64) error {
+	if len(offsetBatches) == 0 {
+		return nil
+	}
+	if !scalars.OffsetsExpanded() || scalars.FirstBatch == 0 {
+		return fmt.Errorf("offset subkey rows present but the key has no expanded batch")
+	}
+	want := scalars.FirstBatch - 1
+	for _, b := range offsetBatches {
+		if b != want {
+			return fmt.Errorf("offset subkey row belongs to batch %d, expected batch %d", b, want)
 		}
 	}
 	return nil
@@ -238,17 +381,17 @@ func insertKeyedSubkeys(tx *sql.Tx, insertSQL string, prefixArgs []any, rows []c
 }
 
 // readVotingRowsFromPartkeyFile loads the subkey rows from a v4 .partkey
-// database, ordered by index.
-func readVotingRowsFromPartkeyFile(tx *sql.Tx) (batches, offsets []crypto.KeyedSubkey, err error) {
+// database, ordered by index, along with each offset row's owning batch.
+func readVotingRowsFromPartkeyFile(tx *sql.Tx) (batches, offsets []crypto.KeyedSubkey, offsetBatches []uint64, err error) {
 	batches, err = readKeyedSubkeys(tx, "SELECT batch, data FROM OtsBatches ORDER BY batch")
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	offsets, err = readKeyedSubkeys(tx, "SELECT off, data FROM OtsOffsets ORDER BY off")
+	offsets, offsetBatches, err = readOffsetSubkeys(tx, "SELECT batch, off, data FROM OtsOffsets ORDER BY off")
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return batches, offsets, nil
+	return batches, offsets, offsetBatches, nil
 }
 
 func readKeyedSubkeys(tx *sql.Tx, query string, args ...any) ([]crypto.KeyedSubkey, error) {
@@ -267,4 +410,65 @@ func readKeyedSubkeys(tx *sql.Tx, query string, args ...any) ([]crypto.KeyedSubk
 		result = append(result, row)
 	}
 	return result, rows.Err()
+}
+
+// groupedSubkeys carries the subkey rows of one pk; batches holds each row's
+// owning batch for offset subkeys (nil for batch subkeys).
+type groupedSubkeys struct {
+	subkeys []crypto.KeyedSubkey
+	batches []uint64
+}
+
+// readGroupedSubkeys loads subkey rows for every key at once, grouped by pk.
+// The query must yield (pk, index, data) rows, or (pk, batch, index, data)
+// when withBatch is set, ordered by (pk, index).
+func readGroupedSubkeys(tx *sql.Tx, query string, withBatch bool) (map[int64]groupedSubkeys, error) {
+	rows, err := tx.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[int64]groupedSubkeys)
+	for rows.Next() {
+		var pk int64
+		var batch uint64
+		var row crypto.KeyedSubkey
+		if withBatch {
+			err = rows.Scan(&pk, &batch, &row.Index, &row.Key)
+		} else {
+			err = rows.Scan(&pk, &row.Index, &row.Key)
+		}
+		if err != nil {
+			return nil, err
+		}
+		group := result[pk]
+		group.subkeys = append(group.subkeys, row)
+		if withBatch {
+			group.batches = append(group.batches, batch)
+		}
+		result[pk] = group
+	}
+	return result, rows.Err()
+}
+
+func readOffsetSubkeys(tx *sql.Tx, query string, args ...any) ([]crypto.KeyedSubkey, []uint64, error) {
+	rows, err := tx.Query(query, args...)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+
+	var result []crypto.KeyedSubkey
+	var batches []uint64
+	for rows.Next() {
+		var batch uint64
+		var row crypto.KeyedSubkey
+		if err := rows.Scan(&batch, &row.Index, &row.Key); err != nil {
+			return nil, nil, err
+		}
+		result = append(result, row)
+		batches = append(batches, batch)
+	}
+	return result, batches, rows.Err()
 }

--- a/data/account/votingRows.go
+++ b/data/account/votingRows.go
@@ -39,6 +39,12 @@ type votingDelta struct {
 	// insertBatches+insertOffsets.
 	fullRewrite bool
 
+	// clearAllRows means the in-memory secrets carry no subkeys at all while
+	// the scalars are unchanged (the end-of-key-life transition): delete
+	// every row, keep the stored scalars.  Idempotent, and once the tables
+	// are empty it writes nothing.
+	clearAllRows bool
+
 	// deleteBatchesBelow deletes batch rows with index < this value
 	// (rollover path; 0 means no batch deletion).
 	deleteBatchesBelow uint64
@@ -55,7 +61,8 @@ type votingDelta struct {
 	insertBatches []crypto.KeyedSubkey
 	insertOffsets []crypto.KeyedSubkey
 
-	// newScalars is the encoded scalar state to store; nil only when noop.
+	// newScalars is the encoded scalar state to store; nil when the stored
+	// scalars need no update (noop and clearAllRows).
 	newScalars []byte
 }
 
@@ -79,9 +86,18 @@ func computeVotingDelta(old *crypto.OneTimeSignatureSecretsPersistent, secrets *
 		return fullRewrite()
 	}
 
-	scalars := secrets.PersistentScalars()
+	scalars, numBatches, numOffsets := secrets.PersistentState()
 	switch {
 	case scalars.FirstBatch == old.FirstBatch && scalars.FirstOffset == old.FirstOffset:
+		if numBatches == 0 && numOffsets == 0 {
+			// End-of-key-life: when a key on its last batch moves past its
+			// end, DeleteBeforeFineGrained clears the remaining offset
+			// subkeys without advancing either scalar, so scalar equality
+			// does not imply the stored rows are current.  A key with no
+			// subkeys in memory must have no rows on disk (forward
+			// security).
+			return votingDelta{clearAllRows: true}
+		}
 		return votingDelta{noop: true}
 
 	case scalars.FirstBatch == old.FirstBatch && scalars.FirstOffset > old.FirstOffset:
@@ -95,7 +111,7 @@ func computeVotingDelta(old *crypto.OneTimeSignatureSecretsPersistent, secrets *
 		// Batch rollover: batch rows consumed, offset rows regenerated.
 		// Re-capture scalars and offset rows in one consistent snapshot;
 		// batch rows are already present in storage and never re-inserted.
-		partScalars, _, offsets := secrets.PersistentParts()
+		partScalars, offsets := secrets.PersistentScalarsAndOffsets()
 		return votingDelta{
 			deleteBatchesBelow: partScalars.FirstBatch,
 			replaceAllOffsets:  true,
@@ -107,6 +123,95 @@ func computeVotingDelta(old *crypto.OneTimeSignatureSecretsPersistent, secrets *
 		// Persisted state is ahead of memory; self-heal.
 		return fullRewrite()
 	}
+}
+
+// votingDeltaTarget names the SQL statements for one of the two row-oriented
+// voting key stores: the .partkey file tables, or the registry tables scoped
+// by pk.  Statements taking a threshold or row values receive prefixArgs
+// first.
+type votingDeltaTarget struct {
+	deleteAllBatches   string
+	deleteBatchesBelow string // args: (prefixArgs..., threshold)
+	deleteAllOffsets   string
+	deleteOffsetsBelow string // args: (prefixArgs..., threshold)
+	insertBatch        string // args: (prefixArgs..., index, data)
+	insertOffset       string // args: (prefixArgs..., index, data)
+	updateScalars      string // args: (scalars, prefixArgs...)
+	prefixArgs         []any
+}
+
+var partkeyFileVotingTarget = votingDeltaTarget{
+	deleteAllBatches:   "DELETE FROM OtsBatches",
+	deleteBatchesBelow: "DELETE FROM OtsBatches WHERE batch<?",
+	deleteAllOffsets:   "DELETE FROM OtsOffsets",
+	deleteOffsetsBelow: "DELETE FROM OtsOffsets WHERE off<?",
+	insertBatch:        "INSERT INTO OtsBatches (batch, data) VALUES (?, ?)",
+	insertOffset:       "INSERT INTO OtsOffsets (off, data) VALUES (?, ?)",
+	updateScalars:      "UPDATE ParticipationAccount SET voting=?",
+}
+
+func registryVotingTarget(pk int64) votingDeltaTarget {
+	return votingDeltaTarget{
+		deleteAllBatches:   deleteVotingBatchesPK,
+		deleteBatchesBelow: "DELETE FROM VotingBatches WHERE pk=? AND batch<?",
+		deleteAllOffsets:   deleteVotingOffsetsPK,
+		deleteOffsetsBelow: "DELETE FROM VotingOffsets WHERE pk=? AND off<?",
+		insertBatch:        "INSERT INTO VotingBatches (pk, batch, data) VALUES (?, ?, ?)",
+		insertOffset:       "INSERT INTO VotingOffsets (pk, off, data) VALUES (?, ?, ?)",
+		updateScalars:      "UPDATE Rolling SET voting=? WHERE pk=?",
+		prefixArgs:         []any{pk},
+	}
+}
+
+// applyVotingDeltaToPartkeyFile applies a delta to a .partkey database.
+func applyVotingDeltaToPartkeyFile(tx *sql.Tx, d votingDelta) error {
+	return applyVotingDelta(tx, partkeyFileVotingTarget, d)
+}
+
+// applyVotingDeltaToRegistry applies a delta to the participation registry
+// tables for one key.
+func applyVotingDeltaToRegistry(tx *sql.Tx, pk int64, d votingDelta) error {
+	return applyVotingDelta(tx, registryVotingTarget(pk), d)
+}
+
+func applyVotingDelta(tx *sql.Tx, target votingDeltaTarget, d votingDelta) error {
+	if d.noop {
+		return nil
+	}
+
+	if d.fullRewrite || d.clearAllRows {
+		if _, err := tx.Exec(target.deleteAllBatches, target.prefixArgs...); err != nil {
+			return fmt.Errorf("applyVotingDelta: failed to clear batches: %w", err)
+		}
+	} else if d.deleteBatchesBelow > 0 {
+		if _, err := tx.Exec(target.deleteBatchesBelow, append(append([]any{}, target.prefixArgs...), d.deleteBatchesBelow)...); err != nil {
+			return fmt.Errorf("applyVotingDelta: failed to trim batches: %w", err)
+		}
+	}
+
+	if d.fullRewrite || d.clearAllRows || d.replaceAllOffsets {
+		if _, err := tx.Exec(target.deleteAllOffsets, target.prefixArgs...); err != nil {
+			return fmt.Errorf("applyVotingDelta: failed to clear offsets: %w", err)
+		}
+	} else if d.deleteOffsetsBelow > 0 {
+		if _, err := tx.Exec(target.deleteOffsetsBelow, append(append([]any{}, target.prefixArgs...), d.deleteOffsetsBelow)...); err != nil {
+			return fmt.Errorf("applyVotingDelta: failed to trim offsets: %w", err)
+		}
+	}
+
+	if err := insertKeyedSubkeys(tx, target.insertBatch, target.prefixArgs, d.insertBatches); err != nil {
+		return fmt.Errorf("applyVotingDelta: failed to insert batches: %w", err)
+	}
+	if err := insertKeyedSubkeys(tx, target.insertOffset, target.prefixArgs, d.insertOffsets); err != nil {
+		return fmt.Errorf("applyVotingDelta: failed to insert offsets: %w", err)
+	}
+
+	if d.newScalars != nil {
+		if _, err := tx.Exec(target.updateScalars, append([]any{d.newScalars}, target.prefixArgs...)...); err != nil {
+			return fmt.Errorf("applyVotingDelta: failed to update scalars: %w", err)
+		}
+	}
+	return nil
 }
 
 // insertKeyedSubkeys bulk-inserts rows with a single prepared statement.
@@ -128,86 +233,6 @@ func insertKeyedSubkeys(tx *sql.Tx, insertSQL string, prefixArgs []any, rows []c
 		if _, err := stmt.Exec(args...); err != nil {
 			return err
 		}
-	}
-	return nil
-}
-
-// applyVotingDeltaToPartkeyFile applies a delta to a .partkey database
-// (tables OtsBatches/OtsOffsets, scalars in ParticipationAccount.voting).
-func applyVotingDeltaToPartkeyFile(tx *sql.Tx, d votingDelta) error {
-	if d.noop {
-		return nil
-	}
-
-	if d.fullRewrite {
-		if _, err := tx.Exec("DELETE FROM OtsBatches"); err != nil {
-			return fmt.Errorf("applyVotingDeltaToPartkeyFile: failed to clear batches: %w", err)
-		}
-	} else if d.deleteBatchesBelow > 0 {
-		if _, err := tx.Exec("DELETE FROM OtsBatches WHERE batch<?", d.deleteBatchesBelow); err != nil {
-			return fmt.Errorf("applyVotingDeltaToPartkeyFile: failed to trim batches: %w", err)
-		}
-	}
-
-	if d.fullRewrite || d.replaceAllOffsets {
-		if _, err := tx.Exec("DELETE FROM OtsOffsets"); err != nil {
-			return fmt.Errorf("applyVotingDeltaToPartkeyFile: failed to clear offsets: %w", err)
-		}
-	} else if d.deleteOffsetsBelow > 0 {
-		if _, err := tx.Exec("DELETE FROM OtsOffsets WHERE off<?", d.deleteOffsetsBelow); err != nil {
-			return fmt.Errorf("applyVotingDeltaToPartkeyFile: failed to trim offsets: %w", err)
-		}
-	}
-
-	if err := insertKeyedSubkeys(tx, "INSERT INTO OtsBatches (batch, data) VALUES (?, ?)", nil, d.insertBatches); err != nil {
-		return fmt.Errorf("applyVotingDeltaToPartkeyFile: failed to insert batches: %w", err)
-	}
-	if err := insertKeyedSubkeys(tx, "INSERT INTO OtsOffsets (off, data) VALUES (?, ?)", nil, d.insertOffsets); err != nil {
-		return fmt.Errorf("applyVotingDeltaToPartkeyFile: failed to insert offsets: %w", err)
-	}
-
-	if _, err := tx.Exec("UPDATE ParticipationAccount SET voting=?", d.newScalars); err != nil {
-		return fmt.Errorf("applyVotingDeltaToPartkeyFile: failed to update scalars: %w", err)
-	}
-	return nil
-}
-
-// applyVotingDeltaToRegistry applies a delta to the participation registry
-// (tables VotingBatches/VotingOffsets keyed by pk, scalars in Rolling.voting).
-func applyVotingDeltaToRegistry(tx *sql.Tx, pk int64, d votingDelta) error {
-	if d.noop {
-		return nil
-	}
-
-	if d.fullRewrite {
-		if _, err := tx.Exec("DELETE FROM VotingBatches WHERE pk=?", pk); err != nil {
-			return fmt.Errorf("applyVotingDeltaToRegistry: failed to clear batches: %w", err)
-		}
-	} else if d.deleteBatchesBelow > 0 {
-		if _, err := tx.Exec("DELETE FROM VotingBatches WHERE pk=? AND batch<?", pk, d.deleteBatchesBelow); err != nil {
-			return fmt.Errorf("applyVotingDeltaToRegistry: failed to trim batches: %w", err)
-		}
-	}
-
-	if d.fullRewrite || d.replaceAllOffsets {
-		if _, err := tx.Exec("DELETE FROM VotingOffsets WHERE pk=?", pk); err != nil {
-			return fmt.Errorf("applyVotingDeltaToRegistry: failed to clear offsets: %w", err)
-		}
-	} else if d.deleteOffsetsBelow > 0 {
-		if _, err := tx.Exec("DELETE FROM VotingOffsets WHERE pk=? AND off<?", pk, d.deleteOffsetsBelow); err != nil {
-			return fmt.Errorf("applyVotingDeltaToRegistry: failed to trim offsets: %w", err)
-		}
-	}
-
-	if err := insertKeyedSubkeys(tx, "INSERT INTO VotingBatches (pk, batch, data) VALUES (?, ?, ?)", []any{pk}, d.insertBatches); err != nil {
-		return fmt.Errorf("applyVotingDeltaToRegistry: failed to insert batches: %w", err)
-	}
-	if err := insertKeyedSubkeys(tx, "INSERT INTO VotingOffsets (pk, off, data) VALUES (?, ?, ?)", []any{pk}, d.insertOffsets); err != nil {
-		return fmt.Errorf("applyVotingDeltaToRegistry: failed to insert offsets: %w", err)
-	}
-
-	if _, err := tx.Exec("UPDATE Rolling SET voting=? WHERE pk=?", d.newScalars, pk); err != nil {
-		return fmt.Errorf("applyVotingDeltaToRegistry: failed to update scalars: %w", err)
 	}
 	return nil
 }

--- a/data/account/votingRows.go
+++ b/data/account/votingRows.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/algorand/go-algorand/logging"
+
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/protocol"
@@ -87,6 +89,12 @@ type votingDelta struct {
 	newScalars []byte
 }
 
+// cursorAhead reports whether a's deletion cursor is strictly ahead of b's.
+func cursorAhead(a, b *crypto.OneTimeSignatureSecretsPersistent) bool {
+	return a.FirstBatch > b.FirstBatch ||
+		(a.FirstBatch == b.FirstBatch && a.FirstOffset > b.FirstOffset)
+}
+
 // computeVotingDelta compares the last-persisted scalars against the current
 // in-memory secrets and returns the row operations to persist the difference.
 // old == nil requests an unconditional full rewrite (missing persisted
@@ -97,7 +105,7 @@ type votingDelta struct {
 // that were already deleted on disk, so that state is an error rather than a
 // self-heal.
 func computeVotingDelta(old *crypto.OneTimeSignatureSecretsPersistent, secrets *crypto.OneTimeSignatureSecrets) (votingDelta, error) {
-	fullRewrite := func() votingDelta {
+	fullRewrite := func() (votingDelta, error) {
 		scalars, batches, offsets := secrets.PersistentParts()
 		d := votingDelta{
 			fullRewrite:           true,
@@ -108,19 +116,22 @@ func computeVotingDelta(old *crypto.OneTimeSignatureSecretsPersistent, secrets *
 			newScalars:            protocol.Encode(&scalars),
 		}
 		if len(offsets) > 0 {
-			d.offsetsBatch = scalars.FirstBatch - 1
+			var err error
+			d.offsetsBatch, err = offsetsOwningBatch(scalars.FirstBatch)
+			if err != nil {
+				return votingDelta{}, err
+			}
 		}
-		return d
+		return d, nil
 	}
 
 	if old == nil {
-		return fullRewrite(), nil
+		return fullRewrite()
 	}
 
 	scalars, numBatches, numOffsets := secrets.PersistentState()
 
-	if old.FirstBatch > scalars.FirstBatch ||
-		(old.FirstBatch == scalars.FirstBatch && old.FirstOffset > scalars.FirstOffset) {
+	if cursorAhead(old, &scalars) {
 		return votingDelta{}, fmt.Errorf("computeVotingDelta: persisted voting state (batch %d, offset %d) is ahead of memory (batch %d, offset %d): stale or corrupt store; refusing to resurrect deleted keys",
 			old.FirstBatch, old.FirstOffset, scalars.FirstBatch, scalars.FirstOffset)
 	}
@@ -128,7 +139,7 @@ func computeVotingDelta(old *crypto.OneTimeSignatureSecretsPersistent, secrets *
 	// Legacy whole-blob persisted state: convert in place.  The cursor check
 	// above guarantees memory holds no more keys than the blob did.
 	if len(old.Batches) != 0 || len(old.Offsets) != 0 {
-		return fullRewrite(), nil
+		return fullRewrite()
 	}
 
 	switch {
@@ -168,7 +179,11 @@ func computeVotingDelta(old *crypto.OneTimeSignatureSecretsPersistent, secrets *
 			newScalars:            protocol.Encode(&partScalars),
 		}
 		if len(offsets) > 0 {
-			d.offsetsBatch = partScalars.FirstBatch - 1
+			var err error
+			d.offsetsBatch, err = offsetsOwningBatch(partScalars.FirstBatch)
+			if err != nil {
+				return votingDelta{}, err
+			}
 			// memory still holds the tail of the batch sequence, so storage
 			// must have carried exactly the same tail and the trim size is
 			// exact; when memory ran out of batches entirely the tail length
@@ -244,11 +259,25 @@ func applyVotingDeltaSelfHealing(tx *sql.Tx, target votingDeltaTarget, d votingD
 	if !errors.Is(err, errInconsistentVotingRows) || secrets == nil {
 		return err
 	}
+	// reaching this path means a disk problem or a delta bug — repair it,
+	// but never silently
+	logging.Base().Warnf("participation voting rows were inconsistent and have been rebuilt from memory: %v", err)
 	full, ferr := computeVotingDelta(nil, secrets)
 	if ferr != nil {
 		return ferr
 	}
 	return applyVotingDelta(tx, target, full)
+}
+
+// offsetsOwningBatch returns the batch that offset subkeys belong to.  Offset
+// subkeys only exist after a batch expansion, which leaves FirstBatch >= 1;
+// FirstBatch == 0 alongside offsets means corrupt in-memory state, which must
+// fail at write time rather than persist a row every later load would reject.
+func offsetsOwningBatch(firstBatch uint64) (uint64, error) {
+	if firstBatch == 0 {
+		return 0, errors.New("offset subkeys present but FirstBatch is 0: corrupt voting state")
+	}
+	return firstBatch - 1, nil
 }
 
 func applyVotingDelta(tx *sql.Tx, target votingDeltaTarget, d votingDelta) error {
@@ -299,8 +328,14 @@ func applyVotingDelta(tx *sql.Tx, target votingDeltaTarget, d votingDelta) error
 		if err != nil {
 			return fmt.Errorf("applyVotingDelta: failed to update scalars: %w", err)
 		}
-		if err := verifyRowsAffected(result, 1, "scalar update"); err != nil {
-			return fmt.Errorf("applyVotingDelta: %w", err)
+		// deliberately not the self-heal sentinel: a missing scalar row is
+		// not repairable by rewriting the subkey rows
+		n, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if n != 1 {
+			return fmt.Errorf("applyVotingDelta: scalar update affected %d rows, expected 1", n)
 		}
 	}
 	return nil

--- a/data/account/votingRows.go
+++ b/data/account/votingRows.go
@@ -111,7 +111,7 @@ func computeVotingDelta(old *crypto.OneTimeSignatureSecretsPersistent, secrets *
 
 // insertKeyedSubkeys bulk-inserts rows with a single prepared statement.
 // insertSQL must take (prefixArgs..., index, data).
-func insertKeyedSubkeys(tx *sql.Tx, insertSQL string, prefixArgs []interface{}, rows []crypto.KeyedSubkey) error {
+func insertKeyedSubkeys(tx *sql.Tx, insertSQL string, prefixArgs []any, rows []crypto.KeyedSubkey) error {
 	if len(rows) == 0 {
 		return nil
 	}
@@ -120,7 +120,7 @@ func insertKeyedSubkeys(tx *sql.Tx, insertSQL string, prefixArgs []interface{}, 
 		return err
 	}
 	defer stmt.Close()
-	args := make([]interface{}, len(prefixArgs)+2)
+	args := make([]any, len(prefixArgs)+2)
 	copy(args, prefixArgs)
 	for _, row := range rows {
 		args[len(prefixArgs)] = row.Index
@@ -199,10 +199,10 @@ func applyVotingDeltaToRegistry(tx *sql.Tx, pk int64, d votingDelta) error {
 		}
 	}
 
-	if err := insertKeyedSubkeys(tx, "INSERT INTO VotingBatches (pk, batch, data) VALUES (?, ?, ?)", []interface{}{pk}, d.insertBatches); err != nil {
+	if err := insertKeyedSubkeys(tx, "INSERT INTO VotingBatches (pk, batch, data) VALUES (?, ?, ?)", []any{pk}, d.insertBatches); err != nil {
 		return fmt.Errorf("applyVotingDeltaToRegistry: failed to insert batches: %w", err)
 	}
-	if err := insertKeyedSubkeys(tx, "INSERT INTO VotingOffsets (pk, off, data) VALUES (?, ?, ?)", []interface{}{pk}, d.insertOffsets); err != nil {
+	if err := insertKeyedSubkeys(tx, "INSERT INTO VotingOffsets (pk, off, data) VALUES (?, ?, ?)", []any{pk}, d.insertOffsets); err != nil {
 		return fmt.Errorf("applyVotingDeltaToRegistry: failed to insert offsets: %w", err)
 	}
 
@@ -226,7 +226,7 @@ func readVotingRowsFromPartkeyFile(tx *sql.Tx) (batches, offsets []crypto.KeyedS
 	return batches, offsets, nil
 }
 
-func readKeyedSubkeys(tx *sql.Tx, query string, args ...interface{}) ([]crypto.KeyedSubkey, error) {
+func readKeyedSubkeys(tx *sql.Tx, query string, args ...any) ([]crypto.KeyedSubkey, error) {
 	rows, err := tx.Query(query, args...)
 	if err != nil {
 		return nil, err

--- a/data/account/votingRows.go
+++ b/data/account/votingRows.go
@@ -97,8 +97,10 @@ func cursorAhead(a, b *crypto.OneTimeSignatureSecretsPersistent) bool {
 
 // computeVotingDelta compares the last-persisted scalars against the current
 // in-memory secrets and returns the row operations to persist the difference.
-// old == nil requests an unconditional full rewrite (missing persisted
-// state, e.g. during format migration).
+// old == nil requests an unconditional full rewrite and is only legitimate for
+// known-new state (nothing persisted yet) and explicit format migration; an
+// undecodable persisted state must fail closed at the caller instead, since
+// it cannot rule out that memory lags storage.
 //
 // Forward security requires the persisted deletion cursor to be monotonic:
 // if storage is ahead of memory, rewriting from memory would resurrect keys
@@ -145,12 +147,11 @@ func computeVotingDelta(old *crypto.OneTimeSignatureSecretsPersistent, secrets *
 	switch {
 	case scalars.FirstBatch == old.FirstBatch && scalars.FirstOffset == old.FirstOffset:
 		if numBatches == 0 && numOffsets == 0 {
-			// End-of-key-life: when a key on its last batch moves past its
-			// end, DeleteBeforeFineGrained clears the remaining offset
-			// subkeys without advancing either scalar, so scalar equality
-			// does not imply the stored rows are current.  A key with no
-			// subkeys in memory must have no rows on disk (forward
-			// security).
+			// Exhausted key whose stored cursor did not move when its rows
+			// were erased (state written before exhaustion advanced
+			// FirstOffset to the batch end): scalar equality does not imply
+			// the stored rows are current, and a key with no subkeys in
+			// memory must have no rows on disk (forward security).
 			return votingDelta{clearAllRows: true, expectedBatchDeletes: -1, expectedOffsetDeletes: -1}, nil
 		}
 		return votingDelta{noop: true}, nil

--- a/data/account/votingRows.go
+++ b/data/account/votingRows.go
@@ -1,0 +1,245 @@
+// Copyright (C) 2019-2026 Algorand Foundation Ltd.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package account
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/protocol"
+)
+
+// votingDelta describes the row operations needed to bring row-oriented
+// persisted voting secrets (whose last-persisted scalars are known) up to the
+// current in-memory state.  Voting subkeys advance monotonically: batch rows
+// are written once when a key is stored and only ever deleted afterwards;
+// offset rows are replaced wholesale on a batch rollover and deleted from the
+// front as rounds pass.
+type votingDelta struct {
+	// noop means the persisted state already matches; skip all writes.
+	noop bool
+
+	// fullRewrite means the persisted state is unusable (ahead of memory,
+	// undecodable, or a legacy whole-blob): delete every row and re-insert
+	// insertBatches+insertOffsets.
+	fullRewrite bool
+
+	// deleteBatchesBelow deletes batch rows with index < this value
+	// (rollover path; 0 means no batch deletion).
+	deleteBatchesBelow uint64
+
+	// deleteOffsetsBelow deletes offset rows with index < this value
+	// (same-batch path; 0 means no offset range-deletion).
+	deleteOffsetsBelow uint64
+
+	// replaceAllOffsets clears the offsets table before inserting
+	// insertOffsets.  Offsets restart at 0 in every batch, so a rollover must
+	// clear rather than range-delete.
+	replaceAllOffsets bool
+
+	insertBatches []crypto.KeyedSubkey
+	insertOffsets []crypto.KeyedSubkey
+
+	// newScalars is the encoded scalar state to store; nil only when noop.
+	newScalars []byte
+}
+
+// computeVotingDelta compares the last-persisted scalars against the current
+// in-memory secrets and returns the row operations to persist the difference.
+// old == nil requests an unconditional full rewrite (undecodable or missing
+// persisted state).
+func computeVotingDelta(old *crypto.OneTimeSignatureSecretsPersistent, secrets *crypto.OneTimeSignatureSecrets) votingDelta {
+	fullRewrite := func() votingDelta {
+		scalars, batches, offsets := secrets.PersistentParts()
+		return votingDelta{
+			fullRewrite:   true,
+			insertBatches: batches,
+			insertOffsets: offsets,
+			newScalars:    protocol.Encode(&scalars),
+		}
+	}
+
+	// Legacy whole-blob or unusable persisted state: convert in place.
+	if old == nil || len(old.Batches) != 0 || len(old.Offsets) != 0 {
+		return fullRewrite()
+	}
+
+	scalars := secrets.PersistentScalars()
+	switch {
+	case scalars.FirstBatch == old.FirstBatch && scalars.FirstOffset == old.FirstOffset:
+		return votingDelta{noop: true}
+
+	case scalars.FirstBatch == old.FirstBatch && scalars.FirstOffset > old.FirstOffset:
+		// Common per-round path: offsets consumed from the front.
+		return votingDelta{
+			deleteOffsetsBelow: scalars.FirstOffset,
+			newScalars:         protocol.Encode(&scalars),
+		}
+
+	case scalars.FirstBatch > old.FirstBatch:
+		// Batch rollover: batch rows consumed, offset rows regenerated.
+		// Re-capture scalars and offset rows in one consistent snapshot;
+		// batch rows are already present in storage and never re-inserted.
+		partScalars, _, offsets := secrets.PersistentParts()
+		return votingDelta{
+			deleteBatchesBelow: partScalars.FirstBatch,
+			replaceAllOffsets:  true,
+			insertOffsets:      offsets,
+			newScalars:         protocol.Encode(&partScalars),
+		}
+
+	default:
+		// Persisted state is ahead of memory; self-heal.
+		return fullRewrite()
+	}
+}
+
+// insertKeyedSubkeys bulk-inserts rows with a single prepared statement.
+// insertSQL must take (prefixArgs..., index, data).
+func insertKeyedSubkeys(tx *sql.Tx, insertSQL string, prefixArgs []interface{}, rows []crypto.KeyedSubkey) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	stmt, err := tx.Prepare(insertSQL)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	args := make([]interface{}, len(prefixArgs)+2)
+	copy(args, prefixArgs)
+	for _, row := range rows {
+		args[len(prefixArgs)] = row.Index
+		args[len(prefixArgs)+1] = row.Key
+		if _, err := stmt.Exec(args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applyVotingDeltaToPartkeyFile applies a delta to a .partkey database
+// (tables OtsBatches/OtsOffsets, scalars in ParticipationAccount.voting).
+func applyVotingDeltaToPartkeyFile(tx *sql.Tx, d votingDelta) error {
+	if d.noop {
+		return nil
+	}
+
+	if d.fullRewrite {
+		if _, err := tx.Exec("DELETE FROM OtsBatches"); err != nil {
+			return fmt.Errorf("applyVotingDeltaToPartkeyFile: failed to clear batches: %w", err)
+		}
+	} else if d.deleteBatchesBelow > 0 {
+		if _, err := tx.Exec("DELETE FROM OtsBatches WHERE batch<?", d.deleteBatchesBelow); err != nil {
+			return fmt.Errorf("applyVotingDeltaToPartkeyFile: failed to trim batches: %w", err)
+		}
+	}
+
+	if d.fullRewrite || d.replaceAllOffsets {
+		if _, err := tx.Exec("DELETE FROM OtsOffsets"); err != nil {
+			return fmt.Errorf("applyVotingDeltaToPartkeyFile: failed to clear offsets: %w", err)
+		}
+	} else if d.deleteOffsetsBelow > 0 {
+		if _, err := tx.Exec("DELETE FROM OtsOffsets WHERE off<?", d.deleteOffsetsBelow); err != nil {
+			return fmt.Errorf("applyVotingDeltaToPartkeyFile: failed to trim offsets: %w", err)
+		}
+	}
+
+	if err := insertKeyedSubkeys(tx, "INSERT INTO OtsBatches (batch, data) VALUES (?, ?)", nil, d.insertBatches); err != nil {
+		return fmt.Errorf("applyVotingDeltaToPartkeyFile: failed to insert batches: %w", err)
+	}
+	if err := insertKeyedSubkeys(tx, "INSERT INTO OtsOffsets (off, data) VALUES (?, ?)", nil, d.insertOffsets); err != nil {
+		return fmt.Errorf("applyVotingDeltaToPartkeyFile: failed to insert offsets: %w", err)
+	}
+
+	if _, err := tx.Exec("UPDATE ParticipationAccount SET voting=?", d.newScalars); err != nil {
+		return fmt.Errorf("applyVotingDeltaToPartkeyFile: failed to update scalars: %w", err)
+	}
+	return nil
+}
+
+// applyVotingDeltaToRegistry applies a delta to the participation registry
+// (tables VotingBatches/VotingOffsets keyed by pk, scalars in Rolling.voting).
+func applyVotingDeltaToRegistry(tx *sql.Tx, pk int64, d votingDelta) error {
+	if d.noop {
+		return nil
+	}
+
+	if d.fullRewrite {
+		if _, err := tx.Exec("DELETE FROM VotingBatches WHERE pk=?", pk); err != nil {
+			return fmt.Errorf("applyVotingDeltaToRegistry: failed to clear batches: %w", err)
+		}
+	} else if d.deleteBatchesBelow > 0 {
+		if _, err := tx.Exec("DELETE FROM VotingBatches WHERE pk=? AND batch<?", pk, d.deleteBatchesBelow); err != nil {
+			return fmt.Errorf("applyVotingDeltaToRegistry: failed to trim batches: %w", err)
+		}
+	}
+
+	if d.fullRewrite || d.replaceAllOffsets {
+		if _, err := tx.Exec("DELETE FROM VotingOffsets WHERE pk=?", pk); err != nil {
+			return fmt.Errorf("applyVotingDeltaToRegistry: failed to clear offsets: %w", err)
+		}
+	} else if d.deleteOffsetsBelow > 0 {
+		if _, err := tx.Exec("DELETE FROM VotingOffsets WHERE pk=? AND off<?", pk, d.deleteOffsetsBelow); err != nil {
+			return fmt.Errorf("applyVotingDeltaToRegistry: failed to trim offsets: %w", err)
+		}
+	}
+
+	if err := insertKeyedSubkeys(tx, "INSERT INTO VotingBatches (pk, batch, data) VALUES (?, ?, ?)", []interface{}{pk}, d.insertBatches); err != nil {
+		return fmt.Errorf("applyVotingDeltaToRegistry: failed to insert batches: %w", err)
+	}
+	if err := insertKeyedSubkeys(tx, "INSERT INTO VotingOffsets (pk, off, data) VALUES (?, ?, ?)", []interface{}{pk}, d.insertOffsets); err != nil {
+		return fmt.Errorf("applyVotingDeltaToRegistry: failed to insert offsets: %w", err)
+	}
+
+	if _, err := tx.Exec("UPDATE Rolling SET voting=? WHERE pk=?", d.newScalars, pk); err != nil {
+		return fmt.Errorf("applyVotingDeltaToRegistry: failed to update scalars: %w", err)
+	}
+	return nil
+}
+
+// readVotingRowsFromPartkeyFile loads the subkey rows from a v4 .partkey
+// database, ordered by index.
+func readVotingRowsFromPartkeyFile(tx *sql.Tx) (batches, offsets []crypto.KeyedSubkey, err error) {
+	batches, err = readKeyedSubkeys(tx, "SELECT batch, data FROM OtsBatches ORDER BY batch")
+	if err != nil {
+		return nil, nil, err
+	}
+	offsets, err = readKeyedSubkeys(tx, "SELECT off, data FROM OtsOffsets ORDER BY off")
+	if err != nil {
+		return nil, nil, err
+	}
+	return batches, offsets, nil
+}
+
+func readKeyedSubkeys(tx *sql.Tx, query string, args ...interface{}) ([]crypto.KeyedSubkey, error) {
+	rows, err := tx.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []crypto.KeyedSubkey
+	for rows.Next() {
+		var row crypto.KeyedSubkey
+		if err := rows.Scan(&row.Index, &row.Key); err != nil {
+			return nil, err
+		}
+		result = append(result, row)
+	}
+	return result, rows.Err()
+}

--- a/data/account/votingRows.go
+++ b/data/account/votingRows.go
@@ -18,12 +18,18 @@ package account
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/protocol"
 )
+
+// errInconsistentVotingRows signals that the stored subkey rows disagree with
+// the stored scalars (a trim removed an unexpected number of rows).  The
+// appliers recover from it by rebuilding the rows from memory.
+var errInconsistentVotingRows = errors.New("stored voting rows are inconsistent with the stored scalars")
 
 // votingDelta describes the row operations needed to bring row-oriented
 // persisted voting secrets (whose last-persisted scalars are known) up to the
@@ -212,15 +218,37 @@ func registryVotingTarget(pk int64) votingDeltaTarget {
 	}
 }
 
-// applyVotingDeltaToPartkeyFile applies a delta to a .partkey database.
-func applyVotingDeltaToPartkeyFile(tx *sql.Tx, d votingDelta) error {
-	return applyVotingDelta(tx, partkeyFileVotingTarget, d)
+// applyVotingDeltaToPartkeyFile applies a delta to a .partkey database,
+// rebuilding the rows from secrets if they turn out inconsistent.
+func applyVotingDeltaToPartkeyFile(tx *sql.Tx, d votingDelta, secrets *crypto.OneTimeSignatureSecrets) error {
+	return applyVotingDeltaSelfHealing(tx, partkeyFileVotingTarget, d, secrets)
 }
 
 // applyVotingDeltaToRegistry applies a delta to the participation registry
-// tables for one key.
-func applyVotingDeltaToRegistry(tx *sql.Tx, pk int64, d votingDelta) error {
-	return applyVotingDelta(tx, registryVotingTarget(pk), d)
+// tables for one key, rebuilding the rows from secrets if they turn out
+// inconsistent.
+func applyVotingDeltaToRegistry(tx *sql.Tx, pk int64, d votingDelta, secrets *crypto.OneTimeSignatureSecrets) error {
+	return applyVotingDeltaSelfHealing(tx, registryVotingTarget(pk), d, secrets)
+}
+
+// applyVotingDeltaSelfHealing applies a delta and, when the trim row counts
+// reveal that the stored rows disagree with the stored scalars, falls back to
+// rebuilding the rows from memory.  The fallback is safe: computeVotingDelta's
+// monotonicity guard already established that storage is not ahead of memory,
+// so a full rewrite can only remove or faithfully restore keys memory
+// legitimately holds — never resurrect deleted ones.  Without it, one
+// inconsistent key would fail every flush forever (blocking on-disk key
+// deletion for all keys, since the registry flush is one transaction).
+func applyVotingDeltaSelfHealing(tx *sql.Tx, target votingDeltaTarget, d votingDelta, secrets *crypto.OneTimeSignatureSecrets) error {
+	err := applyVotingDelta(tx, target, d)
+	if !errors.Is(err, errInconsistentVotingRows) || secrets == nil {
+		return err
+	}
+	full, ferr := computeVotingDelta(nil, secrets)
+	if ferr != nil {
+		return ferr
+	}
+	return applyVotingDelta(tx, target, full)
 }
 
 func applyVotingDelta(tx *sql.Tx, target votingDeltaTarget, d votingDelta) error {
@@ -289,7 +317,7 @@ func verifyRowsAffected(result sql.Result, expected int64, what string) error {
 		return err
 	}
 	if n != expected {
-		return fmt.Errorf("%s affected %d rows, expected %d: stored voting rows are inconsistent", what, n, expected)
+		return fmt.Errorf("%s affected %d rows, expected %d: %w", what, n, expected, errInconsistentVotingRows)
 	}
 	return nil
 }

--- a/data/account/votingRows_test.go
+++ b/data/account/votingRows_test.go
@@ -388,8 +388,38 @@ func TestRestoreDetectsCorruptRows(t *testing.T) {
 			a.NoError(err)
 			_, err = RestoreParticipationUnmigrated(partDB)
 			a.ErrorContains(err, tc.wantErr)
+			// the sentinel lets the node quarantine the file as *.old
+			a.ErrorIs(err, ErrCorruptedVotingRows)
 		})
 	}
+}
+
+// TestDeleteOldKeysSelfHealsInconsistentRows verifies a file whose rows drift
+// from its scalars is rebuilt from memory by the next deletion instead of
+// failing every round.
+func TestDeleteOldKeysSelfHealsInconsistentRows(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	a := require.New(t)
+	const dilution = 10
+	part, partDB := makeSmallTestKey(t, a, 0, 300, dilution)
+	defer closeDBS(partDB)
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	a.NoError(<-part.DeleteOldKeys(basics.Round(25), proto))
+
+	// lose one offset row behind the node's back
+	err := partDB.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.Exec("DELETE FROM OtsOffsets WHERE off=(SELECT MIN(off) FROM OtsOffsets)")
+		return err
+	})
+	a.NoError(err)
+
+	a.NoError(<-part.DeleteOldKeys(basics.Round(26), proto))
+
+	restored, err := RestoreParticipationUnmigrated(partDB)
+	a.NoError(err)
+	a.Equal(encodedVotingSnapshot(part.Voting), encodedVotingSnapshot(restored.Voting))
 }
 
 // TestMigrationRollsBackOnFailure verifies a failing v3-to-v4 migration

--- a/data/account/votingRows_test.go
+++ b/data/account/votingRows_test.go
@@ -173,17 +173,20 @@ func TestComputeVotingDelta(t *testing.T) {
 	current, _, _ := secrets.PersistentState()
 
 	// noop: persisted state matches memory
-	d := computeVotingDelta(&current, secrets)
+	d, err := computeVotingDelta(&current, secrets)
+	a.NoError(err)
 	a.True(d.noop)
 
 	// same-batch advance
 	older := current
 	older.FirstOffset = current.FirstOffset - 2
-	d = computeVotingDelta(&older, secrets)
+	d, err = computeVotingDelta(&older, secrets)
+	a.NoError(err)
 	a.False(d.noop)
 	a.False(d.fullRewrite)
 	a.False(d.replaceAllOffsets)
 	a.Equal(current.FirstOffset, d.deleteOffsetsBelow)
+	a.Equal(int64(2), d.expectedOffsetDeletes)
 	a.Zero(d.deleteBatchesBelow)
 	a.Empty(d.insertBatches)
 	a.Empty(d.insertOffsets)
@@ -193,33 +196,49 @@ func TestComputeVotingDelta(t *testing.T) {
 	prevBatch := current
 	prevBatch.FirstBatch = current.FirstBatch - 2
 	prevBatch.FirstOffset = 5
-	d = computeVotingDelta(&prevBatch, secrets)
+	d, err = computeVotingDelta(&prevBatch, secrets)
+	a.NoError(err)
 	a.False(d.noop)
 	a.False(d.fullRewrite)
 	a.True(d.replaceAllOffsets)
 	a.Equal(current.FirstBatch, d.deleteBatchesBelow)
+	a.Equal(int64(2), d.expectedBatchDeletes)
 	a.Empty(d.insertBatches)
 	a.Equal(len(secrets.Offsets), len(d.insertOffsets))
+	a.Equal(current.FirstBatch-1, d.offsetsBatch)
 	a.NotNil(d.newScalars)
 
 	// nil old: full rewrite
-	d = computeVotingDelta(nil, secrets)
+	d, err = computeVotingDelta(nil, secrets)
+	a.NoError(err)
 	a.True(d.fullRewrite)
 	a.Equal(len(secrets.Batches), len(d.insertBatches))
 	a.Equal(len(secrets.Offsets), len(d.insertOffsets))
+	a.Equal(current.FirstBatch-1, d.offsetsBatch)
 	a.NotNil(d.newScalars)
 
 	// legacy whole-blob persisted state: full rewrite
 	legacy := secrets.Snapshot().OneTimeSignatureSecretsPersistent
 	a.NotEmpty(legacy.Batches)
-	d = computeVotingDelta(&legacy, secrets)
+	d, err = computeVotingDelta(&legacy, secrets)
+	a.NoError(err)
 	a.True(d.fullRewrite)
 
-	// persisted state ahead of memory: full rewrite
+	// persisted state ahead of memory: forward security forbids moving the
+	// deletion cursor backward, so this is an error rather than a rewrite
 	ahead := current
 	ahead.FirstBatch = current.FirstBatch + 1
-	d = computeVotingDelta(&ahead, secrets)
-	a.True(d.fullRewrite)
+	_, err = computeVotingDelta(&ahead, secrets)
+	a.ErrorContains(err, "refusing to resurrect")
+	aheadOffset := current
+	aheadOffset.FirstOffset = current.FirstOffset + 1
+	_, err = computeVotingDelta(&aheadOffset, secrets)
+	a.ErrorContains(err, "refusing to resurrect")
+	// a legacy blob ahead of memory is refused as well
+	legacyAhead := legacy
+	legacyAhead.FirstBatch = current.FirstBatch + 1
+	_, err = computeVotingDelta(&legacyAhead, secrets)
+	a.ErrorContains(err, "refusing to resurrect")
 
 	// end-of-key-life: DeleteBeforeFineGrained clears the remaining subkeys
 	// of a key on its last batch without advancing either scalar; the delta
@@ -234,7 +253,8 @@ func TestComputeVotingDelta(t *testing.T) {
 	afterState, _, _ := spent.PersistentState()
 	a.Equal(persisted.FirstBatch, afterState.FirstBatch) // scalars did not move
 	a.Equal(persisted.FirstOffset, afterState.FirstOffset)
-	d = computeVotingDelta(&persisted, spent)
+	d, err = computeVotingDelta(&persisted, spent)
+	a.NoError(err)
 	a.False(d.noop)
 	a.True(d.clearAllRows)
 	a.Nil(d.newScalars)
@@ -330,6 +350,131 @@ func TestDeleteOldKeysEndOfLife(t *testing.T) {
 	// subsequent rounds on the dead key stay cheap and consistent
 	a.NoError(<-part.DeleteOldKeys(basics.Round(315), proto))
 	a.Zero(countTableRows(a, partDB, "OtsOffsets"))
+}
+
+// TestDeleteOldKeysRefusesStaleDisk verifies the forward-security monotonic
+// guard: when the persisted deletion cursor is ahead of memory, the write is
+// refused instead of resurrecting deleted keys.
+func TestDeleteOldKeysRefusesStaleDisk(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	a := require.New(t)
+	const dilution = 10
+	part, partDB := makeSmallTestKey(t, a, 0, 300, dilution)
+	defer closeDBS(partDB)
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	a.NoError(<-part.DeleteOldKeys(basics.Round(25), proto))
+	batchRows := countTableRows(a, partDB, "OtsBatches")
+	offsetRows := countTableRows(a, partDB, "OtsOffsets")
+
+	// plant a persisted cursor from the future
+	future, _, _ := part.Voting.PersistentState()
+	future.FirstBatch += 5
+	err := partDB.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.Exec("UPDATE ParticipationAccount SET voting=?", protocol.Encode(&future))
+		return err
+	})
+	a.NoError(err)
+
+	err = <-part.DeleteOldKeys(basics.Round(26), proto)
+	a.ErrorContains(err, "refusing to resurrect")
+
+	// nothing was written
+	a.Equal(batchRows, countTableRows(a, partDB, "OtsBatches"))
+	a.Equal(offsetRows, countTableRows(a, partDB, "OtsOffsets"))
+}
+
+// TestRestoreDetectsMissingRows verifies truncated subkey tables are reported
+// as corruption instead of loading a key that silently cannot vote.
+func TestRestoreDetectsMissingRows(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	a := require.New(t)
+	const dilution = 10
+	part, partDB := makeSmallTestKey(t, a, 0, 300, dilution)
+	defer closeDBS(partDB)
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	a.NoError(<-part.DeleteOldKeys(basics.Round(25), proto))
+
+	// sanity: loads fine before the damage
+	_, err := RestoreParticipationUnmigrated(partDB)
+	a.NoError(err)
+
+	// drop the last batch row: count check fires
+	err = partDB.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.Exec("DELETE FROM OtsBatches WHERE batch=(SELECT MAX(batch) FROM OtsBatches)")
+		return err
+	})
+	a.NoError(err)
+	_, err = RestoreParticipationUnmigrated(partDB)
+	a.ErrorContains(err, "missing or extra rows")
+}
+
+// TestRestoreDetectsWrongOffsetBatch verifies an offset row attributed to the
+// wrong batch is reported as corruption.
+func TestRestoreDetectsWrongOffsetBatch(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	a := require.New(t)
+	const dilution = 10
+	part, partDB := makeSmallTestKey(t, a, 0, 300, dilution)
+	defer closeDBS(partDB)
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	a.NoError(<-part.DeleteOldKeys(basics.Round(25), proto))
+	a.NotZero(countTableRows(a, partDB, "OtsOffsets"))
+
+	err := partDB.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.Exec("UPDATE OtsOffsets SET batch=batch+1 WHERE off=(SELECT MIN(off) FROM OtsOffsets)")
+		return err
+	})
+	a.NoError(err)
+	_, err = RestoreParticipationUnmigrated(partDB)
+	a.ErrorContains(err, "expected batch")
+}
+
+// TestMigrationRollsBackOnFailure verifies a failing v3-to-v4 migration
+// leaves the file at version 3 with none of the new tables behind.
+func TestMigrationRollsBackOnFailure(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	a := require.New(t)
+	part, tmpDB := makeSmallTestKey(t, a, 0, 300, 10)
+	defer closeDBS(tmpDB)
+
+	partDB, err := db.MakeAccessor(t.Name()+"_v3", false, true)
+	a.NoError(err)
+	defer closeDBS(partDB)
+	a.NoError(setupTestDBAtVer3(partDB, part.Participation))
+
+	// mangle the voting blob so the conversion fails mid-transaction
+	err = partDB.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		var raw []byte
+		if err := tx.QueryRow("SELECT voting FROM ParticipationAccount").Scan(&raw); err != nil {
+			return err
+		}
+		_, err := tx.Exec("UPDATE ParticipationAccount SET voting=?", raw[:len(raw)/2])
+		return err
+	})
+	a.NoError(err)
+
+	a.Error(Migrate(partDB))
+
+	// the whole migration transaction rolled back
+	versions, err := getSchemaVersions(partDB)
+	a.NoError(err)
+	a.Equal(3, versions[PartTableSchemaName])
+	err = partDB.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		var n int
+		if err := tx.QueryRow("SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('OtsBatches', 'OtsOffsets')").Scan(&n); err != nil {
+			return err
+		}
+		require.Zero(t, n, "migration tables survived the rollback")
+		return nil
+	})
+	a.NoError(err)
 }
 
 // TestDeleteOldKeysLegacyBlobSelfHeals plants a legacy whole-secrets blob in

--- a/data/account/votingRows_test.go
+++ b/data/account/votingRows_test.go
@@ -218,24 +218,62 @@ func TestComputeVotingDelta(t *testing.T) {
 	_, err = computeVotingDelta(&legacyAhead, secrets)
 	a.ErrorContains(err, "refusing to resurrect")
 
-	// end-of-key-life: DeleteBeforeFineGrained clears the remaining subkeys
-	// of a key on its last batch without advancing either scalar; the delta
-	// must clear the rows rather than report a noop
+	// end-of-key-life: moving past the final batch consumes its remaining
+	// offsets and advances FirstOffset to the batch end, so exhaustion is
+	// distinguishable from a live final batch and persists as an exact trim
 	spent := crypto.GenerateOneTimeSignatureSecrets(0, 4)
 	spent.DeleteBeforeFineGrained(crypto.OneTimeSignatureIdentifier{Batch: 3, Offset: 2}, dilution)
 	a.NotEmpty(spent.Offsets) // final batch expanded
 	a.Empty(spent.Batches)
-	persisted, _, _ := spent.PersistentState()
+	persisted, _, numOffsets := spent.PersistentState()
 	spent.DeleteBeforeFineGrained(crypto.OneTimeSignatureIdentifier{Batch: 4, Offset: 0}, dilution)
 	a.Empty(spent.Offsets)
 	afterState, _, _ := spent.PersistentState()
-	a.Equal(persisted.FirstBatch, afterState.FirstBatch) // scalars did not move
-	a.Equal(persisted.FirstOffset, afterState.FirstOffset)
+	a.Equal(persisted.FirstBatch, afterState.FirstBatch)
+	a.Equal(uint64(dilution), afterState.FirstOffset)
 	d, err = computeVotingDelta(&persisted, spent)
+	a.NoError(err)
+	a.Equal(uint64(dilution), d.deleteOffsetsBelow)
+	a.Equal(int64(numOffsets), d.expectedOffsetDeletes)
+
+	// an exhausted key whose stored cursor did not move (legacy encoding of
+	// exhaustion) still gets its rows cleared rather than a noop
+	d, err = computeVotingDelta(&afterState, spent)
 	a.NoError(err)
 	a.False(d.noop)
 	a.True(d.clearAllRows)
 	a.Nil(d.newScalars)
+}
+
+// TestDeleteOldKeysFailsClosedOnCorruptScalars verifies an undecodable
+// persisted cursor refuses to write (a rewrite from possibly-stale memory
+// could resurrect retired keys) and marks the file as corrupt for quarantine.
+func TestDeleteOldKeysFailsClosedOnCorruptScalars(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	a := require.New(t)
+	const dilution = 10
+	part, partDB := makeSmallTestKey(t, a, 0, 300, dilution)
+	defer closeDBS(partDB)
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	a.NoError(<-part.DeleteOldKeys(basics.Round(25), proto))
+	batchRows := countTableRows(a, partDB, "OtsBatches")
+	offsetRows := countTableRows(a, partDB, "OtsOffsets")
+
+	err := partDB.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.Exec("UPDATE ParticipationAccount SET voting=?", []byte{0xff, 0x00})
+		return err
+	})
+	a.NoError(err)
+
+	err = <-part.DeleteOldKeys(basics.Round(26), proto)
+	a.ErrorContains(err, "undecodable")
+	a.Equal(batchRows, countTableRows(a, partDB, "OtsBatches"), "rows rewritten despite undecodable cursor")
+	a.Equal(offsetRows, countTableRows(a, partDB, "OtsOffsets"))
+
+	_, err = RestoreParticipationUnmigrated(partDB)
+	a.ErrorIs(err, ErrCorruptedVotingData)
 }
 
 func TestDeleteOldKeysIncremental(t *testing.T) {
@@ -389,7 +427,7 @@ func TestRestoreDetectsCorruptRows(t *testing.T) {
 			_, err = RestoreParticipationUnmigrated(partDB)
 			a.ErrorContains(err, tc.wantErr)
 			// the sentinel lets the node quarantine the file as *.old
-			a.ErrorIs(err, ErrCorruptedVotingRows)
+			a.ErrorIs(err, ErrCorruptedVotingData)
 		})
 	}
 }

--- a/data/account/votingRows_test.go
+++ b/data/account/votingRows_test.go
@@ -170,7 +170,7 @@ func TestComputeVotingDelta(t *testing.T) {
 
 	secrets := crypto.GenerateOneTimeSignatureSecrets(0, 10)
 	secrets.DeleteBeforeFineGrained(crypto.OneTimeSignatureIdentifier{Batch: 2, Offset: 3}, dilution)
-	current := secrets.PersistentScalars()
+	current, _, _ := secrets.PersistentState()
 
 	// noop: persisted state matches memory
 	d := computeVotingDelta(&current, secrets)
@@ -220,6 +220,24 @@ func TestComputeVotingDelta(t *testing.T) {
 	ahead.FirstBatch = current.FirstBatch + 1
 	d = computeVotingDelta(&ahead, secrets)
 	a.True(d.fullRewrite)
+
+	// end-of-key-life: DeleteBeforeFineGrained clears the remaining subkeys
+	// of a key on its last batch without advancing either scalar; the delta
+	// must clear the rows rather than report a noop
+	spent := crypto.GenerateOneTimeSignatureSecrets(0, 4)
+	spent.DeleteBeforeFineGrained(crypto.OneTimeSignatureIdentifier{Batch: 3, Offset: 2}, dilution)
+	a.NotEmpty(spent.Offsets) // final batch expanded
+	a.Empty(spent.Batches)
+	persisted, _, _ := spent.PersistentState()
+	spent.DeleteBeforeFineGrained(crypto.OneTimeSignatureIdentifier{Batch: 4, Offset: 0}, dilution)
+	a.Empty(spent.Offsets)
+	afterState, _, _ := spent.PersistentState()
+	a.Equal(persisted.FirstBatch, afterState.FirstBatch) // scalars did not move
+	a.Equal(persisted.FirstOffset, afterState.FirstOffset)
+	d = computeVotingDelta(&persisted, spent)
+	a.False(d.noop)
+	a.True(d.clearAllRows)
+	a.Nil(d.newScalars)
 }
 
 func TestDeleteOldKeysIncremental(t *testing.T) {
@@ -274,6 +292,44 @@ func TestDeleteOldKeysBatchRollover(t *testing.T) {
 	restored, err := RestoreParticipationUnmigrated(partDB)
 	a.NoError(err)
 	a.Equal(encodedVotingSnapshot(part.Voting), encodedVotingSnapshot(restored.Voting))
+}
+
+// TestDeleteOldKeysEndOfLife walks a key past its final batch and verifies
+// every subkey row is erased from the file — the forward-security guarantee
+// at the end-of-key-life transition, where DeleteBeforeFineGrained clears the
+// remaining offsets without advancing the scalars.
+func TestDeleteOldKeysEndOfLife(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	a := require.New(t)
+	const dilution = 10
+	part, partDB := makeSmallTestKey(t, a, 0, 300, dilution) // batches 0..30, coverage through round 309
+	defer closeDBS(partDB)
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+
+	// expand the final batch, then move past the end of the key
+	a.NoError(<-part.DeleteOldKeys(basics.Round(305), proto))
+	a.NotZero(countTableRows(a, partDB, "OtsOffsets"))
+	a.NoError(<-part.DeleteOldKeys(basics.Round(311), proto))
+
+	a.Empty(part.Voting.Offsets)
+	a.Zero(countTableRows(a, partDB, "OtsOffsets"), "retired offset subkeys survived on disk")
+	a.Zero(countTableRows(a, partDB, "OtsBatches"))
+
+	// a fresh restore must not resurrect any signing capability
+	restored, err := RestoreParticipationUnmigrated(partDB)
+	a.NoError(err)
+	a.Empty(restored.Voting.Offsets)
+	a.Empty(restored.Voting.Batches)
+	id := basics.OneTimeIDForRound(305, dilution)
+	msg := crypto.OneTimeSignatureSubkeyBatchID{Batch: 1}
+	sig := restored.Voting.Sign(id, msg)
+	a.False(part.Voting.OneTimeSignatureVerifier.Verify(id, msg, sig), "restored secrets signed a retired round")
+
+	// subsequent rounds on the dead key stay cheap and consistent
+	a.NoError(<-part.DeleteOldKeys(basics.Round(315), proto))
+	a.Zero(countTableRows(a, partDB, "OtsOffsets"))
 }
 
 // TestDeleteOldKeysLegacyBlobSelfHeals plants a legacy whole-secrets blob in

--- a/data/account/votingRows_test.go
+++ b/data/account/votingRows_test.go
@@ -1,0 +1,313 @@
+// Copyright (C) 2019-2026 Algorand Foundation Ltd.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package account
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/algorand/go-algorand/util/db"
+)
+
+// makeSmallTestKey creates a participation key with a small dilution so batch
+// rollovers happen quickly in tests.
+func makeSmallTestKey(t *testing.T, a *require.Assertions, first, last basics.Round, dilution uint64) (PersistedParticipation, db.Accessor) {
+	partDB, err := db.MakeAccessor(t.Name()+"_part", false, true)
+	a.NoError(err)
+
+	var addr basics.Address
+	crypto.RandBytes(addr[:])
+	part, err := FillDBWithParticipationKeys(partDB, addr, first, last, dilution)
+	a.NoError(err)
+	return part, partDB
+}
+
+func countTableRows(a *require.Assertions, store db.Accessor, table string) (n int) {
+	err := store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRow("SELECT count(*) FROM " + table).Scan(&n)
+	})
+	a.NoError(err)
+	return n
+}
+
+func readVotingColumn(a *require.Assertions, store db.Accessor) (raw []byte) {
+	err := store.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRow("SELECT voting FROM ParticipationAccount").Scan(&raw)
+	})
+	a.NoError(err)
+	return raw
+}
+
+func encodedVotingSnapshot(secrets *crypto.OneTimeSignatureSecrets) []byte {
+	snap := secrets.Snapshot()
+	return protocol.Encode(&snap)
+}
+
+func setupTestDBAtVer3(partDB db.Accessor, part Participation) error {
+	rawVRF := protocol.Encode(part.VRF)
+	voting := part.Voting.Snapshot()
+	rawVoting := protocol.Encode(&voting)
+	rawStateProof := protocol.Encode(part.StateProofSecrets)
+
+	return partDB.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.Exec(`CREATE TABLE ParticipationAccount (
+		parent BLOB,
+
+		vrf BLOB,
+		voting BLOB,
+
+		firstValid INTEGER,
+		lastValid INTEGER,
+
+		keyDilution INTEGER NOT NULL DEFAULT 0,
+		stateProof BLOB
+	);`)
+		if err != nil {
+			return err
+		}
+
+		if err := setupSchemaForTest(tx, 3); err != nil {
+			return err
+		}
+		_, err = tx.Exec("INSERT INTO ParticipationAccount (parent, vrf, voting, firstValid, lastValid, keyDilution, stateProof) VALUES (?, ?, ?, ?, ?, ?, ?)",
+			part.Parent[:], rawVRF, rawVoting, part.FirstValid, part.LastValid, part.KeyDilution, rawStateProof)
+		return err
+	})
+}
+
+func TestMigrateFromVersion3(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	a := require.New(t)
+
+	// build a mid-life key: offsets expanded, some batches consumed
+	part, tmpDB := makeSmallTestKey(t, a, 0, 300, 10)
+	defer closeDBS(tmpDB)
+	part.Voting.DeleteBeforeFineGrained(basics.OneTimeIDForRound(55, 10), 10)
+	a.NotEmpty(part.Voting.Offsets)
+	a.NotZero(part.Voting.FirstBatch)
+
+	partDB, err := db.MakeAccessor(t.Name()+"_v3", false, true)
+	a.NoError(err)
+	defer closeDBS(partDB)
+
+	a.NoError(setupTestDBAtVer3(partDB, part.Participation))
+	a.NoError(Migrate(partDB))
+
+	versions, err := getSchemaVersions(partDB)
+	a.NoError(err)
+	a.Equal(PartTableSchemaVersion, versions[PartTableSchemaName])
+	a.NoError(testDBContainsAllColumns(partDB))
+
+	a.Equal(len(part.Voting.Batches), countTableRows(a, partDB, "OtsBatches"))
+	a.Equal(len(part.Voting.Offsets), countTableRows(a, partDB, "OtsOffsets"))
+
+	// voting column now holds scalars only
+	var scalars crypto.OneTimeSignatureSecrets
+	a.NoError(protocol.Decode(readVotingColumn(a, partDB), &scalars))
+	a.Empty(scalars.Batches)
+	a.Empty(scalars.Offsets)
+	a.Equal(part.Voting.FirstBatch, scalars.FirstBatch)
+	a.Equal(part.Voting.FirstOffset, scalars.FirstOffset)
+
+	// full restore equals the original
+	restored, err := RestoreParticipation(partDB)
+	a.NoError(err)
+	a.Equal(encodedVotingSnapshot(part.Voting), encodedVotingSnapshot(restored.Voting))
+	a.Equal(part.Parent, restored.Parent)
+	a.Equal(part.KeyDilution, restored.KeyDilution)
+}
+
+func TestPersistCreatesV4(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	a := require.New(t)
+	part, partDB := makeSmallTestKey(t, a, 0, 300, 10)
+	defer closeDBS(partDB)
+
+	versions, err := getSchemaVersions(partDB)
+	a.NoError(err)
+	a.Equal(PartTableSchemaVersion, versions[PartTableSchemaName])
+
+	// fresh keys have batch subkeys only, no offsets yet
+	a.Equal(len(part.Voting.Batches), countTableRows(a, partDB, "OtsBatches"))
+	a.NotZero(countTableRows(a, partDB, "OtsBatches"))
+	a.Zero(countTableRows(a, partDB, "OtsOffsets"))
+
+	var scalars crypto.OneTimeSignatureSecrets
+	a.NoError(protocol.Decode(readVotingColumn(a, partDB), &scalars))
+	a.Empty(scalars.Batches)
+	a.Empty(scalars.Offsets)
+}
+
+func TestComputeVotingDelta(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	a := require.New(t)
+	const dilution = 8
+
+	secrets := crypto.GenerateOneTimeSignatureSecrets(0, 10)
+	secrets.DeleteBeforeFineGrained(crypto.OneTimeSignatureIdentifier{Batch: 2, Offset: 3}, dilution)
+	current := secrets.PersistentScalars()
+
+	// noop: persisted state matches memory
+	d := computeVotingDelta(&current, secrets)
+	a.True(d.noop)
+
+	// same-batch advance
+	older := current
+	older.FirstOffset = current.FirstOffset - 2
+	d = computeVotingDelta(&older, secrets)
+	a.False(d.noop)
+	a.False(d.fullRewrite)
+	a.False(d.replaceAllOffsets)
+	a.Equal(current.FirstOffset, d.deleteOffsetsBelow)
+	a.Zero(d.deleteBatchesBelow)
+	a.Empty(d.insertBatches)
+	a.Empty(d.insertOffsets)
+	a.NotNil(d.newScalars)
+
+	// batch rollover (single and multi-batch jump behave identically)
+	prevBatch := current
+	prevBatch.FirstBatch = current.FirstBatch - 2
+	prevBatch.FirstOffset = 5
+	d = computeVotingDelta(&prevBatch, secrets)
+	a.False(d.noop)
+	a.False(d.fullRewrite)
+	a.True(d.replaceAllOffsets)
+	a.Equal(current.FirstBatch, d.deleteBatchesBelow)
+	a.Empty(d.insertBatches)
+	a.Equal(len(secrets.Offsets), len(d.insertOffsets))
+	a.NotNil(d.newScalars)
+
+	// nil old: full rewrite
+	d = computeVotingDelta(nil, secrets)
+	a.True(d.fullRewrite)
+	a.Equal(len(secrets.Batches), len(d.insertBatches))
+	a.Equal(len(secrets.Offsets), len(d.insertOffsets))
+	a.NotNil(d.newScalars)
+
+	// legacy whole-blob persisted state: full rewrite
+	legacy := secrets.Snapshot().OneTimeSignatureSecretsPersistent
+	a.NotEmpty(legacy.Batches)
+	d = computeVotingDelta(&legacy, secrets)
+	a.True(d.fullRewrite)
+
+	// persisted state ahead of memory: full rewrite
+	ahead := current
+	ahead.FirstBatch = current.FirstBatch + 1
+	d = computeVotingDelta(&ahead, secrets)
+	a.True(d.fullRewrite)
+}
+
+func TestDeleteOldKeysIncremental(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	a := require.New(t)
+	const dilution = 10
+	part, partDB := makeSmallTestKey(t, a, 0, 300, dilution)
+	defer closeDBS(partDB)
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+
+	prevBatchRows := countTableRows(a, partDB, "OtsBatches")
+	for r := basics.Round(1); r <= 120; r++ {
+		firstBatchBefore := part.Voting.FirstBatch
+		a.NoError(<-part.DeleteOldKeys(r, proto))
+
+		// persisted state reconstructs to exactly the in-memory state
+		restored, err := RestoreParticipationUnmigrated(partDB)
+		a.NoError(err)
+		a.Equal(encodedVotingSnapshot(part.Voting), encodedVotingSnapshot(restored.Voting), "round %d", r)
+
+		// batch rows only churn when a batch is consumed (expanded into offsets)
+		batchRows := countTableRows(a, partDB, "OtsBatches")
+		if part.Voting.FirstBatch == firstBatchBefore {
+			a.Equal(prevBatchRows, batchRows, "batch rows changed off-rollover at round %d", r)
+		} else {
+			a.Less(batchRows, prevBatchRows, "batch rows not trimmed at rollover round %d", r)
+		}
+		prevBatchRows = batchRows
+	}
+}
+
+func TestDeleteOldKeysBatchRollover(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	a := require.New(t)
+	const dilution = 10
+	part, partDB := makeSmallTestKey(t, a, 0, 300, dilution)
+	defer closeDBS(partDB)
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+
+	// advance into batch 3 in one jump
+	const round = 3*dilution + 4
+	a.NoError(<-part.DeleteOldKeys(round, proto))
+
+	a.Equal(len(part.Voting.Batches), countTableRows(a, partDB, "OtsBatches"))
+	a.Equal(len(part.Voting.Offsets), countTableRows(a, partDB, "OtsOffsets"))
+	a.NotZero(countTableRows(a, partDB, "OtsOffsets"))
+
+	restored, err := RestoreParticipationUnmigrated(partDB)
+	a.NoError(err)
+	a.Equal(encodedVotingSnapshot(part.Voting), encodedVotingSnapshot(restored.Voting))
+}
+
+// TestDeleteOldKeysLegacyBlobSelfHeals plants a legacy whole-secrets blob in
+// the voting column of a v4 file and verifies the next DeleteOldKeys converts
+// it to rows.
+func TestDeleteOldKeysLegacyBlobSelfHeals(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	a := require.New(t)
+	const dilution = 10
+	part, partDB := makeSmallTestKey(t, a, 0, 300, dilution)
+	defer closeDBS(partDB)
+
+	// simulate stale state: full legacy blob in the voting column, no rows
+	legacyBlob := encodedVotingSnapshot(part.Voting)
+	err := partDB.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.Exec("DELETE FROM OtsBatches"); err != nil {
+			return err
+		}
+		if _, err := tx.Exec("DELETE FROM OtsOffsets"); err != nil {
+			return err
+		}
+		_, err := tx.Exec("UPDATE ParticipationAccount SET voting=?", legacyBlob)
+		return err
+	})
+	a.NoError(err)
+
+	proto := config.Consensus[protocol.ConsensusCurrentVersion]
+	a.NoError(<-part.DeleteOldKeys(basics.Round(25), proto))
+
+	a.Equal(len(part.Voting.Batches), countTableRows(a, partDB, "OtsBatches"))
+	a.Equal(len(part.Voting.Offsets), countTableRows(a, partDB, "OtsOffsets"))
+
+	restored, err := RestoreParticipationUnmigrated(partDB)
+	a.NoError(err)
+	a.Equal(encodedVotingSnapshot(part.Voting), encodedVotingSnapshot(restored.Voting))
+}

--- a/data/account/votingRows_test.go
+++ b/data/account/votingRows_test.go
@@ -140,28 +140,6 @@ func TestMigrateFromVersion3(t *testing.T) {
 	a.Equal(part.KeyDilution, restored.KeyDilution)
 }
 
-func TestPersistCreatesV4(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	a := require.New(t)
-	part, partDB := makeSmallTestKey(t, a, 0, 300, 10)
-	defer closeDBS(partDB)
-
-	versions, err := getSchemaVersions(partDB)
-	a.NoError(err)
-	a.Equal(PartTableSchemaVersion, versions[PartTableSchemaName])
-
-	// fresh keys have batch subkeys only, no offsets yet
-	a.Equal(len(part.Voting.Batches), countTableRows(a, partDB, "OtsBatches"))
-	a.NotZero(countTableRows(a, partDB, "OtsBatches"))
-	a.Zero(countTableRows(a, partDB, "OtsOffsets"))
-
-	var scalars crypto.OneTimeSignatureSecrets
-	a.NoError(protocol.Decode(readVotingColumn(a, partDB), &scalars))
-	a.Empty(scalars.Batches)
-	a.Empty(scalars.Offsets)
-}
-
 func TestComputeVotingDelta(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
@@ -270,6 +248,16 @@ func TestDeleteOldKeysIncremental(t *testing.T) {
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
+	// a fresh Persist stores one row per batch subkey, no offsets, and a
+	// scalar-only voting column (a whole-secrets blob would silently defeat
+	// the row-oriented format through the legacy tolerance)
+	a.Equal(len(part.Voting.Batches), countTableRows(a, partDB, "OtsBatches"))
+	a.Zero(countTableRows(a, partDB, "OtsOffsets"))
+	var freshScalars crypto.OneTimeSignatureSecrets
+	a.NoError(protocol.Decode(readVotingColumn(a, partDB), &freshScalars))
+	a.Empty(freshScalars.Batches)
+	a.Empty(freshScalars.Offsets)
+
 	prevBatchRows := countTableRows(a, partDB, "OtsBatches")
 	for r := basics.Round(1); r <= 120; r++ {
 		firstBatchBefore := part.Voting.FirstBatch
@@ -291,29 +279,6 @@ func TestDeleteOldKeysIncremental(t *testing.T) {
 	}
 }
 
-func TestDeleteOldKeysBatchRollover(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	a := require.New(t)
-	const dilution = 10
-	part, partDB := makeSmallTestKey(t, a, 0, 300, dilution)
-	defer closeDBS(partDB)
-
-	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-
-	// advance into batch 3 in one jump
-	const round = 3*dilution + 4
-	a.NoError(<-part.DeleteOldKeys(round, proto))
-
-	a.Equal(len(part.Voting.Batches), countTableRows(a, partDB, "OtsBatches"))
-	a.Equal(len(part.Voting.Offsets), countTableRows(a, partDB, "OtsOffsets"))
-	a.NotZero(countTableRows(a, partDB, "OtsOffsets"))
-
-	restored, err := RestoreParticipationUnmigrated(partDB)
-	a.NoError(err)
-	a.Equal(encodedVotingSnapshot(part.Voting), encodedVotingSnapshot(restored.Voting))
-}
-
 // TestDeleteOldKeysEndOfLife walks a key past its final batch and verifies
 // every subkey row is erased from the file — the forward-security guarantee
 // at the end-of-key-life transition, where DeleteBeforeFineGrained clears the
@@ -328,9 +293,13 @@ func TestDeleteOldKeysEndOfLife(t *testing.T) {
 
 	proto := config.Consensus[protocol.ConsensusCurrentVersion]
 
-	// expand the final batch, then move past the end of the key
+	// expand the final batch (a multi-batch jump from the fresh state), then
+	// move past the end of the key
 	a.NoError(<-part.DeleteOldKeys(basics.Round(305), proto))
 	a.NotZero(countTableRows(a, partDB, "OtsOffsets"))
+	midRestore, err := RestoreParticipationUnmigrated(partDB)
+	a.NoError(err)
+	a.Equal(encodedVotingSnapshot(part.Voting), encodedVotingSnapshot(midRestore.Voting))
 	a.NoError(<-part.DeleteOldKeys(basics.Round(311), proto))
 
 	a.Empty(part.Voting.Offsets)
@@ -385,54 +354,42 @@ func TestDeleteOldKeysRefusesStaleDisk(t *testing.T) {
 	a.Equal(offsetRows, countTableRows(a, partDB, "OtsOffsets"))
 }
 
-// TestRestoreDetectsMissingRows verifies truncated subkey tables are reported
+// TestRestoreDetectsCorruptRows verifies damaged subkey tables are reported
 // as corruption instead of loading a key that silently cannot vote.
-func TestRestoreDetectsMissingRows(t *testing.T) {
+func TestRestoreDetectsCorruptRows(t *testing.T) {
 	partitiontest.PartitionTest(t)
 
-	a := require.New(t)
-	const dilution = 10
-	part, partDB := makeSmallTestKey(t, a, 0, 300, dilution)
-	defer closeDBS(partDB)
+	cases := []struct {
+		name      string
+		tamperSQL string
+		wantErr   string
+	}{
+		{"missingBatchRow", "DELETE FROM OtsBatches WHERE batch=(SELECT MAX(batch) FROM OtsBatches)", "missing or extra rows"},
+		{"wrongOffsetBatch", "UPDATE OtsOffsets SET batch=batch+1 WHERE off=(SELECT MIN(off) FROM OtsOffsets)", "expected batch"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := require.New(t)
+			const dilution = 10
+			part, partDB := makeSmallTestKey(t, a, 0, 300, dilution)
+			defer closeDBS(partDB)
 
-	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-	a.NoError(<-part.DeleteOldKeys(basics.Round(25), proto))
+			proto := config.Consensus[protocol.ConsensusCurrentVersion]
+			a.NoError(<-part.DeleteOldKeys(basics.Round(25), proto))
 
-	// sanity: loads fine before the damage
-	_, err := RestoreParticipationUnmigrated(partDB)
-	a.NoError(err)
+			// sanity: loads fine before the damage
+			_, err := RestoreParticipationUnmigrated(partDB)
+			a.NoError(err)
 
-	// drop the last batch row: count check fires
-	err = partDB.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.Exec("DELETE FROM OtsBatches WHERE batch=(SELECT MAX(batch) FROM OtsBatches)")
-		return err
-	})
-	a.NoError(err)
-	_, err = RestoreParticipationUnmigrated(partDB)
-	a.ErrorContains(err, "missing or extra rows")
-}
-
-// TestRestoreDetectsWrongOffsetBatch verifies an offset row attributed to the
-// wrong batch is reported as corruption.
-func TestRestoreDetectsWrongOffsetBatch(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	a := require.New(t)
-	const dilution = 10
-	part, partDB := makeSmallTestKey(t, a, 0, 300, dilution)
-	defer closeDBS(partDB)
-
-	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-	a.NoError(<-part.DeleteOldKeys(basics.Round(25), proto))
-	a.NotZero(countTableRows(a, partDB, "OtsOffsets"))
-
-	err := partDB.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.Exec("UPDATE OtsOffsets SET batch=batch+1 WHERE off=(SELECT MIN(off) FROM OtsOffsets)")
-		return err
-	})
-	a.NoError(err)
-	_, err = RestoreParticipationUnmigrated(partDB)
-	a.ErrorContains(err, "expected batch")
+			err = partDB.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+				_, err := tx.Exec(tc.tamperSQL)
+				return err
+			})
+			a.NoError(err)
+			_, err = RestoreParticipationUnmigrated(partDB)
+			a.ErrorContains(err, tc.wantErr)
+		})
+	}
 }
 
 // TestMigrationRollsBackOnFailure verifies a failing v3-to-v4 migration
@@ -475,40 +432,4 @@ func TestMigrationRollsBackOnFailure(t *testing.T) {
 		return nil
 	})
 	a.NoError(err)
-}
-
-// TestDeleteOldKeysLegacyBlobSelfHeals plants a legacy whole-secrets blob in
-// the voting column of a v4 file and verifies the next DeleteOldKeys converts
-// it to rows.
-func TestDeleteOldKeysLegacyBlobSelfHeals(t *testing.T) {
-	partitiontest.PartitionTest(t)
-
-	a := require.New(t)
-	const dilution = 10
-	part, partDB := makeSmallTestKey(t, a, 0, 300, dilution)
-	defer closeDBS(partDB)
-
-	// simulate stale state: full legacy blob in the voting column, no rows
-	legacyBlob := encodedVotingSnapshot(part.Voting)
-	err := partDB.Atomic(func(ctx context.Context, tx *sql.Tx) error {
-		if _, err := tx.Exec("DELETE FROM OtsBatches"); err != nil {
-			return err
-		}
-		if _, err := tx.Exec("DELETE FROM OtsOffsets"); err != nil {
-			return err
-		}
-		_, err := tx.Exec("UPDATE ParticipationAccount SET voting=?", legacyBlob)
-		return err
-	})
-	a.NoError(err)
-
-	proto := config.Consensus[protocol.ConsensusCurrentVersion]
-	a.NoError(<-part.DeleteOldKeys(basics.Round(25), proto))
-
-	a.Equal(len(part.Voting.Batches), countTableRows(a, partDB, "OtsBatches"))
-	a.Equal(len(part.Voting.Offsets), countTableRows(a, partDB, "OtsOffsets"))
-
-	restored, err := RestoreParticipationUnmigrated(partDB)
-	a.NoError(err)
-	a.Equal(encodedVotingSnapshot(part.Voting), encodedVotingSnapshot(restored.Voting))
 }

--- a/docs/participation_key_lifecycle.md
+++ b/docs/participation_key_lifecycle.md
@@ -78,12 +78,20 @@ used keys is a small row delete instead of a rewrite of the whole keyset.
 State proof keys follow the same row-per-key pattern in their own table.
 
 Files created by older releases (schema version 3) stored the whole voting
-keyset as one BLOB; they are migrated in place automatically whenever they
-are opened (by **algod**, **goal**, or **algokey**). Schema versions 1 and 2
-predate state proofs — any key stored in such a file expired years ago — and
-are no longer readable; the node renames them to `*.old` and skips them. To rehearse that
-migration without touching the original file — and to see how long algod will
-spend doing it at startup — use:
+keyset as one BLOB. **algod** migrates such a file in place when it loads it
+at startup (and migrates the copy it receives through the REST install
+endpoint), as does `algokey part reparent`; the read-only commands
+(`algokey part info`, `algokey part keyreg --keyfile`,
+`goal account changeonlinestatus --partkeyfile`) read the file as-is without
+migrating it. Once a file is migrated, older releases cannot read it (the node
+renames such files to `*.old` and skips them); rolling back to an older
+release requires a pre-upgrade backup of the file, or generating and
+registering fresh keys. Schema versions 1 and 2 predate state proofs — any
+key stored in such a file expired years ago — and are no longer readable; the
+node renames them to `*.old` and skips them as well.
+
+To rehearse the migration of a version 3 file without touching the original —
+and to see how long algod will spend doing it at startup — use:
 ```
 algokey part migrate --keyfile keys.db
 ```
@@ -92,10 +100,7 @@ snapshot, so it is consistent even if algod has the file open), prints the
 pure migration time, and validates the migrated keys — including the state
 proof secret keys — against the original (skippable with `--no-validation`).
 If algod advances the keys while the validation is running, the comparison
-can report a spurious mismatch; prefer running it against a stopped node. Note that once a file is migrated, older releases cannot
-read it (the node renames such files to `*.old` and skips them); rolling back
-to an older release requires a pre-upgrade backup of the file, or generating
-and registering fresh keys.
+can report a spurious mismatch; prefer running it against a stopped node.
 
 Similar functionality is built into **goal** along with convenience methods to:
 * Generate and install.

--- a/docs/participation_key_lifecycle.md
+++ b/docs/participation_key_lifecycle.md
@@ -77,9 +77,11 @@ This row-per-subkey layout means the per-round forward-security deletion of
 used keys is a small row delete instead of a rewrite of the whole keyset.
 State proof keys follow the same row-per-key pattern in their own table.
 
-Files created by older releases (schema version 3 and below) stored the whole
-voting keyset as one BLOB; they are migrated in place automatically whenever
-they are opened (by **algod**, **goal**, or **algokey**). To rehearse that
+Files created by older releases (schema version 3) stored the whole voting
+keyset as one BLOB; they are migrated in place automatically whenever they
+are opened (by **algod**, **goal**, or **algokey**). Schema versions 1 and 2
+predate state proofs — any key stored in such a file expired years ago — and
+are no longer readable; the node renames them to `*.old` and skips them. To rehearse that
 migration without touching the original file — and to see how long algod will
 spend doing it at startup — use:
 ```

--- a/docs/participation_key_lifecycle.md
+++ b/docs/participation_key_lifecycle.md
@@ -70,9 +70,27 @@ Using **algokey** a set of keys can be generated with the command:
 algokey part generate --first 35000000 --last 36000000 --parent <account-address> --keyfile keys.db
 ```
 
-This creates a SQLite DB file named **keys.db**. The schema is pretty basic,
-consisting of BLOBs for voting keys. State proof keys are also included and are
-a bit more involved in their storage pattern.
+This creates a SQLite DB file named **keys.db**. Metadata and the scalar
+fields of the voting keyset live in a single-row table, while each ephemeral
+voting subkey is stored as its own row (tables **OtsBatches**/**OtsOffsets**).
+This row-per-subkey layout means the per-round forward-security deletion of
+used keys is a small row delete instead of a rewrite of the whole keyset.
+State proof keys follow the same row-per-key pattern in their own table.
+
+Files created by older releases (schema version 3 and below) stored the whole
+voting keyset as one BLOB; they are migrated in place automatically whenever
+they are opened (by **algod**, **goal**, or **algokey**). To rehearse that
+migration without touching the original file — and to see how long algod will
+spend doing it at startup — use:
+```
+algokey part migrate --keyfile keys.db
+```
+This writes a migrated copy to **keys.db.new**, prints the pure migration
+time, and validates the migrated keys against the original (skippable with
+`--no-validation`). Note that once a file is migrated, older releases cannot
+read it (the node renames such files to `*.old` and skips them); rolling back
+to an older release requires a pre-upgrade backup of the file, or generating
+and registering fresh keys.
 
 Similar functionality is built into **goal** along with convenience methods to:
 * Generate and install.
@@ -118,7 +136,13 @@ votes are cast for the same account causing both to be ignored.
 ## Key Storage
 
 Once installed keys are stored in the **Participation Registry**. This is a
-service that wraps a SQLite file for storage. Once installed, keys are assigned
+service that wraps a SQLite file for storage. Like the key files, the registry
+stores each ephemeral voting subkey as its own row (tables
+**VotingBatches**/**VotingOffsets**), so the per-round deletion of used keys
+writes only the consumed rows. A registry created by an older release is
+upgraded automatically at node startup; older releases refuse to open the
+upgraded registry, so rolling back requires deleting **partregistry.sqlite**
+and re-installing the keys. Once installed, keys are assigned
 an ID, which is referred to as **<participation-ID>** below. The ID is a hash
 built from parts of the participation key metadata. There are additional Admin
 API endpoints available to manage the registry:

--- a/docs/participation_key_lifecycle.md
+++ b/docs/participation_key_lifecycle.md
@@ -85,9 +85,12 @@ spend doing it at startup — use:
 ```
 algokey part migrate --keyfile keys.db
 ```
-This writes a migrated copy to **keys.db.new**, prints the pure migration
-time, and validates the migrated keys against the original (skippable with
-`--no-validation`). Note that once a file is migrated, older releases cannot
+This writes a migrated copy to **keys.db.new** (taken as an atomic SQLite
+snapshot, so it is consistent even if algod has the file open), prints the
+pure migration time, and validates the migrated keys — including the state
+proof secret keys — against the original (skippable with `--no-validation`).
+If algod advances the keys while the validation is running, the comparison
+can report a spurious mismatch; prefer running it against a stopped node. Note that once a file is migrated, older releases cannot
 read it (the node renames such files to `*.old` and skips them); rolling back
 to an older release requires a pre-upgrade backup of the file, or generating
 and registering fresh keys.

--- a/node/node.go
+++ b/node/node.go
@@ -1064,10 +1064,9 @@ func (node *AlgorandFullNode) loadParticipationKeys() error {
 		if err != nil {
 			handle.Close()
 			if err == account.ErrUnsupportedSchema {
-				node.log.Infof("Loaded participation keys from storage: %s %s", part.Address(), info.Name())
 				node.log.Warnf("loadParticipationKeys: not loading unsupported participation key: %s; renaming to *.old", info.Name())
 				fullname := filepath.Join(genesisDir, info.Name())
-				renamedFileName := filepath.Join(fullname, ".old")
+				renamedFileName := fullname + ".old"
 				err = os.Rename(fullname, renamedFileName)
 				if err != nil {
 					node.log.Warnf("loadParticipationKeys: failed to rename unsupported participation key file '%s' to '%s': %v", fullname, renamedFileName, err)

--- a/node/node.go
+++ b/node/node.go
@@ -1063,7 +1063,7 @@ func (node *AlgorandFullNode) loadParticipationKeys() error {
 		part, err := account.RestoreParticipationWithSecrets(handle)
 		if err != nil {
 			handle.Close()
-			if errors.Is(err, account.ErrUnsupportedSchema) || errors.Is(err, account.ErrCorruptedVotingRows) {
+			if errors.Is(err, account.ErrUnsupportedSchema) || errors.Is(err, account.ErrCorruptedVotingData) {
 				node.log.Warnf("loadParticipationKeys: not loading participation key %s (%v); renaming to *.old", info.Name(), err)
 				fullname := filepath.Join(genesisDir, info.Name())
 				// pick a name that does not clobber a previous backup; on any

--- a/node/node.go
+++ b/node/node.go
@@ -1066,7 +1066,14 @@ func (node *AlgorandFullNode) loadParticipationKeys() error {
 			if err == account.ErrUnsupportedSchema {
 				node.log.Warnf("loadParticipationKeys: not loading unsupported participation key: %s; renaming to *.old", info.Name())
 				fullname := filepath.Join(genesisDir, info.Name())
+				// pick a name that does not clobber a previous backup
 				renamedFileName := fullname + ".old"
+				for i := 1; ; i++ {
+					if _, statErr := os.Stat(renamedFileName); os.IsNotExist(statErr) {
+						break
+					}
+					renamedFileName = fmt.Sprintf("%s.old.%d", fullname, i)
+				}
 				err = os.Rename(fullname, renamedFileName)
 				if err != nil {
 					node.log.Warnf("loadParticipationKeys: failed to rename unsupported participation key file '%s' to '%s': %v", fullname, renamedFileName, err)

--- a/node/node.go
+++ b/node/node.go
@@ -1063,13 +1063,15 @@ func (node *AlgorandFullNode) loadParticipationKeys() error {
 		part, err := account.RestoreParticipationWithSecrets(handle)
 		if err != nil {
 			handle.Close()
-			if err == account.ErrUnsupportedSchema {
-				node.log.Warnf("loadParticipationKeys: not loading unsupported participation key: %s; renaming to *.old", info.Name())
+			if errors.Is(err, account.ErrUnsupportedSchema) || errors.Is(err, account.ErrCorruptedVotingRows) {
+				node.log.Warnf("loadParticipationKeys: not loading participation key %s (%v); renaming to *.old", info.Name(), err)
 				fullname := filepath.Join(genesisDir, info.Name())
-				// pick a name that does not clobber a previous backup
+				// pick a name that does not clobber a previous backup; on any
+				// Stat error other than not-exist, stop probing and let the
+				// rename surface the underlying problem
 				renamedFileName := fullname + ".old"
 				for i := 1; ; i++ {
-					if _, statErr := os.Stat(renamedFileName); os.IsNotExist(statErr) {
+					if _, statErr := os.Stat(renamedFileName); statErr != nil {
 						break
 					}
 					renamedFileName = fmt.Sprintf("%s.old.%d", fullname, i)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -709,8 +709,11 @@ func TestLoadParticipationKeysRenamesUnsupported(t *testing.T) {
 
 	n, err := MakeFull(logging.TestingLog(t), testDirectory, config.GetDefaultLocal(), []string{}, genesis)
 	require.NoError(t, err)
-	require.NoError(t, n.Start())
-	n.Stop()
+	err = n.Start()
+	if err == nil {
+		defer n.Stop()
+	}
+	require.NoError(t, err)
 
 	require.NoFileExists(t, partfile)
 	require.FileExists(t, partfile+".old")

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -707,6 +707,10 @@ func TestLoadParticipationKeysRenamesUnsupported(t *testing.T) {
 	require.NoError(t, err)
 	partdb.Close()
 
+	// a backup from an earlier rename must not be clobbered
+	previousBackup := []byte("previous unsupported key backup")
+	require.NoError(t, os.WriteFile(partfile+".old", previousBackup, 0600))
+
 	n, err := MakeFull(logging.TestingLog(t), testDirectory, config.GetDefaultLocal(), []string{}, genesis)
 	require.NoError(t, err)
 	err = n.Start()
@@ -716,7 +720,10 @@ func TestLoadParticipationKeysRenamesUnsupported(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoFileExists(t, partfile)
-	require.FileExists(t, partfile+".old")
+	require.FileExists(t, partfile+".old.1")
+	preserved, err := os.ReadFile(partfile + ".old")
+	require.NoError(t, err)
+	require.Equal(t, previousBackup, preserved)
 }
 
 // TestConfiguredDataDirs tests to see that when HotDataDir and ColdDataDir are set, underlying resources are created in the correct locations

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -18,6 +18,8 @@ package node
 
 import (
 	"bytes"
+	"context"
+	"database/sql"
 	"fmt"
 	"math/rand"
 	"os"
@@ -671,6 +673,47 @@ func TestDefaultResourcePaths(t *testing.T) {
 	require.NoError(t, err)
 	_, err = os.Stat(filepath.Join(testDirectory, genesis.ID(), "crash.sqlite"))
 	require.NoError(t, err)
+}
+
+// TestLoadParticipationKeysRenamesUnsupported confirms that a participation
+// key file with an unsupported (future) schema version is renamed to
+// <name>.old and does not prevent the node from starting.
+func TestLoadParticipationKeysRenamesUnsupported(t *testing.T) {
+	partitiontest.PartitionTest(t)
+
+	testDirectory := t.TempDir()
+
+	genesis := bookkeeping.Genesis{
+		SchemaID:    "gen",
+		Proto:       protocol.ConsensusCurrentVersion,
+		Network:     config.Devtestnet,
+		FeeSink:     sinkAddr.String(),
+		RewardsPool: poolAddr.String(),
+	}
+
+	// plant a partkey file with a schema version from the future
+	genesisDir := filepath.Join(testDirectory, genesis.ID())
+	require.NoError(t, os.MkdirAll(genesisDir, 0700))
+	partfile := filepath.Join(genesisDir, config.PartKeyFilename("unsupported", 0, 3000))
+	partdb, err := db.MakeErasableAccessor(partfile)
+	require.NoError(t, err)
+	err = partdb.Atomic(func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.Exec(`CREATE TABLE schema (tablename TEXT PRIMARY KEY, version INTEGER);`); err != nil {
+			return err
+		}
+		_, err := tx.Exec("INSERT INTO schema (tablename, version) VALUES (?, ?)", account.PartTableSchemaName, 99)
+		return err
+	})
+	require.NoError(t, err)
+	partdb.Close()
+
+	n, err := MakeFull(logging.TestingLog(t), testDirectory, config.GetDefaultLocal(), []string{}, genesis)
+	require.NoError(t, err)
+	require.NoError(t, n.Start())
+	n.Stop()
+
+	require.NoFileExists(t, partfile)
+	require.FileExists(t, partfile+".old")
 }
 
 // TestConfiguredDataDirs tests to see that when HotDataDir and ColdDataDir are set, underlying resources are created in the correct locations

--- a/test/scripts/e2e_subs/serial/goal-partkey-commands.sh
+++ b/test/scripts/e2e_subs/serial/goal-partkey-commands.sh
@@ -110,6 +110,22 @@ OUTPUT=$(${gcmd} account installpartkey --delete-input --partkey test_partkey)
 PARTICIPATION_ID_1=$(echo "$OUTPUT" |awk '{ print $7 }')
 verify_registered_state "no" "$PARTICIPATION_ID_1" "goal account installpartkey"
 
+# algokey part migrate
+# freshly generated files are already at the latest schema version, so migrate
+# reports a no-op and leaves no .new copy behind; the v4 file still installs
+NEW_ACCOUNT_MIGRATE=$(create_and_fund_account)
+algokey part generate --keyfile test_partkey_migrate --first 0 --last 3000 --parent "$NEW_ACCOUNT_MIGRATE"
+OUTPUT=$(algokey part migrate --keyfile test_partkey_migrate)
+if ! echo "$OUTPUT" | grep -q "nothing to do"; then
+    fail_test "algokey part migrate on a fresh key should be a no-op: $OUTPUT"
+fi
+if [ -f test_partkey_migrate.new ]; then
+    fail_test "algokey part migrate no-op should not create test_partkey_migrate.new"
+fi
+OUTPUT=$(${gcmd} account installpartkey --delete-input --partkey test_partkey_migrate)
+PARTICIPATION_ID_MIGRATE=$(echo "$OUTPUT" |awk '{ print $7 }')
+verify_registered_state "no" "$PARTICIPATION_ID_MIGRATE" "goal account installpartkey (latest schema)"
+
 # goal account addpartkey
 # generate and install participation keys (do not register)
 # ============= Example output =============


### PR DESCRIPTION
## Summary

This PR changes storage layout of participation keys - a large blob (serialized `OneTimeSignatureSecretsPersistent`) containing all batch subkeys and a last extended batch (offsets) is replaced by its subset `OneTimeSignatureSecretsHeader` and two new tables `VotingBatches` and `VotingOffsets` maintaining the same semantics as in-memory `Batches` and `Offsets` in order to minimize amount of disk IO happening every round when wiping out used subkeys.

Most of the new code is a careful sync between in-memory `OneTimeSignatureSecretsPersistent` representation and the new storage schema.

Design choices:
1. Keep `OneTimeSignatureSecrets`  / `OneTimeSignatureSecretsPersistent` types to minimize the scope
2. Have minimal changes in `crypto`
3. Automatic migration but with `algokey` extension allowing manual migration and estimating the migration time

Background:
Participation key covers a range of rounds. Rounds are grouped into batches of KeyDilution rounds. `Batches[i]` is the subkey for batch `FirstBatch+i`. When a batch expanded into `KeyDilution` offsets, it gets removed so offsets represent the current keys and batches contain material for future rounds (look at `DeleteBeforeFineGrained` to see how the removal and expansion work).

## Test Plan

1. Unit and e2e tests added
2. Public network testing is ongoing (with benchmarks) 

Expected gains: min 800KB of rewrite (small key) each round down to 200 bytes (header update, offset removal). Every `KeyDilution` rounds new offset `KeyDilution` rows insertion.